### PR TITLE
fix: npc ai_mode improperly running

### DIFF
--- a/data/src/scripts/player/scripts/damage.rs2
+++ b/data/src/scripts/player/scripts/damage.rs2
@@ -30,7 +30,8 @@ while ($i < $size) {
 
     $i = calc($i + 1);
 }
-~update_all(inv_getobj(worn, ^wearpos_rhand));
+buildappearance(worn);
+
 p_telejump(0_50_50_22_22); // todo: randomize
 anim(null, 0);
 mes("Oh dear, you are dead!");

--- a/data/src/scripts/player/scripts/damage.rs2
+++ b/data/src/scripts/player/scripts/damage.rs2
@@ -30,8 +30,7 @@ while ($i < $size) {
 
     $i = calc($i + 1);
 }
-buildappearance(worn);
-
+~update_all(inv_getobj(worn, ^wearpos_rhand));
 p_telejump(0_50_50_22_22); // todo: randomize
 anim(null, 0);
 mes("Oh dear, you are dead!");

--- a/src/lostcity/cache/NpcType.ts
+++ b/src/lostcity/cache/NpcType.ts
@@ -81,7 +81,7 @@ export default class NpcType extends ConfigType {
     // server-side
     category = -1;
     wanderrange = 5;
-    maxrange = 5;
+    maxrange = 10;
     huntrange = 5;
     timer = -1;
     respawnrate = 100; // default to 1-minute

--- a/src/lostcity/entity/Npc.ts
+++ b/src/lostcity/entity/Npc.ts
@@ -505,7 +505,7 @@ export default class Npc extends PathingEntity {
         const targetDistanceFromStart = Position.distanceTo(target, { x: this.startX, z: this.startZ, width: target.width, length: target.length });
         const type = NpcType.get(this.type);
 
-        if (distanceToTarget > type.attackrange) {
+        if (distanceToTarget > type.maxrange) {
             this.playerEscapeMode();
             return;
         }
@@ -519,15 +519,24 @@ export default class Npc extends PathingEntity {
             (this.mode >= NpcMode.OPOBJ1 && this.mode <= NpcMode.OPOBJ5);
         const opOutOfRange = !this.inOperableDistance(this.target);
 
+        if (op && opOutOfRange) {
+            if (targetDistanceFromStart > type.attackrange && distanceToEscape > type.attackrange) {
+                return;
+            }
+            this.playerFollowMode();
+            return;
+        }
+
         const ap = (this.mode >= NpcMode.APNPC1 && this.mode <= NpcMode.APNPC5) ||
             (this.mode >= NpcMode.APPLAYER1 && this.mode <= NpcMode.APPLAYER5) ||
             (this.mode >= NpcMode.APLOC1 && this.mode <= NpcMode.APLOC5) ||
             (this.mode >= NpcMode.APOBJ1 && this.mode <= NpcMode.APOBJ5);
         const apOutOfRange = !this.inApproachDistance(type.attackrange, this.target);
 
-        if ((op && opOutOfRange && (distanceToEscape <= type.maxrange || targetDistanceFromStart <= distanceToEscape)) ||
-            (ap && apOutOfRange && !opOutOfRange))
-        {
+        if (ap && apOutOfRange && !opOutOfRange) {
+            if (targetDistanceFromStart > type.attackrange && distanceToEscape > type.attackrange) {
+                return;
+            }
             this.playerFollowMode();
             return;
         }


### PR DESCRIPTION
- Fixes npcs running ai scripts under specific conditions when they shouldnt be.
- Defaults `maxrange=10` because at 5 just looks wrong when at range > 5 and npcs do nothing.