### PR TITLE
Add fixes to npc wanderrange and attackrange properties.

### DIFF
--- a/data/src/scripts/_unpack/all.npc
+++ b/data/src/scripts/_unpack/all.npc
@@ -3941,6 +3941,7 @@ model7=model_284_obj_wear
 model8=model_249_idk
 head1=model_59_idk_head
 head2=model_81_idk_head
+moverestrict=indoors
 
 [npc_219]
 vislevel=hide
@@ -5820,7 +5821,6 @@ head1=model_63_idk_head
 head2=model_77_npc_head
 head3=model_80_idk_head
 wanderrange=3
-moverestrict=outdoors
 
 [npc_331]
 vislevel=hide
@@ -8881,6 +8881,8 @@ model1=model_2909_npc
 model2=model_2890_npc
 model3=model_2917_npc
 head1=model_21_npc_head
+wanderrange=0
+moverestrict=nomove
 
 [npc_485]
 vislevel=hide
@@ -8893,6 +8895,8 @@ model1=model_2909_npc
 model2=model_2890_npc
 model3=model_2917_npc
 head1=model_21_npc_head
+wanderrange=0
+moverestrict=nomove
 
 [npc_486]
 vislevel=hide
@@ -9980,6 +9984,7 @@ model7=model_244_npc
 model8=model_185_obj_wear
 head1=model_57_obj_wear
 head2=model_84_idk_head
+moverestrict=indoors
 
 [npc_539]
 vislevel=hide
@@ -11977,6 +11982,7 @@ model9=model_245_npc
 head1=model_53_idk_head
 head2=model_40_obj_wear
 head3=model_78_npc_head
+moverestrict=indoors
 
 [romeo]
 name=Romeo
@@ -12045,7 +12051,7 @@ model6=model_275_idk
 model7=model_181_idk
 head1=model_52_idk_head
 head2=model_81_idk_head
-wanderrange=12
+wanderrange=2
 
 [npc_642]
 vislevel=hide
@@ -12809,6 +12815,8 @@ recol2d=4
 recol3s=0
 recol3d=931
 model1=model_2942_npc
+wanderrange=8
+attackrange=10
 
 [npc_678]
 name=Guard
@@ -16437,8 +16445,8 @@ model7=model_265_obj_wear
 model8=model_202_obj_wear
 head1=model_53_idk_head
 head2=model_44_obj_wear
-wanderrange=0
-moverestrict=nomove
+wanderrange=7
+moverestrict=indoors
 
 [npc_845]
 vislevel=hide
@@ -16930,8 +16938,8 @@ readyanim=seq_66
 op2=Attack
 vislevel=27
 model1=model_2943_npc
-wanderrange=3
-attackrange=5
+wanderrange=2
+attackrange=4
 
 [npc_880]
 size=2

--- a/data/src/scripts/areas/area_rimmington/configs/rimmington.npc
+++ b/data/src/scripts/areas/area_rimmington/configs/rimmington.npc
@@ -24,3 +24,4 @@ model6=model_361_obj_wear
 model7=model_377_obj_wear
 head1=model_122_npc_head
 head2=model_102_obj_wear
+moverestrict=indoors

--- a/data/src/scripts/areas/area_yanille/configs/yanille.npc
+++ b/data/src/scripts/areas/area_yanille/configs/yanille.npc
@@ -51,6 +51,7 @@ model11=model_3330_obj_wear
 head1=model_52_idk_head
 head2=model_77_npc_head
 head3=model_82_idk_head
+attackrange=5
 
 [sigbert_the_adventurer]
 vislevel=hide

--- a/src/lostcity/engine/World.ts
+++ b/src/lostcity/engine/World.ts
@@ -573,7 +573,7 @@ class World {
 
         const zone = this.getZone(npc.x, npc.z, npc.level);
         zone.addNpc(npc);
-        this.gameMap.collisionManager.changeNpcCollision(npc.x, npc.z, npc.level, true);
+        this.gameMap.collisionManager.changeNpcCollision(npc.width, npc.x, npc.z, npc.level, true);
 
         npc.x = npc.startX;
         npc.z = npc.startZ;
@@ -585,7 +585,7 @@ class World {
     removeNpc(npc: Npc) {
         const zone = this.getZone(npc.x, npc.z, npc.level);
         zone.removeNpc(npc);
-        this.gameMap.collisionManager.changeNpcCollision(npc.x, npc.z, npc.level, false);
+        this.gameMap.collisionManager.changeNpcCollision(npc.width, npc.x, npc.z, npc.level, false);
 
         npc.despawn = this.currentTick;
         npc.respawn = this.currentTick + 10;

--- a/src/lostcity/engine/collision/CollisionManager.ts
+++ b/src/lostcity/engine/collision/CollisionManager.ts
@@ -215,18 +215,20 @@ export default class CollisionManager {
 
     /**
      * Change collision at a specified Position for npcs.
+     * @param size The size square of this npc. (1x1, 2x2, etc).
      * @param x The x pos.
      * @param z The z pos.
      * @param level The level pos.
      * @param add True if adding this collision. False if removing.
      */
     changeNpcCollision(
+        size: number,
         x: number,
         z: number,
         level: number,
         add: boolean
     ): void {
-        this.npcCollider.change(x, z, level, add);
+        this.npcCollider.change(x, z, level, size, add);
     }
 
     /**

--- a/src/lostcity/engine/collision/NpcCollider.ts
+++ b/src/lostcity/engine/collision/NpcCollider.ts
@@ -12,12 +12,18 @@ export default class NpcCollider {
         x: number,
         z: number,
         level: number,
+        size: number,
         add: boolean
     ): void {
-        if (add) {
-            this.flags.add(x, z, level, CollisionFlag.BLOCK_NPC);
-        } else {
-            this.flags.remove(x, z, level, CollisionFlag.BLOCK_NPC);
+        const mask = CollisionFlag.BLOCK_NPC;
+        for (let index = 0; index < size * size; index++) {
+            const deltaX = x + (index % size);
+            const deltaZ = z + (index / size);
+            if (add) {
+                this.flags.add(deltaX, deltaZ, level, mask);
+            } else {
+                this.flags.remove(deltaX, deltaZ, level, mask);
+            }
         }
     }
 }

--- a/src/lostcity/entity/PathingEntity.ts
+++ b/src/lostcity/entity/PathingEntity.ts
@@ -106,8 +106,9 @@ export default abstract class PathingEntity extends Entity {
      */
     refreshZonePresence(previousX: number, previousZ: number, previousLevel: number): void {
         // update collision map
-        World.collisionManager.changeNpcCollision(previousX, previousZ, previousLevel, false);
-        World.collisionManager.changeNpcCollision(this.x, this.z, this.level, true);
+        // players and npcs both can change this collision
+        World.collisionManager.changeNpcCollision(this.width, previousX, previousZ, previousLevel, false);
+        World.collisionManager.changeNpcCollision(this.width, this.x, this.z, this.level, true);
 
         if (Position.zone(previousX) !== Position.zone(this.x) || Position.zone(previousZ) !== Position.zone(this.z) || previousLevel != this.level) {
             // update zone entities

--- a/src/lostcity/entity/Player.ts
+++ b/src/lostcity/entity/Player.ts
@@ -1692,29 +1692,25 @@ export default class Player extends PathingEntity {
             return true;
         }
 
-        if (target instanceof Player || target instanceof Npc || target instanceof Obj) {
-            return ReachStrategy.reached(World.collisionFlags, this.level, this.x, this.z, target.x, target.z, 1, 1, 1, 0, -2);
+        if (target instanceof Player || target instanceof Npc) {
+            return ReachStrategy.reached(World.collisionFlags, this.level, this.x, this.z, target.x, target.z, target.width, target.length, this.width, 0, -2);
         } else if (target instanceof Loc) {
             const type = LocType.get(target.type);
-            return ReachStrategy.reached(World.collisionFlags, this.level, this.x, this.z, target.x, target.z, type.width, type.length, 1, target.rotation, target.shape);
+            return ReachStrategy.reached(World.collisionFlags, this.level, this.x, this.z, target.x, target.z, type.width, type.length, this.width, target.rotation, target.shape);
         }
-
-        return false;
+        return ReachStrategy.reached(World.collisionFlags, this.level, this.x, this.z, target.x, target.z, 1, 1, this.width, 0, -2);
     }
 
     inApproachDistance(interaction: Interaction): boolean {
         const target = interaction.target;
 
         if (target instanceof Player || target instanceof Npc) {
-            return World.linePathFinder.lineOfSight(this.level, this.x, this.z, target.x, target.z, 1, target.width, target.length).success && Position.distanceTo(this, target) <= interaction.apRange;
+            return World.linePathFinder.lineOfSight(this.level, this.x, this.z, target.x, target.z, this.width, target.width, target.length).success && Position.distanceTo(this, target) <= interaction.apRange;
         } else if (target instanceof Loc) {
             const type = LocType.get(target.type);
-            return World.linePathFinder.lineOfSight(this.level, this.x, this.z, target.x, target.z, 1, type.width, type.length).success && Position.distanceTo(this, target) <= interaction.apRange;
-        } else if (target instanceof Obj) {
-            return World.linePathFinder.lineOfSight(this.level, this.x, this.z, target.x, target.z, 1).success && Position.distanceTo(this, target) <= interaction.apRange;
+            return World.linePathFinder.lineOfSight(this.level, this.x, this.z, target.x, target.z, this.width, type.width, type.length).success && Position.distanceTo(this, target) <= interaction.apRange;
         }
-
-        return false;
+        return World.linePathFinder.lineOfSight(this.level, this.x, this.z, target.x, target.z, this.width).success && Position.distanceTo(this, target) <= interaction.apRange;
     }
 
     /**

--- a/src/lostcity/entity/Player.ts
+++ b/src/lostcity/entity/Player.ts
@@ -1350,7 +1350,7 @@ export default class Player extends PathingEntity {
                     locType.width,
                     locType.length,
                     locType.id,
-                    0,
+                    10,
                     0
                 );
                 World.addLoc(entity, 500);

--- a/src/lostcity/entity/Player.ts
+++ b/src/lostcity/entity/Player.ts
@@ -1350,7 +1350,7 @@ export default class Player extends PathingEntity {
                     locType.width,
                     locType.length,
                     locType.id,
-                    10,
+                    0,
                     0
                 );
                 World.addLoc(entity, 500);


### PR DESCRIPTION
- Also fixes `Player#inOperableDistance` for npcs size > 1
- Also fixes `NpcCollider` by now changing collision for their entire size and not just their SW tile.