### PR TITLE
fix: ::jtele command now uses level properly.

### DIFF
--- a/src/lostcity/entity/Player.ts
+++ b/src/lostcity/entity/Player.ts
@@ -1160,7 +1160,7 @@ export default class Player extends PathingEntity {
                     return;
                 }
 
-                const level = parseInt(args2[0]);
+                const level = parseInt(args2[0].slice(6));
                 const mx = parseInt(args2[1]);
                 const mz = parseInt(args2[2]);
                 const lx = parseInt(args2[3]);


### PR DESCRIPTION
Split 6 chars from args2[0].