### PR TITLE
docs: remove recommendation for NodeJS 19

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ It won't ever profit off your trademarks. Without this project, this version of 
 
 ## Environment Dependencies
 
-- [NodeJS 18/19](https://nodejs.org/en)
+- [NodeJS 18](https://nodejs.org/en)
 - [Java 17+](https://adoptium.net/)
 
 Java is required for JagCompress.jar (a small 1:1 compression utility) and RuneScriptCompiler.jar (the content language compiler).


### PR DESCRIPTION
NodeJS 19 is already at end-of-life and has been for the last 2 months

NodeJS 18 is supported for another 2 years

We should not recommend odd-numbered users to anyone, ever. Only people specifically looking to be part of NodeJS beta channels.