### PR TITLE
fix: WordEnc to properly emulate the Java client

### DIFF
--- a/src/lostcity/cache/WordEncBadWords.ts
+++ b/src/lostcity/cache/WordEncBadWords.ts
@@ -360,7 +360,7 @@ export default class WordEncBadWords {
         let end = combos.length - 1;
 
         while (start <= end) {
-            const mid = Math.floor((start + end) / 2); // client does not floor here
+            const mid = ((start + end) / 2) | 0;
             if (combos[mid][0] === currentIndex && combos[mid][1] === nextIndex) {
                 return true;
             } else if (currentIndex < combos[mid][0] || (currentIndex === combos[mid][0] && nextIndex < combos[mid][1])) {

--- a/src/lostcity/cache/WordEncBadWords.ts
+++ b/src/lostcity/cache/WordEncBadWords.ts
@@ -164,7 +164,7 @@ export default class WordEncBadWords {
                     }
                     index++;
                     count++;
-                    if ((count * 100) / (index - startIndex) > 90) {
+                    if (((count * 100) / (index - startIndex) | 0) > 90) {
                         break;
                     }
                 }

--- a/src/lostcity/cache/WordEncFragments.ts
+++ b/src/lostcity/cache/WordEncFragments.ts
@@ -64,7 +64,7 @@ export default class WordEncFragments {
         let end = fragmentsLength - 1;
 
         while (start <= end) {
-            const mid = Math.floor((start + end) / 2); // client does not floor here
+            const mid = ((start + end) / 2) | 0;
             if (value === fragments[mid]) {
                 return true;
             } else if (value < fragments[mid]) {


### PR DESCRIPTION
I don't think it has any actual side effects but just in case this is technically the correct way.