### PR TITLE
feat: dragon fire for dragons and other small fixes

### DIFF
--- a/data/src/scripts/areas/area_wizard_tower/scripts/wizard_grayzag.rs2
+++ b/data/src/scripts/areas/area_wizard_tower/scripts/wizard_grayzag.rs2
@@ -2,18 +2,7 @@
 // this can be pics, videos, forum posts, recounts, anything.
 
 // auto retaliate
-[ai_queue1,wizard_grayzag](int $arg)
-if (finduid(%npc_attacking_uid) = false) {
-    return;
-}
-// flinch
-// set npc to ap if its out of combat
-if (~npc_out_of_combat = true) {
-    %npc_action_delay = add(map_clock, divide(npc_param(attackrate), 2));
-    npc_setmode(applayer2);
-    return;
-}
-npc_setmode(opplayer2);
+[ai_queue1,wizard_grayzag](int $arg) ~npc_default_retaliate_ap;
 
 
 [ai_applayer2,wizard_grayzag]

--- a/data/src/scripts/macro events/scripts/mining/macro_event_rock_golem.rs2
+++ b/data/src/scripts/macro events/scripts/mining/macro_event_rock_golem.rs2
@@ -18,17 +18,7 @@ sound_synth(rock_spirit_appear, 0, 0);
 npc_delay(2);
 npc_setmode(opplayer2);
 
-[ai_queue1,_macro_event_rock_golem](int $arg)
-if (finduid(%npc_attacking_uid) = false) {
-    return;
-}
-// flinch
-if (~npc_out_of_combat = true) {
-    %npc_action_delay = add(map_clock, divide(npc_param(attackrate), 2));
-    // set to ap, after we reach 2006 dec
-}
-npc_setmode(opplayer2);
-
+// [ai_queue1,_macro_event_rock_golem](int $arg) ~npc_default_retaliate_ap;
 // pretty sure these guys dont have an op attack // https://youtu.be/3SqlpJe90jE?list=PLn23LiLYLb1bQvSMxsNH6T0eM0nRU-5w0&t=139
 // edit: Actually they probably removed the op attack in this update (dec 2006). https://oldschool.runescape.wiki/w/Update:Treasure_Trails,_spiders_and_sheep
 // before then they only melee'd. Ill keep this here for now

--- a/data/src/scripts/npc/scripts/dragon.rs2
+++ b/data/src/scripts/npc/scripts/dragon.rs2
@@ -1,0 +1,88 @@
+[ai_queue1,green_dragon](int $arg) ~npc_default_retaliate_ap;
+[ai_queue1,baby_dragon](int $arg) ~npc_default_retaliate_ap;
+[ai_queue1,baby_blue_dragon](int $arg) ~npc_default_retaliate_ap;
+[ai_queue1,red_dragon](int $arg) ~npc_default_retaliate_ap;
+[ai_queue1,blue_dragon](int $arg) ~npc_default_retaliate_ap;
+[ai_queue1,black_dragon](int $arg) ~npc_default_retaliate_ap;
+
+[ai_opplayer2,green_dragon] @dragon_ai_opplayer2;
+[ai_opplayer2,baby_dragon] @dragon_ai_opplayer2;
+[ai_opplayer2,baby_blue_dragon] @dragon_ai_opplayer2;
+[ai_opplayer2,red_dragon] @dragon_ai_opplayer2;
+[ai_opplayer2,blue_dragon] @dragon_ai_opplayer2;
+[ai_opplayer2,black_dragon] @dragon_ai_opplayer2;
+
+[ai_applayer2,green_dragon] @dragon_ai_applayer2;
+[ai_applayer2,baby_dragon] @dragon_ai_applayer2;
+[ai_applayer2,baby_blue_dragon] @dragon_ai_applayer2;
+[ai_applayer2,red_dragon] @dragon_ai_applayer2;
+[ai_applayer2,blue_dragon] @dragon_ai_applayer2;
+[ai_applayer2,black_dragon] @dragon_ai_applayer2;
+
+
+[label,dragon_ai_applayer2]
+// mes("<tostring(map_clock)>: Ap");
+if (%npc_action_delay > map_clock) {
+    return;
+}
+if (~npc_can_attack_player = false) {
+    npc_setmode(null);
+    return;
+}
+// 1/2 chance to switch to op, with line of walk check (same as elvarg for now)
+if (random(2) = 0 & lineofwalk(npc_coord, coord) = true) {
+    npc_setmode(opplayer2);
+}
+~dragon_fire;
+
+
+[label,dragon_ai_opplayer2]
+// mes("<tostring(map_clock)>: Op");
+if (%npc_action_delay > map_clock) {
+    return;
+}
+if (~npc_can_attack_player = false) {
+    npc_setmode(null);
+    return;
+}
+// 1/8 chance to switch back to ap (same as elvarg for now)
+if (random(8) = 0) {
+    npc_setmode(applayer2);
+}
+~dragon_fire;
+
+
+[proc,dragon_fire]
+if_close;
+spotanim_npc(spotanim_1, 92, 0);
+npc_anim(dragon_firebreath_middle_attack, 0);
+sound_synth(sound_22, 0, 30);
+%npc_action_delay = add(map_clock, 5);
+
+def_int $attack_roll = ~npc_melee_attack_roll;
+def_int $defence_roll = ~player_defence_roll_specific(npc_param(damagetype));
+
+// damage player
+def_int $maxhit = 30;
+if (inv_total(worn, dragonfire_shield) > 0) {
+    $maxhit = 5;
+} else if (%prayer_protectfrommagic = ^true) {
+    $maxhit = 10;
+} else if (randominc($attack_roll) > randominc($defence_roll)) {
+    $maxhit = add($maxhit, 20);
+    // these messages only show for unprotected or antifire protected players
+    mes("You're horribly burnt by the dragon fire!");
+} else {
+    mes("You manage to resist some of the dragon fire!");
+}
+
+if (map_clock < %antifire) {
+    mes("<tostring(map_clock)>, <tostring(%antifire)>");
+    $maxhit = sub($maxhit, 15);
+}
+
+def_int $damage = randominc(max($maxhit, 0));
+queue(damage_player, 0, $damage);
+queue(playerhit_n_retaliate, 0, npc_uid); // this should be a queue* command
+%npc_action_delay = add(map_clock, 4);
+~npc_set_attack_vars;

--- a/data/src/scripts/npc/scripts/dragon.rs2
+++ b/data/src/scripts/npc/scripts/dragon.rs2
@@ -49,7 +49,7 @@ if (~npc_can_attack_player = false) {
 if (random(8) = 0) {
     npc_setmode(applayer2);
 }
-~dragon_fire;
+~npc_default_attack;
 
 
 [proc,dragon_fire]

--- a/data/src/scripts/npc/scripts/dragon.rs2
+++ b/data/src/scripts/npc/scripts/dragon.rs2
@@ -77,7 +77,7 @@ if (inv_total(worn, dragonfire_shield) > 0) {
 }
 
 if (map_clock < %antifire) {
-    mes("<tostring(map_clock)>, <tostring(%antifire)>");
+    //mes("<tostring(map_clock)>, <tostring(%antifire)>");
     $maxhit = sub($maxhit, 15);
 }
 

--- a/data/src/scripts/player/scripts/consumption/effects/scripts/anti_fire.rs2
+++ b/data/src/scripts/player/scripts/consumption/effects/scripts/anti_fire.rs2
@@ -6,3 +6,16 @@ def_obj $consumable = last_item;
 // change item to its next stage. default is null
 inv_setslot(inv, last_slot, oc_param($consumable, next_obj_stage), 1);
 ~consume_effect_messages($consumable, stat(hitpoints), false);
+
+[proc,set_antifire_login]
+if (%antifire < 1) {
+    return;
+}
+%antifire = add(map_clock, %antifire);
+
+[proc,set_antifire_logout]
+if (%antifire < map_clock) {
+    %antifire = null;
+    return;
+}
+%antifire = sub(%antifire, map_clock);

--- a/data/src/scripts/player/scripts/consumption/effects/scripts/anti_poison.rs2
+++ b/data/src/scripts/player/scripts/consumption/effects/scripts/anti_poison.rs2
@@ -7,3 +7,17 @@ def_obj $consumable = last_item;
 // change item to its next stage. default is null
 inv_setslot(inv, last_slot, oc_param($consumable, next_obj_stage), 1);
 ~consume_effect_messages($consumable, stat(hitpoints), false);
+
+
+[proc,set_antipoison_login]
+if (%antipoison < 1) {
+    return;
+}
+%antipoison = add(map_clock, %antipoison);
+
+[proc,set_antipoison_logout]
+if (%antipoison < map_clock) {
+    %antipoison = null;
+    return;
+}
+%antipoison = sub(%antipoison, map_clock);

--- a/data/src/scripts/player/scripts/global.rs2
+++ b/data/src/scripts/player/scripts/global.rs2
@@ -28,6 +28,10 @@ settimer(general_macro_events, 500);
 ~macro_event_general_check;
 // so pk skulls persist after logging back in
 ~set_pk_skull_login;
+// so antifire persists after logging back in
+~set_antifire_login;
+// so antipoison persists after logging back in
+~set_antipoison_login;
 
 
 if (%tutorial_progress < ^tutorial_complete) {

--- a/data/src/scripts/player/scripts/logout.rs2
+++ b/data/src/scripts/player/scripts/logout.rs2
@@ -24,6 +24,8 @@ if (%tradepartner ! null) {
 }
 ~reset_stall_trade_timers;
 ~set_pk_skull_logout;
+~set_antifire_logout;
+~set_antipoison_logout;
 ~clear_ball_shed_uid;
 
 return(true);

--- a/data/src/scripts/quests/quest_dragon/scripts/elvarg.rs2
+++ b/data/src/scripts/quests/quest_dragon/scripts/elvarg.rs2
@@ -14,19 +14,7 @@ if (%dragon_progress < ^dragon_complete) {
 }
 
 
-//data is only from about 50 hits
-[ai_queue1,elvarg](int $arg)
-if (finduid(%npc_attacking_uid) = false) {
-    return;
-}
-// flinch
-// set npc to ap if its out of combat
-if (~npc_out_of_combat = true) {
-    %npc_action_delay = add(map_clock, divide(npc_param(attackrate), 2));
-    npc_setmode(applayer2);
-    return;
-}
-npc_setmode(opplayer2);
+[ai_queue1,elvarg](int $arg) ~npc_default_retaliate_ap;
 
 // https://twitter.com/JagexAsh/status/1756992041777561878
 // "AP -> OP: 1/2, subject to a line-of-walk check.
@@ -97,7 +85,7 @@ if (inv_total(worn, dragonfire_shield) > 0) {
         // https://youtu.be/lSV2whAirvY?t=41
         mes("Your prayers resist some of the dragon fire!");
     }
-    if (%antifire < map_clock) {
+    if (map_clock < %antifire) {
         $maxhit = sub($maxhit, 3);
         // guess based off this https://youtu.be/UXNFe3FeDgg?t=15
         mes("Your potion protects you from the heat of the dragon fire!");
@@ -106,7 +94,7 @@ if (inv_total(worn, dragonfire_shield) > 0) {
     if (%prayer_protectfrommagic = ^true) {
         $maxhit = sub($maxhit, 15);
     }
-    if (%antifire = ^true) {
+    if (map_clock < %antifire) {
         $maxhit = sub($maxhit, 15);
     }
 }

--- a/data/src/scripts/quests/quest_dragon/scripts/elvarg.rs2
+++ b/data/src/scripts/quests/quest_dragon/scripts/elvarg.rs2
@@ -1,6 +1,7 @@
 // death
 [ai_queue3,elvarg](int $arg)
 gosub(npc_death);
+// requires kill credit? https://youtu.be/6ZU7EIZcU4o?list=PLn23LiLYLb1aqrojPTi1_Np81LJku2Nd0&t=141
 if (npc_findhero = false) {
     return;
 }

--- a/data/src/scripts/quests/quest_dragon/scripts/elvarg.rs2
+++ b/data/src/scripts/quests/quest_dragon/scripts/elvarg.rs2
@@ -28,6 +28,9 @@ if (~npc_out_of_combat = true) {
 }
 npc_setmode(opplayer2);
 
+// https://twitter.com/JagexAsh/status/1756992041777561878
+// "AP -> OP: 1/2, subject to a line-of-walk check.
+// OP -> AP: 1/8"
 [ai_applayer2,elvarg]
 //mes("<tostring(map_clock)>: Ap");
 if (%npc_action_delay > map_clock) {
@@ -37,8 +40,8 @@ if (~npc_can_attack_player = false) {
     npc_setmode(null);
     return;
 }
-// seems like 2/3 chance to dragon fire if ap.
-if (random(3) = 0) {
+// 1/2 chance to switch to op, with line of walk check
+if (random(2) = 0 & lineofwalk(npc_coord, coord) = true) {
     npc_setmode(opplayer2);
 }
 ~elvarg_dragon_fire;
@@ -53,8 +56,8 @@ if (~npc_can_attack_player = false) {
     npc_setmode(null);
     return;
 }
-// seems like 2/3 chance to melee if op.
-if (random(3) = 0) {
+// 1/8 chance to switch back to ap
+if (random(8) = 0) {
     npc_setmode(applayer2);
 }
 ~npc_default_attack;

--- a/data/src/scripts/quests/quest_dragon/scripts/elvarg.rs2
+++ b/data/src/scripts/quests/quest_dragon/scripts/elvarg.rs2
@@ -58,15 +58,13 @@ npc_anim(dragon_firebreath_middle_attack, 0);
 sound_synth(sound_22, 0, 30);
 %npc_action_delay = add(map_clock, 5);
 
-def_int $attack_roll = ~npc_melee_attack_roll;
-def_int $defence_roll = ~player_defence_roll_specific(npc_param(damagetype));
-
 // damage player
 def_int $maxhit = ~elvarg_max_hit;
-def_int $damage = 0;
-if (randominc($attack_roll) > randominc($defence_roll)) {
-    $damage = randominc($maxhit);
-}
+def_int $damage = randominc(~elvarg_max_hit);
+
+// not sure if this was a thing, but this video has it https://youtu.be/ucaYfz3ihWs?list=PLn23LiLYLb1aqrojPTi1_Np81LJku2Nd0&t=130
+stat_sub(prayer, 0 , 10); // 10%
+
 queue(damage_player, 0, $damage);
 queue(playerhit_n_retaliate, 0, npc_uid); // this should be a queue* command
 %npc_action_delay = add(map_clock, 4);

--- a/data/src/scripts/quests/quest_dragon/scripts/melzar_the_mad.rs2
+++ b/data/src/scripts/quests/quest_dragon/scripts/melzar_the_mad.rs2
@@ -1,16 +1,5 @@
 // auto retaliate
-[ai_queue1,melzar](int $arg)
-if (finduid(%npc_attacking_uid) = false) {
-    return;
-}
-// flinch
-// set npc to ap if its out of combat
-if (~npc_out_of_combat = true) {
-    %npc_action_delay = add(map_clock, divide(npc_param(attackrate), 2));
-    npc_setmode(applayer2);
-    return;
-}
-npc_setmode(opplayer2);
+[ai_queue1,melzar](int $arg) ~npc_default_retaliate_ap;
 
 
 // his ap attacks dont have the curse spell. It is replaced with the zap spell

--- a/data/src/scripts/skill_combat/scripts/npc/npc_combat.rs2
+++ b/data/src/scripts/skill_combat/scripts/npc/npc_combat.rs2
@@ -14,6 +14,22 @@ if (finduid(%npc_attacking_uid) = true) {
     npc_setmode(opplayer2);
 }
 
+// mostly used for ranged and magic npc's
+[proc,npc_default_retaliate_ap]
+// set npc to ap if its out of combat
+if (~npc_out_of_combat = true) {
+    %npc_action_delay = add(map_clock, divide(npc_param(attackrate), 2));
+    %npc_attacking_uid = %npc_aggressive_player;
+    if (finduid(%npc_attacking_uid) = true) {
+        npc_setmode(applayer2);
+    }
+    return;
+}
+if (finduid(%npc_attacking_uid) = true) {
+    npc_setmode(opplayer2);
+}
+
+
 // a default melee attack script.
 [proc,npc_default_attack]
 if (stat(hitpoints) = 0) {
@@ -101,7 +117,7 @@ if (~npc_is_attackable($npc) = false) {
 return (true);
 
 [proc,npc_out_of_combat]()(boolean)
-if (add(%npc_lastattack, 8) < map_clock | (npc_getmode ! opplayer2 & npc_getmode ! playerescape)) {
+if (add(%npc_lastattack, 8) < map_clock | (npc_getmode ! applayer2 & npc_getmode ! opplayer2 & npc_getmode ! playerescape)) {
     return (true);
 }
 return (false);


### PR DESCRIPTION
- Antipoison and antifire persists after logging back in. Not sure if stat buffs or potion buffs like antifire & antipoison should be removed on logout.
- Elvarg attack switching chances
- Dragon fire for colored dragons (same chances as elvarg for now)
- Not every npc's retaliations were updated for singles/multi logic. Added a npc_default_retaliate_ap proc, I think most monsters that have an ap attack always auto retaliate with ap first.