### PR TITLE
fix: levelup reward message for smithing level 48 steel platebodies

### DIFF
--- a/data/src/scripts/levelup/scripts/levelup_unlocks_smithing.rs2
+++ b/data/src/scripts/levelup/scripts/levelup_unlocks_smithing.rs2
@@ -42,7 +42,7 @@ switch_int(stat_base(smithing)) {
     case 42: ~objboxt(steel_kiteshield,"You can now make @dbl@Steel Kite Shields@bla@.");
     case 44: ~objboxt(steel_2h_sword,"You can now make @dbl@Steel Two Handed Swords@bla@.");
     case 46: ~doubleobjbox(steel_platelegs,steel_plateskirt,"You can now make @dbl@Steel Plate Legs@bla@ and @dbl@Steel plate skirts@bla@.");
-    case 48: ~objboxt(steel_platebody,"You can now make @dbl@Steel Plate Bodies@bla@ and @dbl@Steel|@dbl@Medium Helms@bla@.");
+    case 48: ~objboxt(steel_platebody,"You can now make @dbl@Steel Plate Bodies@bla@.");
     case 50: ~objboxt(mithril_dagger,"You can now make @dbl@Mithril Daggesr@bla@.");
     case 51: ~objboxt(mithril_axe,"You can now make @dbl@Mithril Axes@bla@.");
     case 52: ~objbox(mithril_mace,"You can now make @dbl@Mithril Maces@bla@.");


### PR DESCRIPTION
- Steel Med Helms are defined for Smithing level 33 reward.