### PR TITLE
fix: Quest complete interface text correct for Cook's Assistant quest.

### DIFF
--- a/data/src/scripts/quests/quest_cook/scripts/quest_cook.rs2
+++ b/data/src/scripts/quests/quest_cook/scripts/quest_cook.rs2
@@ -86,7 +86,7 @@ queue(cooks_quest_complete, 0);
 [queue,cooks_quest_complete]
 %cook_progress = 2;
 givexp(cooking, 3000);
-~send_quest_complete(quest_journal:cook, cake, 250, 1, "You have completed the\\nCooks' Potion Quest!");
+~send_quest_complete(quest_journal:cook, cake, 250, 1, "You have completed the\\nCooks' Quest!");
 
 [oplocu,cook_range]
 def_coord $cook_kitchen_centre = 0_50_50_9_15;


### PR DESCRIPTION
Got messed up during implementation of ~send_quest_complete proc due to lazy c&p.