### PR TITLE
ci: lint PR titles for conventional commits

### DIFF
--- a/.github/workflows/pr-conventional-commits.yml
+++ b/.github/workflows/pr-conventional-commits.yml
@@ -1,0 +1,16 @@
+name: "PR title should be conventional commit format"
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v3.4.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Checks that PR titles are in the [conventional commits format](https://www.conventionalcommits.org/)

This will allow @Pazaz  to one-click merge without changing commit message