### PR TITLE
build: add VS Code launch tasks for Jest debugging

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,39 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "node",
+            "request": "launch",
+            "name": "Debug Jest: Current test file",
+            "program": "${workspaceFolder}/node_modules/jest/bin/jest.js",
+            "args": [
+                "${fileBasenameNoExtension}",
+                "--runInBand",
+                "--config",
+                "${workspaceFolder}/jest.config.ts"
+            ],
+            "skipFiles": [
+                "<node_internals>/**"
+            ],
+            "console": "internalConsole"
+        },
+        {
+            "type": "node",
+            "request": "launch",
+            "name": "Debug Jest: All tests",
+            "program": "${workspaceFolder}/node_modules/jest/bin/jest.js",
+            "args": [
+                "--runInBand",
+                "--config",
+                "${workspaceFolder}/jest.config.ts"
+            ],
+            "skipFiles": [
+                "<node_internals>/**"
+            ],
+            "console": "internalConsole",
+        }
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -49,6 +49,9 @@ Whenever you make a change to a config or script file while the server is runnin
 We use `jest` for unit tests.
 
 - You can run the tests with `npm test`.
+- If you're using VS Code, there are two launch options you can use. Both of these options will run in debug mode so you can set breakpoints.
+    - `Debug Jest: All tests` will run all tests in series.
+    - `Debug Jest: Current test file` will run the tests in the currently open test file.
 
 Test files should be colocated with the source files, i.e. `src/foo.ts` should have a test file `src/foo.test.ts`.
 


### PR DESCRIPTION
I had two issues with this:
- I can't use `integratedTerminal` (which I'd like to) but I think this might be some issue with my local setup (Unix-like shell in Windows environment)
- I can't reliably get console output from the tests

However besides that this seems to work well and uses the default VS Code inspector for stepping through the breakpoints.

Please test this branch on your machines and see if it all works for you too.