### PR TITLE
fix: change bolt rangebonus and pearl bolt's required level

### DIFF
--- a/data/src/scripts/skill_combat/configs/ranged/bolts.obj
+++ b/data/src/scripts/skill_combat/configs/ranged/bolts.obj
@@ -63,7 +63,8 @@ iop2=Wield
 wearpos=quiver
 weight=18g
 category=bolts
-param=rangebonus,14
+param=rangebonus,22
+//UNKNOWN, setting to same rangebonus as mithril arrow as according to guesses in https://web.archive.org/web/20041204070450/https://www.lunagang.nl/ , used to be 14 as according to osrs. TODO CONFIRM
 param=levelrequire,1
 param=proj_launch,crossbowbolt_launch
 param=proj_travel,crossbowbolt_travel
@@ -89,8 +90,10 @@ iop2=Wield
 wearpos=quiver
 weight=18g
 category=bolts
-param=rangebonus,48
-param=levelrequire,26
+param=rangebonus,16
+//UNKNOWN, set to same rangebonus as steel arrowas according to guesses in https://web.archive.org/web/20041204070450/https://www.lunagang.nl/ , used to be 48 as according to osrs . TODO CONFIRM
+param=levelrequire,1
+//Level requirements are guessed to be nonexistent. osrs/post-crossbow-update puts them at 26
 param=proj_launch,crossbowbolt_launch
 param=proj_travel,crossbowbolt_travel
 tradeable=yes
@@ -111,7 +114,8 @@ iop2=Wield
 wearpos=quiver
 weight=18g
 category=bolts
-param=rangebonus,12
+param=rangebonus,40
+//UNKNOWN, setting to rangebonus between adamant and rune arrows (31+49/2=40) as according to guesses in https://web.archive.org/web/20041204070450/https://www.lunagang.nl/ , used to be 12 as according to osrs. TODO CONFIRM
 param=levelrequire,1
 param=proj_launch,crossbowbolt_launch
 param=proj_travel,crossbowbolt_travel

--- a/data/src/scripts/skill_combat/scripts/player/player_ranged.rs2
+++ b/data/src/scripts/skill_combat/scripts/player/player_ranged.rs2
@@ -96,10 +96,11 @@ if ($weapon_cat = weapon_crossbow & $ammo_cat ! bolts) {
     mes("You can't use that ammo with your crossbow."); // TODO confirm this for 2004.
     return(null);
 }
-if (oc_param($ammo, levelrequire) > oc_param($rhand, levelrequire)) {
+if (oc_param($ammo, levelrequire) > oc_param($rhand, levelrequire)) { //TODO confirm crossbows could use all bolts at lvl 1
     mes("Your bow isn't powerful enough for those arrows."); // TODO confirm this for 2004.
     return(null);
 }
+
 return($ammo);
 
 [proc,player_ranged_use_weapon](obj $rhand, obj $ammo)(int)


### PR DESCRIPTION
this is a controversial one because there's no concrete data on any of this. Guesses were made based off of lunagang.nl's guesses.
pearl bolts are now usable, too, since the crossbow is no longer "too low level" for them.