### PR TITLE
fix: ~bank_withdraw_request fix

### DIFF
--- a/data/src/scripts/interface_bank/scripts/bank.rs2
+++ b/data/src/scripts/interface_bank/scripts/bank.rs2
@@ -41,18 +41,21 @@ if (%bank_noted ! 0) {
     $cert_or_uncert = oc_cert($obj);
 }
 
-def_int $overflow = inv_itemspace2($inv, $cert_or_uncert, $amount, inv_size($inv));
-if ($overflow >= $amount) {
-    if (oc_cert($obj) = $obj) {
+if (inv_itemspace($inv, $obj, $amount, inv_size($inv)) = false){
+    if (oc_stackable($obj) = true) {
         // https://youtu.be/8vNeG5bHg0Q?t=443
         mes("You're not going to be able to carry all that!");
+    } else if (inv_freespace(inv) = 0) {
+        // https://youtu.be/Zv7Wh3TIDOc?t=22
+        mes("You don't have enough inventory space.");
+        return;
     } else {
         // https://youtu.be/HnEZFSGbYqM?t=79
         mes("You don't have enough inventory space to withdraw that many.");
     }
-    return;
 }
 
+def_int $overflow = inv_itemspace2($inv, $cert_or_uncert, $amount, inv_size($inv));
 switch_int (%bank_noted) {
     case 0 : inv_moveitem_uncert(bank, $inv, $obj, sub($amount, $overflow));
     case default :

--- a/data/src/scripts/interface_bank/scripts/bank.rs2
+++ b/data/src/scripts/interface_bank/scripts/bank.rs2
@@ -45,7 +45,7 @@ if (inv_itemspace($inv, $obj, $amount, inv_size($inv)) = false){
     if (oc_stackable($obj) = true) {
         // https://youtu.be/8vNeG5bHg0Q?t=443
         mes("You're not going to be able to carry all that!");
-    } else if (inv_freespace(inv) = 0) {
+    } else if (inv_freespace($inv) = 0) {
         // https://youtu.be/Zv7Wh3TIDOc?t=22
         mes("You don't have enough inventory space.");
         return;

--- a/data/src/scripts/interface_bank/scripts/bank.rs2
+++ b/data/src/scripts/interface_bank/scripts/bank.rs2
@@ -41,6 +41,10 @@ if (%bank_noted ! 0) {
     $cert_or_uncert = oc_cert($obj);
 }
 
+if (%bank_noted = ^true & oc_cert($obj) = $obj) {
+    mes("This item can not be withdrawn as a note."); // 2005
+}
+
 if (inv_itemspace($inv, $obj, $amount, inv_size($inv)) = false){
     if (oc_stackable($obj) = true) {
         // https://youtu.be/8vNeG5bHg0Q?t=443
@@ -56,13 +60,11 @@ if (inv_itemspace($inv, $obj, $amount, inv_size($inv)) = false){
 }
 
 def_int $overflow = inv_itemspace2($inv, $cert_or_uncert, $amount, inv_size($inv));
-switch_int (%bank_noted) {
-    case 0 : inv_moveitem_uncert(bank, $inv, $obj, sub($amount, $overflow));
-    case default :
-        if (oc_cert($obj) = $obj) {
-            mes("This item can not be withdrawn as a note."); // 2005
-        }
-        inv_moveitem_cert(bank, $inv, $obj, sub($amount, $overflow));
+if (sub($amount, $overflow) > 0) {
+    switch_int (%bank_noted) {
+        case 0 : inv_moveitem_uncert(bank, $inv, $obj, sub($amount, $overflow));
+        case default : inv_moveitem_cert(bank, $inv, $obj, sub($amount, $overflow));
+    }
 }
 
 [proc,bank_deposit_request](inv $inv, obj $obj, int $amount, int $slot)


### PR DESCRIPTION
- check for oc_stackable instead of oc_cert
- new message if inv_freespace(inv) = 0 (same as osrs)
![image](https://github.com/2004scape/Server/assets/61213166/abe6cea3-2149-47b5-8a69-b9311e8c0e90)

- inv_itemspace instead of inv_itemspace2
- move "This item can not be withdrawn as a note." message
![image](https://github.com/2004scape/Server/assets/61213166/662833d9-baa3-4195-8b88-7a334c40d952)
