### PR TITLE
feat: Stealing Wine of Zamorak

### DIFF
--- a/data/src/scripts/general/scripts/misc/wine_of_zamorak.rs2
+++ b/data/src/scripts/general/scripts/misc/wine_of_zamorak.rs2
@@ -1,0 +1,36 @@
+// Sources
+// https://www.youtube.com/watch?v=U3NUBXGV1SY&t=78s
+// https://www.youtube.com/watch?v=9WB1kF-IBro&t=230s
+// https://oldschool.runescape.wiki/w/Wine_of_zamorak
+
+[proc,wine_of_zamorak_attack](namedobj $obj, coord $coord)(boolean)
+// & $coord = 0_45_54_50_59
+if ($obj = wine_of_zamorak & $coord = 0_45_54_50_59) {
+    mes("STOP STEALING MY WINE! GAH!");
+    spotanim_pl(spotanim_78, 0, 0);
+    ~damage_self(calc((stat(hitpoints) / 20) + 1));
+    stat_sub(attack, 0, 5);
+    stat_sub(strength, 0, 5);
+    stat_sub(defence,0, 5);
+    stat_sub(ranged, 0, 5);
+    stat_sub(magic, 0, 5);
+
+    def_boolean $has_spoken = false;
+
+    $has_spoken = ~set_monk_aggro(0_45_54_50_59, $has_spoken);
+    $has_spoken = ~set_monk_aggro(0_45_54_57_61, $has_spoken);
+    return($has_spoken);
+}
+
+[proc,set_monk_aggro](coord $coord, boolean $has_spoken)(boolean)
+npc_findallzone($coord);
+while (npc_findnext = true) {
+    if (npc_category = monk_of_zamorak) {
+        if ($has_spoken = false) {
+            npc_say("Hands off Zamorak's wine!");
+            $has_spoken = true;
+        }
+        npc_setmode(opplayer2);
+    }
+}
+return($has_spoken);

--- a/data/src/scripts/general/scripts/misc/wine_of_zamorak.rs2
+++ b/data/src/scripts/general/scripts/misc/wine_of_zamorak.rs2
@@ -13,6 +13,7 @@ if (~wine_of_zamorak_attack(obj_type, obj_coord) = true) {
 if ($obj = wine_of_zamorak & $coord = 0_45_54_50_59) {
     mes("STOP STEALING MY WINE! GAH!");
     spotanim_pl(spotanim_78, 0, 0);
+    sound_synth(flames_of_zamorak, 0, 0);
     ~damage_self(calc((stat(hitpoints) / 20) + 1));
     stat_sub(attack, 0, 5);
     stat_sub(strength, 0, 5);

--- a/data/src/scripts/general/scripts/misc/wine_of_zamorak.rs2
+++ b/data/src/scripts/general/scripts/misc/wine_of_zamorak.rs2
@@ -4,7 +4,6 @@
 // https://oldschool.runescape.wiki/w/Wine_of_zamorak
 
 [proc,wine_of_zamorak_attack](namedobj $obj, coord $coord)(boolean)
-// & $coord = 0_45_54_50_59
 if ($obj = wine_of_zamorak & $coord = 0_45_54_50_59) {
     mes("STOP STEALING MY WINE! GAH!");
     spotanim_pl(spotanim_78, 0, 0);

--- a/data/src/scripts/general/scripts/misc/wine_of_zamorak.rs2
+++ b/data/src/scripts/general/scripts/misc/wine_of_zamorak.rs2
@@ -2,6 +2,12 @@
 // https://www.youtube.com/watch?v=U3NUBXGV1SY&t=78s
 // https://www.youtube.com/watch?v=9WB1kF-IBro&t=230s
 // https://oldschool.runescape.wiki/w/Wine_of_zamorak
+[opobj3,wine_of_zamorak]
+if (~wine_of_zamorak_attack(obj_type, obj_coord) = true) {
+    return;
+}
+@pickup_obj(obj_coord, obj_type, obj_count);
+
 
 [proc,wine_of_zamorak_attack](namedobj $obj, coord $coord)(boolean)
 if ($obj = wine_of_zamorak & $coord = 0_45_54_50_59) {

--- a/data/src/scripts/player/scripts/pickup.rs2
+++ b/data/src/scripts/player/scripts/pickup.rs2
@@ -4,7 +4,7 @@
 if (distance(coord, $coord) = 0) {
     @pickup_obj_floor($obj, $amount);
 } else {
-    @pickup_obj_table($obj, $amount);
+    @pickup_obj_table($coord, $obj, $amount);
 }
 
 [label,pickup_obj_floor](namedobj $obj, int $amount)
@@ -15,10 +15,15 @@ anim(null, 0);
 obj_takeitem(inv);
 sound_synth(pick2, 0, 0);
 
-[label,pickup_obj_table](namedobj $obj, int $amount)
+[label,pickup_obj_table](coord $coord, namedobj $obj, int $amount)
 if (~pickup_obj_check_for_space($obj, $amount) = false) {
     return;
 }
+
+if (~wine_of_zamorak_attack($obj, $coord) = true) {
+    return;
+}
+
 anim(null, 0);
 p_delay(0);
 anim(human_pickuptable, 0);

--- a/data/src/scripts/player/scripts/pickup.rs2
+++ b/data/src/scripts/player/scripts/pickup.rs2
@@ -4,7 +4,7 @@
 if (distance(coord, $coord) = 0) {
     @pickup_obj_floor($obj, $amount);
 } else {
-    @pickup_obj_table($coord, $obj, $amount);
+    @pickup_obj_table($obj, $amount);
 }
 
 [label,pickup_obj_floor](namedobj $obj, int $amount)
@@ -15,15 +15,10 @@ anim(null, 0);
 obj_takeitem(inv);
 sound_synth(pick2, 0, 0);
 
-[label,pickup_obj_table](coord $coord, namedobj $obj, int $amount)
+[label,pickup_obj_table](namedobj $obj, int $amount)
 if (~pickup_obj_check_for_space($obj, $amount) = false) {
     return;
 }
-
-if (~wine_of_zamorak_attack($obj, $coord) = true) {
-    return;
-}
-
 anim(null, 0);
 p_delay(0);
 anim(human_pickuptable, 0);


### PR DESCRIPTION
Code for stealing Wine of Zamorak

Features:
* Reduces Attack, Strength, Defence, Ranged, Magic by 5%
* Damages player by their HP level / 20 + 1
* All monks in both zones attack player
* When all monks are dead the player can take the wine, but still receives damage (confirmed this happens on RS)
* Player can telegrab the wine