### PR TITLE
fix walking tele

### DIFF
--- a/src/lostcity/engine/World.ts
+++ b/src/lostcity/engine/World.ts
@@ -387,7 +387,7 @@ class World {
             }
 
             try {
-                if (player.tele && !player.jump && (Math.abs(player.x - player.lastX) < 2 || Math.abs(player.z - player.lastZ) < 2)) {
+                if (player.tele && !player.jump && Math.abs(player.x - player.lastX) < 2 && Math.abs(player.z - player.lastZ) < 2) {
                     // convert teleport to a walk/run op
                     player.walkDir = Position.face(player.lastX, player.lastZ, player.x, player.z);
                     player.runDir = -1; // TODO support run <= 2 tiles


### PR DESCRIPTION
if you try to p_teleport with a > 2 change in only x or z, you will try to walk it and desync client/server player pos, this fixes it by checking for both dx and dz < 2 before converting to walk/run