### PR TITLE
Demon Slayer fixes

### DIFF
--- a/data/src/scripts/areas/area_varrock/scripts/captain_rovin.rs2
+++ b/data/src/scripts/areas/area_varrock/scripts/captain_rovin.rs2
@@ -56,6 +56,6 @@ if ($option = 1) {
 [proc,demon_slayer_captain_rovin_dialogue_options]()(int)
 if (%demon_progress < 2 | %demon_progress = ^demon_complete) {
     return(~p_choice2("I am one of the palace guards.", 1, "What about the King?", 2));
-} else if (%demon_progress > 2 & %demon_progress < ^demon_complete) {
+} else if (%demon_progress > 1 & %demon_progress < ^demon_complete) {
     return(~p_choice3("I am one of the palace guards.", 1, "What about the King?", 2, "Yes I know, but this is important.", 3));
 }

--- a/data/src/scripts/ladders+stairs/scripts/stairs.rs2
+++ b/data/src/scripts/ladders+stairs/scripts/stairs.rs2
@@ -129,6 +129,10 @@ if($coord = 0_50_50_4_7) { // Lumbridge Castle South - level 0
     p_telejump(1_50_53_39_55);
 } else if($coord = 0_45_53_18_36) { // Taverly Sanfew House - level 0
     p_telejump(1_45_53_18_35);
+} else if($coord = 0_50_54_2_41) { // Varrock Palace Northwest Tower - level 0
+    p_telejump(1_50_54_3_40);
+} else if($coord = 0_48_49_31_23) { // Wizard Tower - level 0
+      p_telejump(1_48_49_33_24);
 } else {
     @unhandled_stairs($coord);
 }
@@ -143,6 +147,10 @@ if($coord = 1_50_50_4_7) { // Lumbridge Castle South - level 1
     @stair_options(2_50_50_6_29, 0_50_50_5_28);
 } else if($coord = 1_40_50_12_40) { // Clock Tower - level 1
     @stair_options(2_40_50_11_41, 0_40_50_12_42);
+} else if($coord = 1_50_54_2_41) { // Varrock Palace Northwest Tower - level 1
+    @stair_options(2_50_54_4_41, 0_50_54_3_40);
+} else if($coord = 1_48_49_31_23) { // Wizard Tower - level 1
+    @stair_options(2_48_49_32_25, 0_48_49_33_24);
 } else {
     @unhandled_stairs($coord);
 }
@@ -157,6 +165,10 @@ if($coord = 1_50_50_4_7) { // Lumbridge Castle South - level 1
     p_telejump(2_50_50_6_29);
 } else if($coord = 1_40_50_12_40) { // Clock Tower - level 1
     p_telejump(2_40_50_11_41);
+} else if($coord = 1_50_54_2_41) { // Varrock Palace Northwest Tower - level 1
+    p_telejump(2_50_54_4_41);
+} else if($coord = 1_48_49_31_23) { // Wizard Tower - level 1
+    p_telejump(2_48_49_32_25);
 } else {
     @unhandled_stairs($coord);
 }
@@ -171,6 +183,10 @@ if($coord = 1_50_50_4_7) { // Lumbridge Castle South - level 1
     p_telejump(0_50_50_5_28);
 } else if($coord = 1_40_50_12_40) { // Clock Tower - level 1
     p_telejump(0_40_50_12_42);
+} else if($coord = 1_50_54_2_41) { // Varrock Palace Northwest Tower - level 1
+    p_telejump(0_50_54_3_40);
+} else if($coord = 1_48_49_31_23) { // Wizard Tower - level 1
+    p_telejump(0_48_49_33_24);
 } else {
     @unhandled_stairs($coord);
 }
@@ -199,6 +215,10 @@ if($coord = 2_50_50_5_8) { // Lumbridge Castle South - level 2
     p_telejump(0_50_53_54_29);
 } else if($coord = 1_45_53_18_36) { // Taverly Sanfew House - level 1
     p_telejump(0_45_53_17_36);
+} else if($coord = 2_50_54_3_41) { // Varrock Palace Northwest Tower - level 2
+    p_telejump(1_50_54_3_40);
+} else if($coord = 2_48_49_32_24) { // Wizard Tower - level 2
+    p_telejump(1_48_49_33_24);
 } else {
     @unhandled_stairs($coord);
 }

--- a/data/src/scripts/quests/quest_demon/scripts/demon_slayer.rs2
+++ b/data/src/scripts/quests/quest_demon/scripts/demon_slayer.rs2
@@ -50,6 +50,8 @@ mes("That was the wrong incantation");
 [label,demon_slayer_correct_incantation]
 if_close();
 mes("Delrith is sucked back into the dark dimension from which he came!");
+// TODO: This is temporary so Delrith is reset. Once we figure out how he's looped into combat this will be irrelevant
+npc_changetype(delrith);
 queue(demon_slayer_complete, 1);
 
 [queue,demon_slayer_complete]
@@ -72,6 +74,9 @@ if (%demon_progress < 2) {
     mes("I have no reason to do that.");
     p_delay(2);
 } else {
+    if (last_item ! bucket_water) {
+        @nothing_interesting_happens;
+    }
     mes("You pour the liquid down the drain.");
     p_delay(2);
     mes("Ok, I think I've washed the key down to the sewer.");
@@ -81,5 +86,6 @@ if (%demon_progress < 2) {
     inv_del(inv, bucket_water, 1);
     inv_add(inv, bucket_empty, 1);
     // Tele to 3227 9898 0
+    // TODO: this should be instanced per player
     obj_add(0_50_154_25_41, demon_prysin_key, 1, 300); // Guessing Duration is ticks?
 }


### PR DESCRIPTION
Fixes:
- Stairs now work in the Varrock Castle and Wizard Tower.
- Once "killed" Delrith resets to his non-weakened form.  This is temporary until we can actually defeat him in combat.
- The sewer drain now correctly checks for only a bucket of water rather than letting you use any item.
- - This matches the functionality of RSC, as well as being able to have multiple keys spawned in the sewer at once
- Captain Rovin is now willing to talk about having a key after speaking with Sir Prysin.