### PR TITLE
💂Implement the Lumbridge/Al Kharid border toll gates and guards.

### DIFF
--- a/data/src/scripts/_test/scripts/debug_telejump.rs2
+++ b/data/src/scripts/_test/scripts/debug_telejump.rs2
@@ -1,8 +1,8 @@
 [debugproc,p_tele]
-p_tele(movecoord(coord, 0, 0, 1));
+p_teleport(movecoord(coord, 0, 0, 1));
 
 [debugproc,p_tele3]
-p_tele(movecoord(coord, 0, 0, 3));
+p_teleport(movecoord(coord, 0, 0, 3));
 
 [debugproc,p_telejump]
 p_telejump(movecoord(coord, 0, 0, 1));

--- a/data/src/scripts/_unpack/all.loc
+++ b/data/src/scripts/_unpack/all.loc
@@ -19512,19 +19512,6 @@ model=model_loc_37
 sharelight=yes
 op1=Open
 
-[loc_2882]
-name=Gate
-desc=The toll gate from Lumbridge to Al-Kharid.
-model=model_loc_52
-op1=Open
-
-[loc_2883]
-name=Gate
-desc=The toll gate from Lumbridge to Al-Kharid.
-model=model_loc_52
-op1=Open
-mirror=yes
-
 [loc_2884]
 name=Ladder
 desc=I can climb this.

--- a/data/src/scripts/_unpack/all.npc
+++ b/data/src/scripts/_unpack/all.npc
@@ -6799,6 +6799,7 @@ model6=model_2990_npc
 model7=model_2988_npc
 head1=model_0_npc_head
 head2=model_8_npc_head
+wanderrange=2
 
 [npc_383]
 vislevel=hide
@@ -10727,6 +10728,7 @@ model7=model_185_obj_wear
 model8=model_323_obj_wear
 head1=model_46_idk_head
 head2=model_85_idk_head
+moverestrict=indoors
 
 [npc_591]
 vislevel=hide
@@ -10757,6 +10759,7 @@ model6=model_176_idk
 model7=model_181_idk
 head1=model_53_idk_head
 head2=model_85_idk_head
+moverestrict=indoors
 
 [npc_592]
 vislevel=hide

--- a/data/src/scripts/areas/area_alkharid/configs/border_gate.loc
+++ b/data/src/scripts/areas/area_alkharid/configs/border_gate.loc
@@ -1,0 +1,16 @@
+[loc_2882]
+name=Gate
+desc=The toll gate from Lumbridge to Al-Kharid.
+model=model_loc_52
+op1=Open
+category=border_gate_toll_left
+param=next_loc_stage,loc_1562
+
+[loc_2883]
+name=Gate
+desc=The toll gate from Lumbridge to Al-Kharid.
+model=model_loc_52
+op1=Open
+mirror=yes
+category=border_gate_toll_right
+param=next_loc_stage,loc_1563

--- a/data/src/scripts/areas/area_alkharid/configs/border_guard.npc
+++ b/data/src/scripts/areas/area_alkharid/configs/border_guard.npc
@@ -25,6 +25,9 @@ model9=model_191_npc
 head1=model_53_idk_head
 head2=model_81_idk_head
 head3=model_34_npc_head
+wanderrange=0
+moverestrict=nomove
+timer=4
 
 [border_guard_alkharid]
 name=Border Guard
@@ -53,3 +56,6 @@ model9=model_191_npc
 head1=model_53_idk_head
 head2=model_81_idk_head
 head3=model_34_npc_head
+wanderrange=0
+moverestrict=nomove
+timer=4

--- a/data/src/scripts/areas/area_alkharid/scripts/border_gate.rs2
+++ b/data/src/scripts/areas/area_alkharid/scripts/border_gate.rs2
@@ -86,7 +86,7 @@ if (coordz(coord) > coordz($north_coord)) {
     // capture our coord before teleporting
     def_coord $coord = coord;
     // teleport us to the north coord and delay
-    p_tele($north_coord);
+    p_teleport($north_coord);
     p_delay(distance($coord, $north_coord));
 }
 
@@ -99,7 +99,7 @@ if ($west = true) {
 def_coord $coord = coord;
 if ($coord ! $south_coord) {
     // teleport us to the south coord
-    p_tele($south_coord);
+    p_teleport($south_coord);
 }
 
 p_delay(add(distance($coord, $south_coord), 1));
@@ -137,7 +137,7 @@ while (loc_findnext = true) {
 
 sound_synth(grate_open, 0, 0);
 facesquare($destination);
-p_tele($destination);
+p_teleport($destination);
 p_delay(0);
 
 [proc,open_border_gate_toll_left_closed]()

--- a/data/src/scripts/areas/area_alkharid/scripts/border_gate.rs2
+++ b/data/src/scripts/areas/area_alkharid/scripts/border_gate.rs2
@@ -1,5 +1,33 @@
-[opnpc1,border_guard_lumby]
+[ai_timer,border_guard_lumby] @guard_scout_toll_fence;
+[ai_timer,border_guard_alkharid] @guard_scout_toll_fence;
+[opnpc1,border_guard_lumby] ~talk_to_border_guard(false, null);
+[opnpc1,border_guard_alkharid] ~talk_to_border_guard(false, null);
+[oploc1,loc_2882] @find_and_talk_to_border_guard;
+[oploc1,loc_2883] @find_and_talk_to_border_guard;
+
+// searches for a nearby border guard
+// then starts dialogue with them
+[label,find_and_talk_to_border_guard]
+npc_findallzone(coord);
+while (npc_findnext = true) {
+    if ((npc_type = border_guard_lumby | npc_type = border_guard_alkharid) & lineofwalk(coord, npc_coord) = true) {
+        ~talk_to_border_guard(true, loc_coord);
+        return;
+    }
+}
+
+[proc,talk_to_border_guard](boolean $from_gate, coord $loc_coord)
+if (distance(coord, npc_coord) > 2) {
+    return;
+}
+
 ~chatplayer(happy, "Can I come through this gate?");
+
+if ($from_gate = true) {
+    // yes they face coord here after the first line
+    facesquare(npc_coord);
+}
+npc_facesquare(coord); // TODO npc mode
 
 if (%prince_progress = 1) {
     ~chatnpc(happy, "You may pass for free! You are a friend of Al Kharid");
@@ -27,3 +55,159 @@ if (inv_total(inv, coins) < 10) {
 
 ~mesbox("You pay the guard.");
 inv_del(inv, coins, 10);
+
+// close the dialogue
+if_close;
+
+def_coord $north_coord = 0_51_50_4_28;
+def_coord $south_coord = 0_51_50_4_27;
+def_boolean $west = false;
+
+// checks if we are west of the gate on the lumbridge side
+if (coordx(coord) < coordx($south_coord)) {
+    $west = true;
+}
+
+// check if we are standing directly next to the gate somewhere
+if (~within_border_gate_toll_distance($west, $north_coord, $south_coord, $loc_coord) = true) {
+    p_delay(1);
+    // directly enter the gate
+    ~enter_through_border_gate_toll($west, $loc_coord);
+    return;
+}
+
+// check if we are north of the gate
+if (coordz(coord) > coordz($north_coord)) {
+    if ($west = true) {
+        // if we are on the west side then our north coord
+        // destination is moved over to the west
+        $north_coord = movecoord($north_coord, -1, 0, 0);
+    }
+    // capture our coord before teleporting
+    def_coord $coord = coord;
+    // teleport us to the north coord and delay
+    p_tele($north_coord);
+    p_delay(distance($coord, $north_coord));
+}
+
+// if we are on the west side then our south coord
+// destination is moved over to the west
+if ($west = true) {
+    $south_coord = movecoord($south_coord, -1, 0, 0);
+}
+// capture our coord before teleporting
+def_coord $coord = coord;
+if ($coord ! $south_coord) {
+    // teleport us to the south coord
+    p_tele($south_coord);
+}
+
+p_delay(add(distance($coord, $south_coord), 1));
+// open the gates and teleport through
+~enter_through_border_gate_toll($west, $loc_coord);
+
+// opens the gate and blocks all 4 sides
+// teleports us through the gate
+// plays the gates synth when opening
+// does magic
+[proc,enter_through_border_gate_toll](boolean $west, coord $loc_coord)
+def_coord $destination;
+if ($west = true) {
+    $destination = movecoord(coord, 1, 0, 0);
+    $loc_coord = $destination;
+} else {
+    if ($loc_coord = null) {
+        $destination = movecoord(coord, -1, 0, 0);
+        $loc_coord = coord;
+    } else {
+        $destination = movecoord($loc_coord, -1, 0, 0);
+    }
+}
+
+loc_findallzone($loc_coord);
+while (loc_findnext = true) {
+    if (loc_coord = $loc_coord & (loc_category = border_gate_toll_right | loc_category = border_gate_toll_left)) {
+        if (loc_category = border_gate_toll_left) {
+            ~open_border_gate_toll_left_closed;
+        } else {
+            ~open_border_gate_toll_right_closed;
+        }
+    }
+}
+
+sound_synth(grate_open, 0, 0);
+facesquare($destination);
+p_tele($destination);
+p_delay(0);
+
+[proc,open_border_gate_toll_left_closed]()
+loc_del(2);
+loc_add(loc_coord, loc_83, loc_angle, wall_straight, 2);
+
+def_coord $coord = ~movecoord_loc_return(~door_left_open(loc_angle));
+loc_add($coord, loc_83, loc_angle, wall_straight, 2);
+loc_add($coord, loc_param(next_loc_stage), calc(loc_angle + 3), wall_straight, 2);
+
+def_coord $other = movecoord(loc_coord, 0, 0, 1);
+
+loc_findallzone($coord);
+while (loc_findnext = true) {
+    if (loc_coord = $other & loc_category = border_gate_toll_right) {
+        loc_del(2);
+        loc_add(loc_coord, loc_83, loc_angle, wall_straight, 2);
+
+        def_coord $coord = ~movecoord_loc_return(~door_open(loc_angle));
+        loc_add($coord, loc_83, loc_angle, wall_straight, 2);
+        loc_add($coord, loc_param(next_loc_stage), calc(loc_angle + 1), wall_straight, 2);
+    }
+}
+
+[proc,open_border_gate_toll_right_closed]()
+loc_del(2);
+loc_add(loc_coord, loc_83, loc_angle, wall_straight, 2);
+
+def_coord $coord = ~movecoord_loc_return(~door_open(loc_angle));
+loc_add($coord, loc_83, loc_angle, wall_straight, 2);
+loc_add($coord, loc_param(next_loc_stage), calc(loc_angle + 1), wall_straight, 2);
+
+def_coord $other = movecoord(loc_coord, 0, 0, -1);
+
+loc_findallzone($coord);
+while (loc_findnext = true) {
+    if (loc_coord = $other & loc_category = border_gate_toll_left) {
+        loc_del(2);
+        loc_add(loc_coord, loc_83, loc_angle, wall_straight, 2);
+
+        def_coord $coord = ~movecoord_loc_return(~door_left_open(loc_angle));
+        loc_add($coord, loc_83, loc_angle, wall_straight, 2);
+        loc_add($coord, loc_param(next_loc_stage), calc(loc_angle + 3), wall_straight, 2);
+    }
+}
+
+// checks if you are standing directly next to the gate on 4 sides.
+[proc,within_border_gate_toll_distance](boolean $west, coord $north_coord, coord $south_coord, coord $loc_coord)(boolean)
+if ($west = false & coord ! $loc_coord) { // trust me on this one
+    return(false);
+} else if ($west = true & coord = movecoord($north_coord, -1, 0, 0)) {
+    return(true);
+} else if ($west = true & coord = movecoord($south_coord, -1, 0, 0)) {
+    return(true);
+} else if ($west = false & coord = $north_coord) {
+    return(true);
+} else if ($west = false & coord = $south_coord) {
+    return(true);
+}
+return(false);
+
+[label,guard_scout_toll_fence]
+if (random(4) ! 0) return;
+
+def_coord $next_coord = movecoord(npc_coord, ~random_range(-1, 1), 0, ~random_range(-1, 1));
+
+def_int $count = 0;
+while ($next_coord = npc_coord & $count < 10) {
+    $next_coord = movecoord(npc_coord, ~random_range(-1, 1), 0, ~random_range(-1, 1));
+    $count = add($count, 1);
+}
+
+npc_facesquare($next_coord);

--- a/data/src/scripts/areas/area_lumbridge/scripts/shortcuts.rs2
+++ b/data/src/scripts/areas/area_lumbridge/scripts/shortcuts.rs2
@@ -4,18 +4,18 @@ p_telejump(0_49_51_61_14);
 p_delay(0);
 
 mes("[<tostring(map_clock)>] Walking to");
-p_walk(0_49_51_61_13);
+p_tele(0_49_51_61_13);
 p_delay(0);
 
 mes("[<tostring(map_clock)>] Climbing over");
 anim(seq_839, 30);
 p_locmerge(30, 64, 0_49_51_61_12, 0_49_51_61_13);
-p_walk(0_49_51_61_12);
+p_tele(0_49_51_61_12);
 p_exactmove(0_49_51_61_13, 0_49_51_61_12, 30, 64, ^exact_west);
 p_delay(2);
 
 mes("[<tostring(map_clock)>] Walking away");
-p_walk(0_49_51_61_11);
+p_tele(0_49_51_61_11);
 
 /*
 [92] Movement(type = Walk, Location(level = 0, msqx = 49, msqz = 51, tx = 61, tz = 13))

--- a/data/src/scripts/areas/area_lumbridge/scripts/shortcuts.rs2
+++ b/data/src/scripts/areas/area_lumbridge/scripts/shortcuts.rs2
@@ -4,18 +4,18 @@ p_telejump(0_49_51_61_14);
 p_delay(0);
 
 mes("[<tostring(map_clock)>] Walking to");
-p_tele(0_49_51_61_13);
+p_teleport(0_49_51_61_13);
 p_delay(0);
 
 mes("[<tostring(map_clock)>] Climbing over");
 anim(seq_839, 30);
 p_locmerge(30, 64, 0_49_51_61_12, 0_49_51_61_13);
-p_tele(0_49_51_61_12);
+p_teleport(0_49_51_61_12);
 p_exactmove(0_49_51_61_13, 0_49_51_61_12, 30, 64, ^exact_west);
 p_delay(2);
 
 mes("[<tostring(map_clock)>] Walking away");
-p_tele(0_49_51_61_11);
+p_teleport(0_49_51_61_11);
 
 /*
 [92] Movement(type = Walk, Location(level = 0, msqx = 49, msqz = 51, tx = 61, tz = 13))

--- a/data/src/scripts/areas/area_taverly/dungeon/scripts/prison_doors.rs2
+++ b/data/src/scripts/areas/area_taverly/dungeon/scripts/prison_doors.rs2
@@ -43,9 +43,9 @@ while(loc_findnext = true) {
 }
 
 if(coord ! 0_45_153_9_38 & coord ! 0_45_153_9_39) { // Easter Side of doors
-    p_tele(movecoord(coord, 1, 0, 0));
+    p_teleport(movecoord(coord, 1, 0, 0));
 } else {
-    p_tele(movecoord(coord, -1, 0, 0));
+    p_teleport(movecoord(coord, -1, 0, 0));
 }
 
 

--- a/data/src/scripts/areas/area_taverly/dungeon/scripts/prison_doors.rs2
+++ b/data/src/scripts/areas/area_taverly/dungeon/scripts/prison_doors.rs2
@@ -43,9 +43,9 @@ while(loc_findnext = true) {
 }
 
 if(coord ! 0_45_153_9_38 & coord ! 0_45_153_9_39) { // Easter Side of doors
-    p_walk(movecoord(coord, 1, 0, 0));
+    p_tele(movecoord(coord, 1, 0, 0));
 } else {
-    p_walk(movecoord(coord, -1, 0, 0));
+    p_tele(movecoord(coord, -1, 0, 0));
 }
 
 

--- a/data/src/scripts/engine.rs2
+++ b/data/src/scripts/engine.rs2
@@ -117,7 +117,7 @@
 [command,getweakqueue](weakqueue $queue)(int)
 [command,p_locmerge](int $startCycle, int $endCycle, coord $southEast, coord $northWest);
 [command,last_login_info]
-[command,p_tele](coord $coord)
+[command,p_teleport](coord $coord)
 
 // Npc ops (2500-2999)
 [command,npc_finduid](npc_uid $uid)(boolean)

--- a/data/src/scripts/general_use/scripts/pickables.rs2
+++ b/data/src/scripts/general_use/scripts/pickables.rs2
@@ -3,11 +3,11 @@
 p_arrivedelay;
 if(inv_freespace(inv) = 0) {
     mes("You don't have room for this potato.");
-    p_tele(loc_coord);
+    p_teleport(loc_coord);
     p_delay(0);
 } else {
     anim(bury, 0);
-    p_tele(loc_coord);
+    p_teleport(loc_coord);
     p_delay(0);
     sound_synth(pick, 0, 0);
     loc_del(50);
@@ -20,11 +20,11 @@ if(inv_freespace(inv) = 0) {
 p_arrivedelay;
 if(inv_freespace(inv) = 0) {
     mes("You can't carry any more grain.");
-    p_tele(loc_coord);
+    p_teleport(loc_coord);
     p_delay(0);
 } else {
     anim(bury, 0);
-    p_tele(loc_coord);
+    p_teleport(loc_coord);
     p_delay(0);
     sound_synth(pick, 0, 0);
     loc_del(20);
@@ -37,11 +37,11 @@ if(inv_freespace(inv) = 0) {
 p_arrivedelay;
 if(inv_freespace(inv) = 0) {
     mes("You don't have room for this onion.");
-    p_tele(loc_coord);
+    p_teleport(loc_coord);
     p_delay(0);
 } else {
     anim(bury, 0);
-    p_tele(loc_coord);
+    p_teleport(loc_coord);
     p_delay(0);
     sound_synth(pick, 0, 0);
     loc_del(50);
@@ -54,11 +54,11 @@ if(inv_freespace(inv) = 0) {
 p_arrivedelay;
 if(inv_freespace(inv) = 0) {
     mes("You don't have room for this cabbage.");
-    p_tele(loc_coord);
+    p_teleport(loc_coord);
     p_delay(0);
 } else {
     anim(bury, 0);
-    p_tele(loc_coord);
+    p_teleport(loc_coord);
     p_delay(0);
     sound_synth(pick, 0, 0);
     loc_del(70);

--- a/data/src/scripts/general_use/scripts/pickables.rs2
+++ b/data/src/scripts/general_use/scripts/pickables.rs2
@@ -3,11 +3,11 @@
 p_arrivedelay;
 if(inv_freespace(inv) = 0) {
     mes("You don't have room for this potato.");
-    p_walk(loc_coord);
+    p_tele(loc_coord);
     p_delay(0);
 } else {
     anim(bury, 0);
-    p_walk(loc_coord);
+    p_tele(loc_coord);
     p_delay(0);
     sound_synth(pick, 0, 0);
     loc_del(50);
@@ -20,11 +20,11 @@ if(inv_freespace(inv) = 0) {
 p_arrivedelay;
 if(inv_freespace(inv) = 0) {
     mes("You can't carry any more grain.");
-    p_walk(loc_coord);
+    p_tele(loc_coord);
     p_delay(0);
 } else {
     anim(bury, 0);
-    p_walk(loc_coord);
+    p_tele(loc_coord);
     p_delay(0);
     sound_synth(pick, 0, 0);
     loc_del(20);
@@ -37,11 +37,11 @@ if(inv_freespace(inv) = 0) {
 p_arrivedelay;
 if(inv_freespace(inv) = 0) {
     mes("You don't have room for this onion.");
-    p_walk(loc_coord);
+    p_tele(loc_coord);
     p_delay(0);
 } else {
     anim(bury, 0);
-    p_walk(loc_coord);
+    p_tele(loc_coord);
     p_delay(0);
     sound_synth(pick, 0, 0);
     loc_del(50);
@@ -54,11 +54,11 @@ if(inv_freespace(inv) = 0) {
 p_arrivedelay;
 if(inv_freespace(inv) = 0) {
     mes("You don't have room for this cabbage.");
-    p_walk(loc_coord);
+    p_tele(loc_coord);
     p_delay(0);
 } else {
     anim(bury, 0);
-    p_walk(loc_coord);
+    p_tele(loc_coord);
     p_delay(0);
     sound_synth(pick, 0, 0);
     loc_del(70);

--- a/data/src/scripts/skill_thieving/scripts/doors/locked_door.rs2
+++ b/data/src/scripts/skill_thieving/scripts/doors/locked_door.rs2
@@ -104,7 +104,7 @@ if (~check_axis(coord, $loc_coord, $angle) = true) {
     }
     mes("You manage to pick the lock.");
     if (coord ! $loc_coord) {
-        p_walk($loc_coord);
+        p_tele($loc_coord);
         p_delay(2);
     }
 
@@ -137,7 +137,7 @@ if ($exiting = false) {
     sound_synth(locked, 0, 0);
     $dest = movecoord($loc_coord, $x, 0, $z);
 }
-p_walk($dest);
+p_tele($dest);
 
 [proc,check_axis](coord $coord, coord $loc_coord, int $angle)(boolean)
 if ($angle = 1 | $angle = 3) {

--- a/data/src/scripts/skill_thieving/scripts/doors/locked_door.rs2
+++ b/data/src/scripts/skill_thieving/scripts/doors/locked_door.rs2
@@ -104,7 +104,7 @@ if (~check_axis(coord, $loc_coord, $angle) = true) {
     }
     mes("You manage to pick the lock.");
     if (coord ! $loc_coord) {
-        p_tele($loc_coord);
+        p_teleport($loc_coord);
         p_delay(2);
     }
 
@@ -137,7 +137,7 @@ if ($exiting = false) {
     sound_synth(locked, 0, 0);
     $dest = movecoord($loc_coord, $x, 0, $z);
 }
-p_tele($dest);
+p_teleport($dest);
 
 [proc,check_axis](coord $coord, coord $loc_coord, int $angle)(boolean)
 if ($angle = 1 | $angle = 3) {

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -291,8 +291,8 @@ These can be found in their signature format as `data/src/scripts/engine.rs2`.
 | p_opnpc             | Set the current interaction to opnpc(x) for the next tick                                                                                  |                                                                             |
 | p_pausebutton       |                                                                                                                                            |                                                                             |
 | p_stopaction        |                                                                                                                                            |                                                                             |
-| p_telejump          | Teleport and jump the player to a specified jagex coord                                                                                    | p_telejump(1_41_51_41_57);                                                  |
-| p_walk              | Walk the player somewhere. Ignores map clipping                                                                                            | p_walk(movecoord(coord, 0, 0, 1));                                          |
+| p_telejump          | Teleport and jump the player to a specified jagex coord. Does not use walk animations                                                      | p_telejump(1_41_51_41_57);                                                  |
+| p_walk              | Walk the player somewhere with full pathfinding support                                                                                    | p_walk(movecoord(coord, 0, 0, 1));                                          |
 | say                 | Make the player force say something                                                                                                        |                                                                             |
 | sound_synth         | Play a synth to the player                                                                                                                 | sound_synth(found_gem, 0, 0);                                               |
 | staffmodlevel       | Checks the staff level of the player                                                                                                       | 0, 1, 2                                                                     |
@@ -344,8 +344,8 @@ These can be found in their signature format as `data/src/scripts/engine.rs2`.
 | getqueue            |                                                                                                                                            |                                                                             |
 | getweakqueue        |                                                                                                                                            |                                                                             |
 | p_locmerge          | Merge the player with a loc. Mostly used for Agility                                                                                       | p_locmerge(30, 64, 0_49_51_61_12, 0_49_51_61_13);                           |
-| last_login_info     | Sends the last login information to the player containing the last ip their account was logged in from.                                    |                                                                             |
-| p_tele              | Teleport the player to a specified jagex coord                                                                                             | p_tele(movecoord(coord, 0, 0, 3));                                          |
+| last_login_info     | Sends the last login information to the player containing the last ip their account was logged in from.                                    | last_login_info;                                                            |
+| p_teleport          | Teleport the player to a specified jagex coord. Enables walk animation if the distance is short enough                                     | p_teleport(movecoord(coord, 0, 0, 1));                                      |
 
 ### Npc
 
@@ -395,7 +395,7 @@ These can be found in their signature format as `data/src/scripts/engine.rs2`.
 | loc_find        | Returns if a loc at a coord is found or not                      | if (loc_find(coord, loc_type) = true) {}           |
 | loc_findallzone | Finds all locs within the zone of a jagex coord                  | loc_findallzone(coord);                            |
 | loc_findnext    | Iterates through the found locs within the zone of a jagex coord | while (loc_findnext = true) {}                     |
-| loc_param       | Returns a param of a loc                                         |                                                    |
+| loc_param       | Returns a param of a loc                                         | def_int $is_empty = loc_param(mining_rock_empty);  |
 | loc_type        | Returns the config type for a loc                                | if (loc_type = loc_818) {}                         |
 | loc_name        | Returns the name of a loc                                        | if (loc_name = "Magic Tree") {}                    |
 | loc_shape       | Returns the shape of a loc                                       | if (loc_shape = centrepiece_straight) {}           |
@@ -409,7 +409,7 @@ These can be found in their signature format as `data/src/scripts/engine.rs2`.
 | obj_param  | Returns a param of an obj          |                                 |
 | obj_name   | Returns the name of an obj         | if (obj_name = "Coins") {}      |
 | obj_del    | Deletes an obj from the world      | obj_del;                        |
-| obj_count  |                                    |                                 |
+| obj_count  |                                    | def_int $count = obj_count;     |
 | obj_type   | Returns the config type for an obj | if (obj_type = coins) {}        |
 
 ### Npc config
@@ -434,21 +434,21 @@ These can be found in their signature format as `data/src/scripts/engine.rs2`.
 
 ### Obj config
 
-| Name         | Description                                     | Example                                       |
-|--------------|-------------------------------------------------|-----------------------------------------------|
-| oc_name      | Returns the name of an obj                      | if (oc_name(coins) = "Coins") {}              |
-| oc_param     | Returns a param of an obj                       |                                               |
-| oc_category  | Returns a category of an obj                    | if (oc_category($clue) = trail_clue_easy) {}  |
-| oc_desc      | Returns the description of an obj               | def_string $desc = oc_desc(coins);            |
-| oc_members   | Returns if an obj is members or not             | if (oc_members($chocolate) = true) {}         |
-| oc_weight    | Returns the weight of an obj                    | def_int $weight = oc_weight(coins);           |
-| oc_wearpos   | Returns the primary slot of an obj              |                                               |
-| oc_wearpos2  | Returns the secondary override slot of an obj   |                                               |
-| oc_wearpos3  | Returns the secondary override 2 slot of an obj |                                               |
-| oc_debugname | Returns the leaked debug name of an obj         | def_string $debugname = oc_debugname(coins);  |
-| oc_cert      | Returns the cert of an obj                      | def_namedobj $cert_logs = oc_cert(logs);      |
-| oc_uncert    | Returns the uncert of an obj                    | def_namedobj $logs = oc_uncert(cert_logs);    |
-| oc_stackable | Returns if an obj is stackable or not           | def_boolean $stackable = oc_stackable(coins); |
+| Name         | Description                                     | Example                                          |
+|--------------|-------------------------------------------------|--------------------------------------------------|
+| oc_name      | Returns the name of an obj                      | if (oc_name(coins) = "Coins") {}                 |
+| oc_param     | Returns a param of an obj                       | def_coord $coord = oc_param($clue, trail_coord); |
+| oc_category  | Returns a category of an obj                    | if (oc_category($clue) = trail_clue_easy) {}     |
+| oc_desc      | Returns the description of an obj               | def_string $desc = oc_desc(coins);               |
+| oc_members   | Returns if an obj is members or not             | if (oc_members($chocolate) = true) {}            |
+| oc_weight    | Returns the weight of an obj                    | def_int $weight = oc_weight(coins);              |
+| oc_wearpos   | Returns the primary slot of an obj              |                                                  |
+| oc_wearpos2  | Returns the secondary override slot of an obj   |                                                  |
+| oc_wearpos3  | Returns the secondary override 2 slot of an obj |                                                  |
+| oc_debugname | Returns the leaked debug name of an obj         | def_string $debugname = oc_debugname(coins);     |
+| oc_cert      | Returns the cert of an obj                      | def_namedobj $cert_logs = oc_cert(logs);         |
+| oc_uncert    | Returns the uncert of an obj                    | def_namedobj $logs = oc_uncert(cert_logs);       |
+| oc_stackable | Returns if an obj is stackable or not           | def_boolean $stackable = oc_stackable(coins);    |
 
 ### Inventory
 
@@ -459,7 +459,7 @@ These can be found in their signature format as `data/src/scripts/engine.rs2`.
 | inv_del             | Delete an obj from an inv                                       | inv_del(inv, coins, 10);                                                                         |
 | inv_getobj          | Return an obj from an inv                                       | def_obj $amulet = inv_getobj(worn, 2);                                                           |
 | inv_itemspace2      | Returns an overflow for adding an obj to an inv                 | def_int $overflow = inv_itemspace2($inv, $cert_or_uncert, $amount, inv_size($inv));              |
-| inv_moveitem        | Moves an obj from one inv to another inv                        |                                                                                                  |
+| inv_moveitem        | Moves an obj from one inv to another inv                        | inv_moveitem(bank, $inv, $obj, sub($amount, $overflow));                                         |
 | inv_resendslot      | Refreshes an inv from the input slot to the inv capacity        | inv_resendslot(bank, 0);                                                                         |
 | inv_setslot         | Sets the slot of an inv with an obj                             | inv_setslot(crafting_rings, 3, null, 0);                                                         |
 | inv_size            | Returns the capacity of an inv                                  | inv_size(bank);                                                                                  |
@@ -469,8 +469,8 @@ These can be found in their signature format as `data/src/scripts/engine.rs2`.
 | inv_swap            | Swap an inv slot to another slot                                | inv_swap(inv, last_slot, last_useslot);                                                          |
 | inv_itemspace       | Returns if there is overflow or not for adding an obj to an inv | if (inv_itemspace(inv, $slotobj, inv_total(reward_inv, $slotobj), inv_freespace(inv)) = true) {} |
 | inv_freespace       | Returns if there is any free space in an inv                    | if (inv_freespace(inv) = 0) {}                                                                   |
-| inv_allstock        | Returns if an inv is an allstock. Used for shop type invs       | if (inv_allstock = false & inv_exists(%shop, $item) = false) {}                                  |
-| inv_exists          | Returns if an obj exists in an inv                              |                                                                                                  |
+| inv_allstock        | Returns if an inv is an allstock. Used for shop type invs       | if (inv_allstock = false) {}                                                                     |
+| inv_exists          | Returns if an obj exists in an inv                              | def_boolean $exists = inv_exists(inv, coins);                                                    |
 | inv_getnum          | Returns the number of an obj in an inv                          | def_int $slot_count = inv_getnum(bank, $count);                                                  |
 | inv_moveitem_cert   | Moves an obj from one inv to another inv forcing cert           | inv_moveitem_cert(bank, $inv, $obj, sub($amount, $overflow));                                    |
 | inv_moveitem_uncert | Moves an obj from one inv to another inv forcing uncert         | inv_moveitem_uncert($inv, bank, $obj, sub($amount, $overflow));                                  |

--- a/src/lostcity/engine/script/ScriptOpcode.ts
+++ b/src/lostcity/engine/script/ScriptOpcode.ts
@@ -147,7 +147,7 @@ const ScriptOpcode = {
     GETWEAKQUEUE: 2088,
     P_LOCMERGE: 2089,
     LAST_LOGIN_INFO: 2090,
-    P_TELE: 2091,
+    P_TELEPORT: 2091,
 
     // Npc ops (2500-2999)
     NPC_FINDUID: 2500,

--- a/src/lostcity/engine/script/handlers/NpcOps.ts
+++ b/src/lostcity/engine/script/handlers/NpcOps.ts
@@ -231,7 +231,7 @@ const NpcOps: CommandHandlers = {
         const x = (coord >> 14) & 0x3fff;
         const z = coord & 0x3fff;
 
-        state.activeNpc.tele(x, z, level);
+        state.activeNpc.teleport(x, z, level);
     }),
 };
 

--- a/src/lostcity/engine/script/handlers/PlayerOps.ts
+++ b/src/lostcity/engine/script/handlers/PlayerOps.ts
@@ -284,8 +284,9 @@ const PlayerOps: CommandHandlers = {
         const x = (coord >> 14) & 0x3fff;
         const z = coord & 0x3fff;
 
-        state.activePlayer.queueWalkStep(x, z, true);
-        state.activePlayer.processMovement();
+        const player = state.activePlayer;
+
+        player.queueWalkSteps(World.pathFinder.findPath(player.level, player.x, player.z, x, z, player.width, 1, 1, player.orientation).waypoints);
     }),
 
     [ScriptOpcode.SAY]: checkedHandler(ActivePlayer, (state) => {

--- a/src/lostcity/engine/script/handlers/PlayerOps.ts
+++ b/src/lostcity/engine/script/handlers/PlayerOps.ts
@@ -268,14 +268,14 @@ const PlayerOps: CommandHandlers = {
         state.activePlayer.teleJump(x, z, level);
     }),
 
-    [ScriptOpcode.P_TELE]: checkedHandler(ProtectedActivePlayer, (state) => {
+    [ScriptOpcode.P_TELEPORT]: checkedHandler(ProtectedActivePlayer, (state) => {
         const coord = state.popInt();
 
         const level = (coord >> 28) & 0x3fff;
         const x = (coord >> 14) & 0x3fff;
         const z = coord & 0x3fff;
 
-        state.activePlayer.tele(x, z, level);
+        state.activePlayer.teleport(x, z, level);
     }),
 
     [ScriptOpcode.P_WALK]: checkedHandler(ProtectedActivePlayer, (state) => {

--- a/src/lostcity/engine/script/handlers/ServerOps.ts
+++ b/src/lostcity/engine/script/handlers/ServerOps.ts
@@ -58,10 +58,13 @@ const ServerOps: CommandHandlers = {
             fromX,
             fromZ,
             toX,
-            toZ
+            toZ,
+            state.activePlayer.width,
+            1,
+            1
         );
 
-        state.pushInt(lineOfWalk.success || lineOfWalk.alternative ? 1 : 0);
+        state.pushInt(lineOfWalk.success ? 1 : 0);
     },
 
     [ScriptOpcode.OBJECTVERIFY]: (state) => {

--- a/src/lostcity/entity/Npc.ts
+++ b/src/lostcity/entity/Npc.ts
@@ -68,7 +68,7 @@ export default class Npc extends PathingEntity {
     }
 
     updateMovement(running: number = -1): void {
-        if (this.teleport) {
+        if (this.tele) {
             this.walkDir = -1;
             this.runDir = -1;
             return;

--- a/src/lostcity/entity/PathingEntity.ts
+++ b/src/lostcity/entity/PathingEntity.ts
@@ -19,7 +19,7 @@ export default abstract class PathingEntity extends Entity {
     lastX: number = -1;
     lastZ: number = -1;
     forceMove: boolean = false;
-    teleport: boolean = false;
+    tele: boolean = false;
     jump: boolean = false;
 
     orientation: number = -1;
@@ -35,7 +35,7 @@ export default abstract class PathingEntity extends Entity {
     protected constructor(level: number, x: number, z: number, width: number, length: number, moveRestrict: MoveRestrict) {
         super(level, x, z, width, length);
         this.moveRestrict = moveRestrict;
-        this.teleport = true;
+        this.tele = true;
     }
 
     /**
@@ -190,11 +190,11 @@ export default abstract class PathingEntity extends Entity {
     }
 
     teleJump(x: number, z: number, level: number): void {
-        this.tele(x, z, level);
+        this.teleport(x, z, level);
         this.jump = true;
     }
 
-    tele(x: number, z: number, level: number): void {
+    teleport(x: number, z: number, level: number): void {
         if (isNaN(level)) {
             level = 0;
         }
@@ -209,7 +209,7 @@ export default abstract class PathingEntity extends Entity {
         this.level = level;
         this.refreshZonePresence(previousX, previousZ, previousLevel);
 
-        this.teleport = true;
+        this.tele = true;
         this.walkDir = -1;
         this.runDir = -1;
         this.walkStep = 0;
@@ -222,13 +222,13 @@ export default abstract class PathingEntity extends Entity {
      * Check if the number of tiles moved is > 2, we use Teleport for this PathingEntity.
      */
     validateDistanceWalked() {
-        if (this.teleport) {
+        if (this.tele) {
             return;
         }
 
         const distanceCheck = Position.distanceTo({ x: this.x, z: this.z }, { x: this.lastX, z: this.lastZ }) > 2;
         if (distanceCheck) {
-            this.teleport = true;
+            this.tele = true;
         }
     }
 
@@ -242,7 +242,7 @@ export default abstract class PathingEntity extends Entity {
     resetTransient(): void {
         this.walkDir = -1;
         this.runDir = -1;
-        this.teleport = false;
+        this.tele = false;
         this.jump = false;
         this.lastX = this.x;
         this.lastZ = this.z;

--- a/src/lostcity/entity/PathingEntity.ts
+++ b/src/lostcity/entity/PathingEntity.ts
@@ -214,6 +214,8 @@ export default abstract class PathingEntity extends Entity {
         this.runDir = -1;
         this.walkStep = 0;
         this.walkQueue = [];
+
+        this.orientation = Position.face(previousX, previousZ, x, z);
     }
 
     /**

--- a/src/lostcity/entity/Player.ts
+++ b/src/lostcity/entity/Player.ts
@@ -2398,7 +2398,7 @@ export default class Player extends PathingEntity {
             out.pBit(5, xPos);
             out.pBit(5, zPos);
 
-            if (n.orientation !== -1) {
+            if (n.orientation !== -1 || n.faceX !== -1 || n.faceZ != -1 || n.faceEntity !== -1) {
                 out.pBit(1, 1);
                 updates.push(n);
             } else {

--- a/src/lostcity/entity/Player.ts
+++ b/src/lostcity/entity/Player.ts
@@ -1181,7 +1181,7 @@ export default class Player extends PathingEntity {
                 const lx = parseInt(args2[3]);
                 const lz = parseInt(args2[4]);
 
-                this.tele((mx << 6) + lx, (mz << 6) + lz, level);
+                this.teleport((mx << 6) + lx, (mz << 6) + lz, level);
             } break;
             case 'pos': {
                 this.messageGame(`Position: ${this.x} ${this.z} ${this.level}`);
@@ -1199,7 +1199,7 @@ export default class Player extends PathingEntity {
                 const z = parseInt(args[1]);
                 const level = parseInt(args[2] ?? this.level);
 
-                this.tele(x, z, level);
+                this.teleport(x, z, level);
             } break;
             case 'telelevel': {
                 if (args.length < 1) {
@@ -1208,7 +1208,7 @@ export default class Player extends PathingEntity {
 
                 const level = parseInt(args[0]);
 
-                this.tele(this.x, this.z, level);
+                this.teleport(this.x, this.z, level);
             } break;
             case 'region': {
                 if (args.length < 2) {
@@ -1220,7 +1220,7 @@ export default class Player extends PathingEntity {
                 const z = parseInt(args[1]);
                 const level = parseInt(args[2] ?? this.level);
 
-                this.tele((x << 6) + 32, (z << 6) + 32, level);
+                this.teleport((x << 6) + 32, (z << 6) + 32, level);
             } break;
             case 'setlevel': {
                 if (args.length < 2) {
@@ -1265,7 +1265,7 @@ export default class Player extends PathingEntity {
                 this.addXp(stat, Math.round(Number(args[1]) * 10));
             } break;
             case 'home': {
-                this.tele(3222, 3222, 0);
+                this.teleport(3222, 3222, 0);
             } break;
             case 'givecrap': {
                 for (let i = 0; i < 8; i++) {
@@ -1400,7 +1400,7 @@ export default class Player extends PathingEntity {
     // ----
 
     updateMovement(): void {
-        if (this.containsModalInterface() || this.teleport) {
+        if (this.containsModalInterface() || this.tele) {
             this.walkDir = -1;
             this.runDir = -1;
             return;
@@ -1886,7 +1886,7 @@ export default class Player extends PathingEntity {
         const dz = Math.abs(this.z - this.loadedZ);
 
         // if the build area should be regenerated, do so now
-        if (dx >= 36 || dz >= 36 || (this.teleport && (Position.zone(this.x) !== Position.zone(this.loadedX) || Position.zone(this.z) !== Position.zone(this.loadedZ)))) {
+        if (dx >= 36 || dz >= 36 || (this.tele && (Position.zone(this.x) !== Position.zone(this.loadedX) || Position.zone(this.z) !== Position.zone(this.loadedZ)))) {
             this.loadArea(Position.zone(this.x), Position.zone(this.z));
 
             this.loadedX = this.x;
@@ -1995,8 +1995,8 @@ export default class Player extends PathingEntity {
         const out = new Packet();
         out.bits();
 
-        out.pBit(1, (this.mask > 0 || this.teleport || (this.walkDir !== -1 || this.runDir !== -1)) ? 1 : 0);
-        if (this.teleport) {
+        out.pBit(1, (this.mask > 0 || this.tele || (this.walkDir !== -1 || this.runDir !== -1)) ? 1 : 0);
+        if (this.tele) {
             out.pBit(2, 3);
             out.pBit(2, this.level);
             out.pBit(7, Position.local(this.x));
@@ -2027,7 +2027,7 @@ export default class Player extends PathingEntity {
         const updates: any[] = [];
         out.pBit(8, this.players.length);
         this.players = this.players.filter(x => {
-            if (x.type === 1 || x.player.teleport) {
+            if (x.type === 1 || x.player.tele) {
                 // remove
                 out.pBit(1, 1);
                 out.pBit(2, 3);


### PR DESCRIPTION
- Border gate guards now scout the area and no longer move around.
- Border gates now properly open and block clipping.
- Players can now pay 10 coins to pass through the border gates.
- `p_walk` is now used for walking with pathfinding support.
- `p_tele` renamed to `p_teleport`.
- Update scripts that used `p_walk` to now use `p_teleport`
- Update other npc wander ranges and moverestricts.
- Fixed `lineofwalk` to use correct dest sizes and remove alternative check.
- `PathingEntity` orientations now update properly when teleporting/jumping, to the player client. (When they are new to your view)
- `Npc` orientations now update properly when turning, to the player client. (When they are new to your view)