### PR TITLE
Swapped Angry and Beckon to be the correct ids

### DIFF
--- a/data/pack/seq.pack
+++ b/data/pack/seq.pack
@@ -857,12 +857,12 @@
 856=emote_no
 857=emote_think
 858=emote_bow
-859=emote_beckon
+859=emote_angry
 860=emote_cry
 861=emote_laugh
 862=emote_cheer
 863=emote_wave
-864=emote_angry
+864=emote_beckon
 865=emote_clap
 866=emote_dance
 867=human_woodcutting_rune_axe

--- a/data/src/scripts/_unpack/all.seq
+++ b/data/src/scripts/_unpack/all.seq
@@ -12266,7 +12266,7 @@ frame11=anim_1985
 frame12=anim_1687
 frame13=anim_1396
 
-[emote_beckon]
+[emote_angry]
 righthand=hide
 lefthand=hide
 priority=2
@@ -12370,7 +12370,7 @@ frame13=anim_868
 frame14=anim_576
 frame15=anim_2297
 
-[emote_angry]
+[emote_beckon]
 righthand=hide
 lefthand=hide
 priority=2


### PR DESCRIPTION
Angry and Beckon had the incorrect IDs associated with them. I was able to just swap the two and it resolved the issue with doing emotes from the emotes tab as well.