### PR TITLE
fix: Tutorial Island warranty fixes

### DIFF
--- a/data/src/scripts/player/scripts/global.rs2
+++ b/data/src/scripts/player/scripts/global.rs2
@@ -96,7 +96,7 @@ if (/*staffmodlevel = 2 & */inv_getobj(worn, ^wearpos_rhand) = poisoned_dagger) 
 ~update_bas; // update appearance
 ~update_bonuses; // update bonuses if
 ~update_weight; // update weight
-if (%tutorial_progress > ^combat_instructor_dagger_equipped) {
+if (%tutorial_progress > ^combat_instructor_unequipping_items) {
     ~update_weapon_category($previous_weapon); // the attack tab weapon category
 }
 ~player_combat_stat; // update combat varps

--- a/data/src/scripts/tutorial/configs/tutorial.npc
+++ b/data/src/scripts/tutorial/configs/tutorial.npc
@@ -162,6 +162,7 @@ head1=model_52_idk_head
 head2=model_82_idk_head
 head3=model_44_obj_wear
 wanderrange=2
+moverestrict=indoors
 
 [financial_advisor]
 vislevel=hide

--- a/data/src/scripts/tutorial/scripts/guides/brother_brace.rs2
+++ b/data/src/scripts/tutorial/scripts/guides/brother_brace.rs2
@@ -33,7 +33,7 @@ if (%tutorial_progress = ^brother_brace_opened_prayer_tab) {
 
 [label,brother_brace_friends_and_ignore_tabs]
 ~chatnpc(neutral, "Good. Now you have both menus open I'll tell you a little about each. You can add people to either list by clicking the add button then typing in their name into the box that appears.");
-~chatnpc(neutral, "You remove people from the lists in the same way. if you add someone to your ignore list they will not be able to talk to you, or send any form of message to you.");
+~chatnpc(neutral, "You remove people from the lists in the same way. If you add someone to your ignore list they will not be able to talk to you, or send any form of message to you.");
 ~chatnpc(neutral, "Your friends list shows the online status of your friends. Friends in red are offline, green online and on the same server, and yellow online but on a different server.");
 ~chatplayer(quiz, "Are there rules on ingame behavior?");
 ~chatnpc(neutral, "Yes you should read the rules of conduct on our frontpage to make sure you do nothing to get yourself banned.");
@@ -65,7 +65,7 @@ if (%tutorial_progress = ^brother_brace_after_friends_tab) {
 
 [label,brother_brace_friends_recap]
 ~chatnpc(neutral, "Your friends and ignore lists, yes... I'll tell you a little about each. You can add people to either list by clicking the add button then typing in their name into the box that appears.");
-~chatnpc(neutral, "You remove people from the lists in the same way. if you add someone to your ignore list they will not be able to talk to you, or send any form of message to you.");
+~chatnpc(neutral, "You remove people from the lists in the same way. If you add someone to your ignore list they will not be able to talk to you, or send any form of message to you.");
 ~chatnpc(neutral, "Your friends list shows the online status of your friends. Friends in red are offline, green online and on the same server, and yellow online but on a different server.");
 @brother_brace_recap_questions;
 

--- a/data/src/scripts/tutorial/scripts/guides/combat_instructor.rs2
+++ b/data/src/scripts/tutorial/scripts/guides/combat_instructor.rs2
@@ -123,19 +123,14 @@ if (%tutorial_progress = ^combat_instructor_after_rat_kill_melee) {
 ~chatnpc(neutral, "Ok then, <displayname>.");
 
 [proc,combat_instructor_replace_items]
-if (inv_freespace(inv) = 0) {
-    ~mesbox("You need some new weapons for this section of the tutorial but you don't have enough inventory room. You'll need to drop something. To do so, right click on an item you don't want and select drop. Once you've done that, speak to the combat instructor again.");
-    return;
-}
-
 if (%tutorial_progress > ^combat_instructor_start
     & (%tutorial_progress < ^combat_instructor_dagger_equipped
         | %tutorial_progress > ^combat_instructor_before_attacking_ranged) ) {
-        if (~tutorial_has_obj_on_person(bronze_dagger) = false & inv_freespace(inv) > 0) {
-            inv_add(inv, bronze_dagger, 1);
-            ~objbox(bronze_dagger, "The Combat Guide gives you a |@blu@Bronze dagger!");
-        }
+    if (~tutorial_has_obj_on_person(bronze_dagger) = false & inv_freespace(inv) > 0) {
+        inv_add(inv, bronze_dagger, 1);
+        ~objbox(bronze_dagger, "The Combat Guide gives you a |@blu@Bronze dagger!");
     }
+}
 if (%tutorial_progress > ^combat_instructor_worn_inventory
     & %tutorial_progress ! ^combat_instructor_after_rat_kill_melee
     & %tutorial_progress ! ^combat_instructor_before_attacking_ranged) {

--- a/data/src/scripts/tutorial/scripts/guides/combat_instructor.rs2
+++ b/data/src/scripts/tutorial/scripts/guides/combat_instructor.rs2
@@ -93,7 +93,7 @@ if (%tutorial_progress = ^combat_instructor_after_rat_kill_melee) {
 ~chatnpc(neutral, "You will find out on the mainland that certain items can also affect your stats. There are potions that can be drunk that can alter your stats temporarily, such as raising Strength.");
 ~chatnpc(neutral, "You will also raise your Defence and Attack values by using different weapons and armours.");
 ~chatnpc(neutral, "Before going into combat with an opponent it is wise to put the mouse over them and see what combat level they are.");
-~chatnpc(neutral, "Green coloured writing usually means it will be an easy fight for you, red means you will probably lose, yellow means they ar around your level and orange means they are slightly stronger.");
+~chatnpc(neutral, "Green coloured writing usually means it will be an easy fight for you, red means you will probably lose, yellow means they are around your level and orange means they are slightly stronger.");
 ~chatnpc(neutral, "Sometimes things will go your way, sometimes they won't. There is no such thing as a guaranteed win, but if the odds are  on your side, you stand the best chance of walking away victorious.");
 ~chatnpc(quiz, "Now, was there something else you wanted to hear about again.");
 @combat_instructor_recap_questions;

--- a/data/src/scripts/tutorial/scripts/guides/combat_instructor.rs2
+++ b/data/src/scripts/tutorial/scripts/guides/combat_instructor.rs2
@@ -129,8 +129,9 @@ if (inv_freespace(inv) = 0) {
 }
 
 if (%tutorial_progress > ^combat_instructor_start
-    & %tutorial_progress < ^combat_instructor_dagger_equipped) {
-        if (inv_total(inv, bronze_dagger) < 1 & inv_freespace(inv) > 0) {
+    & (%tutorial_progress < ^combat_instructor_dagger_equipped
+        | %tutorial_progress > ^combat_instructor_before_attacking_ranged) ) {
+        if (~tutorial_has_obj_on_person(bronze_dagger) = false & inv_freespace(inv) > 0) {
             inv_add(inv, bronze_dagger, 1);
             ~objbox(bronze_dagger, "The Combat Guide gives you a |@blu@Bronze dagger!");
         }
@@ -138,44 +139,40 @@ if (%tutorial_progress > ^combat_instructor_start
 if (%tutorial_progress > ^combat_instructor_worn_inventory
     & %tutorial_progress ! ^combat_instructor_after_rat_kill_melee
     & %tutorial_progress ! ^combat_instructor_before_attacking_ranged) {
-    if (inv_total(inv, bronze_sword) < 1 & inv_total(worn, bronze_sword) < 1
-        & inv_total(inv, wooden_shield) < 1 & inv_total(worn, wooden_shield) < 1
+    if (~tutorial_has_obj_on_person(bronze_sword) = false
+        & ~tutorial_has_obj_on_person(wooden_shield) = false
         & inv_freespace(inv) > 1) {
         inv_add(inv, bronze_sword, 1);
         inv_add(inv, wooden_shield, 1);
         ~doubleobjbox(bronze_sword, wooden_shield, "The Combat Guide gives you a |@blu@Bronze sword@bla@ |and a |@blu@Wooden Shield!");
     }
 
-    if (inv_total(inv, bronze_sword) < 1 & inv_total(worn, bronze_sword) < 1
-        & inv_freespace(inv) > 0) {
+    if (~tutorial_has_obj_on_person(bronze_sword) = false & inv_freespace(inv) > 0) {
         inv_add(inv, bronze_sword, 1);
         ~objboxt(bronze_sword, "The Combat Guide gives you a |@blu@Bronze sword!");
     }
 
-    if (inv_total(inv, wooden_shield) < 1 & inv_total(worn, wooden_shield) < 1
-        & inv_freespace(inv) > 0) {
+    if (~tutorial_has_obj_on_person(wooden_shield) = false & inv_freespace(inv) > 0) {
         inv_add(inv, wooden_shield, 1);
         ~objboxt(wooden_shield, "The Combat Guide gives you a |@blu@Wooden Shield!");
     }
 }
 
 if (%tutorial_progress > ^combat_instructor_after_rat_kill_melee) {
-    if (inv_total(inv, bronze_arrow) < 1 & inv_total(worn, bronze_arrow) < 1
-        & inv_total(inv, shortbow) < 1 & inv_total(worn, shortbow) < 1
+    if (~tutorial_has_obj_on_person(bronze_arrow) = false
+        & ~tutorial_has_obj_on_person(shortbow) = false
         & inv_freespace(inv) > 1) {
         inv_add(inv, bronze_arrow, 50);
         inv_add(inv, shortbow, 1);
         ~doubleobjbox(bronze_arrow_5, shortbow, "The Combat Guide gives you some |@blu@Bronze arrows@bla@ |and a |@blu@Shortbow!");
     }
 
-    if (inv_total(inv, bronze_arrow) < 1 & inv_total(worn, bronze_arrow) < 1
-        & inv_freespace(inv) > 0) {
+    if (~tutorial_has_obj_on_person(bronze_arrow) = false & inv_freespace(inv) > 0) {
         inv_add(inv, bronze_arrow, 50);
         ~objboxt(bronze_arrow_5, "The Combat Guide gives you some |@blu@Bronze arrows!");
     }
 
-    if (inv_total(inv, shortbow) < 1 & inv_total(worn, shortbow) < 1
-        & inv_freespace(inv) > 0) {
+    if (~tutorial_has_obj_on_person(shortbow) = false & inv_freespace(inv) > 0) {
         inv_add(inv, shortbow, 1);
         ~objboxt(shortbow, "The Combat Guide gives you a |@blu@Shortbow!");
     }

--- a/data/src/scripts/tutorial/scripts/guides/combat_instructor.rs2
+++ b/data/src/scripts/tutorial/scripts/guides/combat_instructor.rs2
@@ -126,7 +126,7 @@ if (%tutorial_progress = ^combat_instructor_after_rat_kill_melee) {
 if (%tutorial_progress > ^combat_instructor_start
     & (%tutorial_progress < ^combat_instructor_dagger_equipped
         | %tutorial_progress > ^combat_instructor_before_attacking_ranged) ) {
-    if (~tutorial_has_obj_on_person(bronze_dagger) = false & inv_freespace(inv) > 0) {
+    if (~tutorial_has_obj_on_person(bronze_dagger) = false) {
         inv_add(inv, bronze_dagger, 1);
         ~objbox(bronze_dagger, "The Combat Guide gives you a |@blu@Bronze dagger!");
     }
@@ -135,19 +135,14 @@ if (%tutorial_progress > ^combat_instructor_worn_inventory
     & %tutorial_progress ! ^combat_instructor_after_rat_kill_melee
     & %tutorial_progress ! ^combat_instructor_before_attacking_ranged) {
     if (~tutorial_has_obj_on_person(bronze_sword) = false
-        & ~tutorial_has_obj_on_person(wooden_shield) = false
-        & inv_freespace(inv) > 1) {
+        & ~tutorial_has_obj_on_person(wooden_shield) = false) {
         inv_add(inv, bronze_sword, 1);
         inv_add(inv, wooden_shield, 1);
         ~doubleobjbox(bronze_sword, wooden_shield, "The Combat Guide gives you a |@blu@Bronze sword@bla@ |and a |@blu@Wooden Shield!");
-    }
-
-    if (~tutorial_has_obj_on_person(bronze_sword) = false & inv_freespace(inv) > 0) {
+    }else if (~tutorial_has_obj_on_person(bronze_sword) = false) {
         inv_add(inv, bronze_sword, 1);
         ~objboxt(bronze_sword, "The Combat Guide gives you a |@blu@Bronze sword!");
-    }
-
-    if (~tutorial_has_obj_on_person(wooden_shield) = false & inv_freespace(inv) > 0) {
+    }else if (~tutorial_has_obj_on_person(wooden_shield) = false) {
         inv_add(inv, wooden_shield, 1);
         ~objboxt(wooden_shield, "The Combat Guide gives you a |@blu@Wooden Shield!");
     }
@@ -155,19 +150,14 @@ if (%tutorial_progress > ^combat_instructor_worn_inventory
 
 if (%tutorial_progress > ^combat_instructor_after_rat_kill_melee) {
     if (~tutorial_has_obj_on_person(bronze_arrow) = false
-        & ~tutorial_has_obj_on_person(shortbow) = false
-        & inv_freespace(inv) > 1) {
+        & ~tutorial_has_obj_on_person(shortbow) = false) {
         inv_add(inv, bronze_arrow, 50);
         inv_add(inv, shortbow, 1);
         ~doubleobjbox(bronze_arrow_5, shortbow, "The Combat Guide gives you some |@blu@Bronze arrows@bla@ |and a |@blu@Shortbow!");
-    }
-
-    if (~tutorial_has_obj_on_person(bronze_arrow) = false & inv_freespace(inv) > 0) {
+    }else if (~tutorial_has_obj_on_person(bronze_arrow) = false) {
         inv_add(inv, bronze_arrow, 50);
         ~objboxt(bronze_arrow_5, "The Combat Guide gives you some |@blu@Bronze arrows!");
-    }
-
-    if (~tutorial_has_obj_on_person(shortbow) = false & inv_freespace(inv) > 0) {
+    }else if (~tutorial_has_obj_on_person(shortbow) = false) {
         inv_add(inv, shortbow, 1);
         ~objboxt(shortbow, "The Combat Guide gives you a |@blu@Shortbow!");
     }

--- a/data/src/scripts/tutorial/scripts/guides/financial_advisor.rs2
+++ b/data/src/scripts/tutorial/scripts/guides/financial_advisor.rs2
@@ -7,10 +7,10 @@ if (%tutorial_progress = ^tutorial_opened_financial_advisor_door) {
 
 [label,financial_advisor_incomplete]
 ~chatplayer(quiz, "Hello... Who are you?");
-~chatnpc(neutral, "I'm a financial advisor. |I'm here to tell people how ot make money.");
+~chatnpc(neutral, "I'm a financial advisor. |I'm here to tell people how to make money.");
 ~chatplayer(quiz, "OK... How can I make money then?");
 ~chatnpc(neutral, "...how can you make money. Quite.");
-~chatnpc(neutral, "Well there are three basic ways of making money here; Combat, Quests and Trading. I will talk you through each of tem very quickly.");
+~chatnpc(neutral, "Well there are three basic ways of making money here; Combat, Quests and Trading. I will talk you through each of them very quickly.");
 ~chatnpc(neutral, "Let's start with combat, as it is probably still fresh in your mind. Many enemies, both human and monster will drop items when they die.");
 ~chatnpc(neutral, "Now, the next way to earn money quickly is by quests. Many people on RuneScape have things they need doing, which they will reward you for.");
 ~chatnpc(neutral, "By getting a high level in skills such as cooking, mining, smithing or fishing, you can create your own items and sell them for pure profit.");

--- a/data/src/scripts/tutorial/scripts/guides/magic_instructor.rs2
+++ b/data/src/scripts/tutorial/scripts/guides/magic_instructor.rs2
@@ -44,19 +44,12 @@ if (inv_total(inv, airrune) < 25 & inv_total(inv, mindrune) < 25) {
     ~doubleobjbox(airrune, mindrune, "Terrova gives you some |@blu@Air runes| and some |@blu@Mind runes!");
     inv_add(inv, airrune, ~magic_instructor_runes_to_give(airrune));
     inv_add(inv, mindrune, ~magic_instructor_runes_to_give(mindrune));
-    return;
-}
-
-if (inv_total(inv, airrune) < 25) {
+}else if (inv_total(inv, airrune) < 25) {
     ~objboxt(airrune, "Terrova gives you some |@blu@Air runes!");
     inv_add(inv, airrune, ~magic_instructor_runes_to_give(airrune));
-    return;
-}
-
-if (inv_total(inv, mindrune) < 25) {
+}else if (inv_total(inv, mindrune) < 25) {
     ~objboxt(mindrune, "Terrova gives you some |@blu@Mind runes!");
     inv_add(inv, mindrune, ~magic_instructor_runes_to_give(mindrune));
-    return;
 }
 
 [proc,magic_instructor_runes_to_give](obj $obj)(int)
@@ -97,9 +90,6 @@ if (%tutorial_progress = ^tutorial_successful_wind_strike) {
 // check inventory space...
 // There's no inventory full message on OSRS it still shows the interface just no runes are given...
 ~doubleobjbox(airrune, mindrune, "Terrova gives you five |@blu@Air runes| and five |@blu@Mind runes!");
-if (inv_freespace(inv) < 1) {
-    return;
-}
 inv_add(inv, airrune, 5);
 inv_add(inv, mindrune, 5);
 

--- a/data/src/scripts/tutorial/scripts/guides/master_chef.rs2
+++ b/data/src/scripts/tutorial/scripts/guides/master_chef.rs2
@@ -27,28 +27,22 @@ switch_int(%tutorial_progress) {
 //    return;
 //}
 
-if (inv_total(inv, pot_of_flour) < 1 & inv_total(inv, bucket_water) > 0 & inv_freespace(inv) > 0) {
-    inv_add(inv, pot_of_flour, 1);
-    ~objbox(pot_of_flour, "The Cooking Guide gives you a |@blu@Pot of Flour.");
-    return;
-}
+//if (inv_total(inv, pot_of_flour) < 1 & inv_total(inv, bucket_water) < 1) {
+//    inv_add(inv, pot_of_flour, 1);
+//    ~objbox(pot_of_flour, "The Cooking Guide gives you some flour. He would have given you some water as well but you didn't have room for it. To get some drop something and talk to the |Cooking Guide again.");
+//    return;
+//}
 
-if (inv_freespace(inv) = 1 & inv_total(inv, pot_of_flour) < 1 & inv_total(inv, bucket_water) < 1) {
-    inv_add(inv, pot_of_flour, 1);
-    ~objbox(pot_of_flour, "The Cooking Guide gives you some flour. He would have given you some water as well but you didn't have room for it. To get some drop something and talk to the |Cooking Guide again.");
-    return;
-}
-
-if (inv_total(inv, bucket_water) < 1 & inv_total(inv, pot_of_flour) > 0 & inv_freespace(inv) > 0) {
-    inv_add(inv, bucket_water, 1);
-    ~objbox(bucket_water, "The Cooking Guide gives you a|@blu@Bucket of Water.");
-    return;
-}
-
-if (inv_freespace(inv) > 1 & inv_total(inv, pot_of_flour) < 1 & inv_total(inv, bucket_water) < 1) {
+if (inv_total(inv, pot_of_flour) < 1 & inv_total(inv, bucket_water) < 1) {
     inv_add(inv, pot_of_flour, 1);
     inv_add(inv, bucket_water, 1);
     ~doubleobjbox(bucket_water, pot_of_flour, "The Cooking Guide gives you a |@blu@Bucket of Water@bla@ |and a|@blu@Pot of Flour!");
+} else if (inv_total(inv, pot_of_flour) < 1 & inv_total(inv, bucket_water) > 0) {
+    inv_add(inv, pot_of_flour, 1);
+    ~objbox(pot_of_flour, "The Cooking Guide gives you a |@blu@Pot of Flour.");
+} else if (inv_total(inv, bucket_water) < 1 & inv_total(inv, pot_of_flour) > 0) {
+    inv_add(inv, bucket_water, 1);
+    ~objbox(bucket_water, "The Cooking Guide gives you a|@blu@Bucket of Water.");
 }
 
 [label,master_chef_recap]

--- a/data/src/scripts/tutorial/scripts/guides/master_chef.rs2
+++ b/data/src/scripts/tutorial/scripts/guides/master_chef.rs2
@@ -21,10 +21,11 @@ switch_int(%tutorial_progress) {
 ~master_chef_give_ingredients;
 
 [proc,master_chef_give_ingredients]
-if (inv_freespace(inv) = 0 & %tutorial_progress < ^chef_baked_bread) {
-    ~mesbox("You need some ingredients for this section of the tutorial but you don't have enough inventory room. You'll need to drop something. To do so, right-click on an item you don't want and select drop. Once you've done that speak to the Cooking Guide again.");
-    return;
-}
+// Probably added in a later OSRS update
+//if (inv_freespace(inv) = 0 & %tutorial_progress < ^chef_baked_bread) {
+//    ~mesbox("You need some ingredients for this section of the tutorial but you don't have enough inventory room. You'll need to drop something. To do so, right-click on an item you don't want and select drop. Once you've done that speak to the Cooking Guide again.");
+//    return;
+//}
 
 if (inv_total(inv, pot_of_flour) < 1 & inv_total(inv, bucket_water) > 0 & inv_freespace(inv) > 0) {
     inv_add(inv, pot_of_flour, 1);

--- a/data/src/scripts/tutorial/scripts/guides/mining_instructor.rs2
+++ b/data/src/scripts/tutorial/scripts/guides/mining_instructor.rs2
@@ -111,7 +111,7 @@ switch_int(%tutorial_progress) {
 ~chatnpc(neutral, "Ok then, <displayname>.");
 
 [proc,mining_instructor_replace_items]
-if (%tutorial_progress > ^mining_instructor_prospected_copper_second & inv_total(inv, bronze_pickaxe) < 1 & inv_freespace(inv) > 0) {
+if (%tutorial_progress > ^mining_instructor_prospected_copper_second & ~tutorial_has_obj_on_person(bronze_pickaxe) = false & inv_freespace(inv) > 0) {
     inv_add(inv, bronze_pickaxe, 1);
     ~objboxt(bronze_pickaxe, "Dezzick gives you a |@blu@Bronze pickaxe!");
 }

--- a/data/src/scripts/tutorial/scripts/guides/mining_instructor.rs2
+++ b/data/src/scripts/tutorial/scripts/guides/mining_instructor.rs2
@@ -111,12 +111,12 @@ switch_int(%tutorial_progress) {
 ~chatnpc(neutral, "Ok then, <displayname>.");
 
 [proc,mining_instructor_replace_items]
-if (%tutorial_progress > ^mining_instructor_prospected_copper_second & ~tutorial_has_obj_on_person(bronze_pickaxe) = false & inv_freespace(inv) > 0) {
+if (%tutorial_progress > ^mining_instructor_prospected_copper_second & ~tutorial_has_obj_on_person(bronze_pickaxe) = false) {
     inv_add(inv, bronze_pickaxe, 1);
     ~objboxt(bronze_pickaxe, "Dezzick gives you a |@blu@Bronze pickaxe!");
 }
 
-if (%tutorial_progress > ^mining_instructor_before_smelt_bronze_bar & inv_total(inv, hammer) < 1 & inv_freespace(inv) > 0) {
+if (%tutorial_progress > ^mining_instructor_before_smelt_bronze_bar & inv_total(inv, hammer) < 1) {
     inv_add(inv, hammer, 1);
     ~objboxt(hammer, "Dezzick gives you a |@blu@Hammer!");
 }

--- a/data/src/scripts/tutorial/scripts/guides/quest_guide.rs2
+++ b/data/src/scripts/tutorial/scripts/guides/quest_guide.rs2
@@ -21,7 +21,7 @@ switch_int(%tutorial_progress) {
 ~chatnpc(neutral, "When you start a quest it will change colour to yellow,|and green when you've finished. This is so you can|easily see what's complete, what's started, and what's left|to begin.");
 ~chatnpc(neutral, "The start of quests are easy to find. Look out for the|star icons on the minimap, like the one you should see|marking my house.");
 ~chatnpc(neutral, "The quests themselves can vary greatly from collecting|beads to hunting down dragons. Generally quests are|started by talking to a non player character and will|involve a series of tasks.");
-~chatnpc(neutral, "There's not a lot more I can tell you about questing.|You have to experience the thrill of it yourself to fully|understand; You may find some adventure in the caves|under my house.");
+~chatnpc(neutral, "There's not a lot more I can tell you about questing.|You have to experience the thrill of it yourself to fully|understand. You may find some adventure in the caves|under my house.");
 
 [label,quest_guide_menu_not_opened]
 ~chatnpc(quiz, "Have you not opened that menu yet?");

--- a/data/src/scripts/tutorial/scripts/guides/survival_guide.rs2
+++ b/data/src/scripts/tutorial/scripts/guides/survival_guide.rs2
@@ -29,13 +29,13 @@ switch_int(%tutorial_progress) {
 // https://web.archive.org/web/20051215201825im_/http://runevillage.com/images/rsTutorial10.gif
 // Looks like the exclamation points don't switch back to black.
 [proc,survival_guide_replace_items]
-if (inv_total(inv, bronze_axe) < 1 & inv_total(inv, tinderbox) < 1 & inv_freespace(inv) > 1) {
+if (~tutorial_has_obj_on_person(bronze_axe) = false & inv_total(inv, tinderbox) < 1 & inv_freespace(inv) > 1) {
     inv_add(inv, bronze_axe, 1);
     inv_add(inv, tinderbox, 1);
     ~doubleobjbox(tinderbox, bronze_axe, "The Survival Guide gives you a |@blu@Tinderbox@bla@ |and a |@blu@Bronze Hatchet!");
 }
 
-if (inv_total(inv, bronze_axe) < 1 & inv_freespace(inv) > 0) {
+if (~tutorial_has_obj_on_person(bronze_axe) = false & inv_freespace(inv) > 0) {
     inv_add(inv, bronze_axe, 1);
     ~objboxt(bronze_axe, "The Survival Guide gives you a |@blu@Bronze Hatchet!");
 }
@@ -52,7 +52,7 @@ if (%tutorial_progress > ^survival_guide_open_skill_menu & inv_total(inv, net) <
 
 // Used later for OSRS so we'll leave it.
 [proc,survival_guide_replace_items_no_objboxes]
-if (inv_total(inv, bronze_axe) < 1 & inv_freespace(inv) > 0) {
+if (~tutorial_has_obj_on_person(bronze_axe) = false & inv_freespace(inv) > 0) {
     inv_add(inv, bronze_axe, 1);
 }
 

--- a/data/src/scripts/tutorial/scripts/guides/survival_guide.rs2
+++ b/data/src/scripts/tutorial/scripts/guides/survival_guide.rs2
@@ -29,23 +29,19 @@ switch_int(%tutorial_progress) {
 // https://web.archive.org/web/20051215201825im_/http://runevillage.com/images/rsTutorial10.gif
 // Looks like the exclamation points don't switch back to black.
 [proc,survival_guide_replace_items]
-if (~tutorial_has_obj_on_person(bronze_axe) = false & inv_total(inv, tinderbox) < 1 & inv_freespace(inv) > 1) {
+if (~tutorial_has_obj_on_person(bronze_axe) = false & inv_total(inv, tinderbox) < 1) {
     inv_add(inv, bronze_axe, 1);
     inv_add(inv, tinderbox, 1);
     ~doubleobjbox(tinderbox, bronze_axe, "The Survival Guide gives you a |@blu@Tinderbox@bla@ |and a |@blu@Bronze Hatchet!");
-}
-
-if (~tutorial_has_obj_on_person(bronze_axe) = false & inv_freespace(inv) > 0) {
+} else if (~tutorial_has_obj_on_person(bronze_axe) = false) {
     inv_add(inv, bronze_axe, 1);
     ~objboxt(bronze_axe, "The Survival Guide gives you a |@blu@Bronze Hatchet!");
-}
-
-if (inv_total(inv, tinderbox) < 1 & inv_freespace(inv) > 0) {
+}else if (inv_total(inv, tinderbox) < 1) {
     inv_add(inv, tinderbox, 1);
     ~objboxt(tinderbox, "The Survival Guide gives you a |@blu@Tinderbox!");
 }
 
-if (%tutorial_progress > ^survival_guide_open_skill_menu & inv_total(inv, net) < 1 & inv_freespace(inv) > 0) {
+if (%tutorial_progress > ^survival_guide_open_skill_menu & inv_total(inv, net) < 1) {
     inv_add(inv, net, 1);
     ~objbox(net, "The Survival Guide gives you a |@blu@Net!");
 }

--- a/data/src/scripts/tutorial/scripts/npcs/tut_giant_rat.rs2
+++ b/data/src/scripts/tutorial/scripts/npcs/tut_giant_rat.rs2
@@ -80,7 +80,7 @@ if (%tutorial_progress > ^combat_instructor_before_attacking_ranged
 
 // 2013 Vid shows that maybe the check is > tut_step && less than tut complete
 // https://youtu.be/7zsi7hiF4SQ?t=536
-if (%tutorial_progress > ^combat_instructor_after_attacking_ranged
+if (%tutorial_progress > ^combat_instructor_before_attacking_ranged
     & %tutorial_progress < ^tutorial_complete) {
     ~mesbox("You've already done that.|Perhaps you should move on.");
     return;

--- a/data/src/scripts/tutorial/scripts/skills/tut_smelting.rs2
+++ b/data/src/scripts/tutorial/scripts/skills/tut_smelting.rs2
@@ -35,4 +35,4 @@ inv_del(inv, tin_ore, 1);
 ~tutorial_give_xp(smithing, 62);
 inv_add(inv, bronze_bar, 1);
 ~set_tutorial_progress;
-mes("You retrive a bar of bronze.");
+mes("You retreive a bar of bronze.");

--- a/data/src/scripts/tutorial/scripts/skills/tut_smelting.rs2
+++ b/data/src/scripts/tutorial/scripts/skills/tut_smelting.rs2
@@ -11,6 +11,17 @@ if (last_useitem = copper_ore | last_useitem = tin_ore) {
 }
 
 [label,tut_smelting]
+
+if (inv_total(inv, tin_ore) < 1) {
+    ~mesbox("You also need some tin ore to make a bronze bar.");
+    return;
+}
+
+if (inv_total(inv, copper_ore) < 1) {
+    ~mesbox("You also need some copper ore to make a bronze bar.");
+    return;
+}
+
 p_arrivedelay();
 anim(human_furnace, 0);
 sound_synth(furnace, 0, 0);

--- a/data/src/scripts/tutorial/scripts/skills/tut_smithing.rs2
+++ b/data/src/scripts/tutorial/scripts/skills/tut_smithing.rs2
@@ -10,7 +10,7 @@ inv_add(inv, bronze_dagger, 1);
 // add smithing xp
 ~tutorial_give_xp(smithing, 62);
 // display message
-mes("You hammer the bronze and make dagger.");
+mes("You hammer the bronze and make a dagger.");
 // end smithing if count is less than 1
 $count = calc($count - 1);
 if ($count < 1) {

--- a/data/src/scripts/tutorial/scripts/tut_chatbox_steps.rs2
+++ b/data/src/scripts/tutorial/scripts/tut_chatbox_steps.rs2
@@ -97,6 +97,7 @@ hint_coord(^hint_east, 0_48_48_0_18, 150);
 ~tutorialstep("The Music Player.", "From this interface you can control the music that is played.|As you explore the world more of the tunes will become unlocked.|Once you've examined this menu use the next door|to continue.");
 
 [proc,tutorial_step_click_run_icon]
+~update_weight; // update weight
 if_settabflash(^tab_player_controls);
 if_settab(controls, ^tab_player_controls);
 
@@ -217,6 +218,7 @@ hint_stop();
 [proc,tutorial_step_wielding_weapons]
 hint_stop();
 ~tutorialstep("", "Wielding weapons.|You now have access to a new interface. Click on the flashing icon of a man, the one to the right of your backpack icon.");
+~update_bonuses; // update bonuses if
 inv_transmit(worn, wornitems:wear);
 if_settab(wornitems, ^tab_wornitems);
 if_settabflash(^tab_wornitems);

--- a/data/src/scripts/tutorial/scripts/tut_chatbox_steps.rs2
+++ b/data/src/scripts/tutorial/scripts/tut_chatbox_steps.rs2
@@ -75,7 +75,7 @@ hint_coord(^hint_east, 0_48_48_6_12, 150);
 
 [proc,tutorial_step_make_dough]
 hint_stop();
-~tutorialstep("Making dough.", "This is the base for many of the meals. To make dough we must|mix flour and water. So first right click the bucket of water and|select use  then left click on the pot of flour.");
+~tutorialstep("Making dough.", "This is the base for many of the meals. To make dough we must|mix flour and water. So first right click the bucket of water and|select use then left click on the pot of flour.");
 
 [proc,tutorial_step_cooking_dough]
 hint_coord(2, 0_48_48_3_9, 100);
@@ -97,9 +97,9 @@ hint_coord(^hint_east, 0_48_48_0_18, 150);
 ~tutorialstep("The Music Player.", "From this interface you can control the music that is played.|As you explore the world more of the tunes will become unlocked.|Once you've examined this menu use the next door|to continue.");
 
 [proc,tutorial_step_click_run_icon]
-~update_weight; // update weight
 if_settabflash(^tab_player_controls);
 if_settab(controls, ^tab_player_controls);
+~update_weight; // update weight
 
 ~tutorialstep("It's only a short distance to the next guide.", "|Why not try running there. Start by opening the player|controls, that's the flashing icon of a running man.");
 
@@ -184,16 +184,16 @@ if (%tutorial_progress = ^mining_instructor_mining_start) {
 }
 
 if (%tutorial_progress = ^mining_instructor_minted_copper_first) {
-    ~tutorialstep("Mining.", "Now you have some copper ore you just need some tin ore, then you'll have all you need to create a bronze bar. As you did before right click on the tin rock and select 'mine'.");
+    ~tutorialstep("Mining.", "Now you have some copper ore you just need some tin ore, then you'll have all you need to create a bronze bar. As you did|before right click on the tin rock and select 'mine'.");
 }
 
 if (%tutorial_progress = ^mining_instructor_mined_tin_first) {
-    ~tutorialstep("Mining.", "Now you have some tin ore you just need some copper ore, then you'll have all you need to create a bronze bar. As you did before right click on the copper rock and select 'mine'.");
+    ~tutorialstep("Mining.", "Now you have some tin ore you just need some copper ore, then you'll have all you need to create a bronze bar. As you did|before right click on the copper rock and select 'mine'.");
 }
 
 [proc,tutorial_step_smelting]
 hint_coord(^hint_center, 0_48_148_7_24, 150);
-~tutorialstep("Smelting.", "You should now have some copper and tin ore. So let's smelt|them to make a bronze bar. To do this right click on either tin or|copper ore and select use then left click on the furnace. Try it now.");
+~tutorialstep("Smelting.", "You should now have both copper and tin ore. So let's smelt|them to make a bronze bar. To do this right click on either tin or|copper ore and select use then left click on the furnace. Try it now.");
 
 [proc,tutorial_step_bronze_bar]
 hint_stop();

--- a/data/src/scripts/tutorial/scripts/tut_chatbox_steps.rs2
+++ b/data/src/scripts/tutorial/scripts/tut_chatbox_steps.rs2
@@ -32,7 +32,7 @@ hint_coord(^hint_west, 0_48_48_28_23, 175);
 ~tutorialstep("Cut down a tree", "You can click on the backpack icon at any time to view|the items you currently have in your inventory. You will see that you now have an axe in your inventory. Use this to get some logs by clicking on the indicated tree.");
 
 [proc,tutorial_please_wait_woodcutting]
-~tutorialstep("Please wait...", "|Your character is now attempting to cut down the tree. Sit back|for a moment whilst he does all the hard work.");
+~tutorialstep("Please wait...", "|Your character is now attempting to cut down the tree. Sit back|for a moment whilst <text_gender("he", "she")> does all the hard work.");
 
 [proc,tutorial_step_build_fire]
 ~tutorialstep("Building a fire", "Well done - you managed to cut some logs from the tree! Next, use the tinderbox in your inventory to light the logs.|a) First click on the tinderbox to use it.|b) Then click on the logs in your inventory to light them.");

--- a/data/src/scripts/tutorial/scripts/tut_chatbox_steps.rs2
+++ b/data/src/scripts/tutorial/scripts/tut_chatbox_steps.rs2
@@ -131,7 +131,7 @@ if_settab(questlist, ^tab_quest_journal);
 ~tutorialstep("", "Your Quest journal.|This is your quest journal, a list of all the quests in the game.|Talk to the instructor again for an explanation.");
 
 [proc,tutorial_step_enter_mine]
-hint_coord(^hint_center, 0_48_48_16_47, 100);
+hint_coord(^hint_center, 0_48_48_16_47, 0);
 ~tutorialstep("", "Moving on.|It's time to enter some caves. Click on the ladder to go down to|the next area.");
 
 [proc,tutorial_step_talk_to_mining_instructor]
@@ -269,7 +269,7 @@ hint_coord(^hint_center, 0_48_48_50_52, 125);
 
 [proc,tutorial_step_this_is_your_bank_box]
 hint_coord(^hint_east, 0_48_48_52_52, 150);
-~tutorialstep("This is your bank box.", "You can store stuff here for safe keeping. If you die, anything in your bank will be saved. To deposit something right click it and select store. Once you've had a good look close the window and move on through the door indicated.");
+~tutorialstep("This is your bank box.", "You can store stuff here for safe keeping. If you die,|anything in your bank will be saved. To deposit something right|click it and select store. Once you've had a good look close the|window and move on through the door indicated.");
 
 [proc,tutorial_step_financial_advisor]
 ~set_hint_icon_financial_advisor;

--- a/data/src/scripts/tutorial/scripts/tut_chatbox_steps.rs2
+++ b/data/src/scripts/tutorial/scripts/tut_chatbox_steps.rs2
@@ -261,7 +261,7 @@ hint_stop();
 
 [proc,tutorial_step_combat_moving_on]
 hint_coord(^hint_center, 0_48_148_39_54, 125);
-~tutorialstep("Moving on.", "You have completed the tasks here, to move on click on the ladder shown. If you need to go over any of what you learned here just to Vannaka and he'll tell you what he can.");
+~tutorialstep("Moving on.", "You have completed the tasks here, to move on click on the|ladder shown. If you need to go over any of what you learned|here just talk to Vannaka and he'll tell you what he can.");
 
 [proc,tutorial_step_banking]
 hint_coord(^hint_center, 0_48_48_50_52, 125);

--- a/data/src/scripts/tutorial/scripts/tut_doors_and_gates.rs2
+++ b/data/src/scripts/tutorial/scripts/tut_doors_and_gates.rs2
@@ -1,12 +1,4 @@
 [proc,tut_island_survial_gate]
-if (%tutorial_progress < ^survival_guide_complete) {
-    ~mesbox("You need to talk to the Survival Guide and complete her tasks before you are allowed to proceed through this gate.");
-    return;
-}
-if (%tutorial_progress = ^survival_guide_complete) {
-    %tutorial_progress = ^tutorial_opened_gate_to_chef;
-    ~set_tutorial_progress;
-}
 loc_findallzone(coord);
 while(loc_findnext = true) {
     if(loc_category = tutorial_gate) {
@@ -25,6 +17,14 @@ p_delay(0);
 
 // Survival Tutor Gate
 [oploc1,_tutorial_gate]
+if (%tutorial_progress < ^survival_guide_complete) {
+    ~mesbox("You need to talk to the Survival Guide and complete her tasks before you are allowed to proceed through this gate.");
+    return;
+}
+if (%tutorial_progress = ^survival_guide_complete) {
+    %tutorial_progress = ^tutorial_opened_gate_to_chef;
+    ~set_tutorial_progress;
+}
 if(coordx(coord) <= coordx(loc_coord)) {
     p_teleport(movecoord(loc_coord, 1, 0, 0));
     ~tut_island_survial_gate;

--- a/data/src/scripts/tutorial/scripts/tutorial.rs2
+++ b/data/src/scripts/tutorial/scripts/tutorial.rs2
@@ -312,7 +312,7 @@ inv_add(inv, wooden_shield, 1);
 inv_add(inv, shortbow, 1);
 inv_add(inv, bronze_arrow, 25);
 inv_add(inv, airrune, 25);
-inv_add(inv, mindrune, 16);
+inv_add(inv, mindrune, 15);
 inv_add(inv, waterrune, 6);
 inv_add(inv, earthrune, 4);
 inv_add(inv, bodyrune, 2);

--- a/data/src/scripts/tutorial/scripts/tutorial.rs2
+++ b/data/src/scripts/tutorial/scripts/tutorial.rs2
@@ -81,6 +81,7 @@ if (%tutorial_progress > ^chef_baked_bread) {
 }
 
 if (%tutorial_progress > ^chef_opened_music_tab) {
+    ~update_weight; // update weight
     if_settab(controls, ^tab_player_controls);
 }
 
@@ -89,7 +90,9 @@ if (%tutorial_progress > ^quest_guide_open_menu) {
     if_settab(questlist, ^tab_quest_journal);
 }
 
+
 if (%tutorial_progress > ^combat_instructor_wielding_weapons) {
+    ~update_bonuses; // update bonuses if
     inv_transmit(worn, wornitems:wear);
     if_settab(wornitems, ^tab_wornitems);
 }

--- a/data/src/scripts/tutorial/scripts/tutorial.rs2
+++ b/data/src/scripts/tutorial/scripts/tutorial.rs2
@@ -270,7 +270,9 @@ if (%tutorial_progress < ^combat_instructor_worn_inventory) {
     return;
 }
 
-if (%tutorial_progress = ^combat_instructor_worn_inventory) {
+def_obj $weapon = inv_getobj(inv, $slot);
+
+if (%tutorial_progress = ^combat_instructor_worn_inventory & $weapon = bronze_dagger) {
     %tutorial_progress = ^combat_instructor_dagger_equipped;
     ~set_tutorial_progress;
 }

--- a/data/src/scripts/tutorial/scripts/tutorial.rs2
+++ b/data/src/scripts/tutorial/scripts/tutorial.rs2
@@ -172,7 +172,6 @@ if (%tutorial_progress = 2) {
 }
 ~set_tutorial_progress;
 
-
 [proc,set_tutorial_progress]
 switch_int(%tutorial_progress) {
     // Runescape Guide's House
@@ -276,6 +275,12 @@ if (%tutorial_progress = ^combat_instructor_worn_inventory) {
 @levelrequire_attack(1, $slot);
 if_settab(null, ^tab_combat_options);
 
+[proc,tutorial_has_obj_on_person](namedobj $obj)(boolean)
+if (inv_total(inv, $obj) > 0 | inv_total(worn, $obj) > 0) {
+    return (true);
+} else {
+    return (false);
+}
 
 [proc,tutorial_give_xp](stat $skill, int $xp)
 if (stat_base($skill) >= 3) {


### PR DESCRIPTION
Thanks to everyone who chipped in testing and finding all of these issues and never ending typos. I'm sure there will be more time come.

Fixes:
- Removal of inventory full messages. Items now drop to the ground
- Loads of typos for NPC and tutorial step dialogues
- Smelting now requires both copper and tin ores
- Updated bonuses and weight when player controls and equipment screens are shown
- Rats can no longer be ranged after you've completed that step
- Corrected mind rune total when completing the tutorial
- Fixed incorrect timing of display for attack styles tab