### PR TITLE
fix: dragon headbutt, elvarg ap, and ap retal fix

### DIFF
--- a/data/src/scripts/_test/scripts/cheats/cheat_tele.rs2
+++ b/data/src/scripts/_test/scripts/cheats/cheat_tele.rs2
@@ -67,3 +67,11 @@ if (p_finduid(uid) = true) {
 } else {
     @please_finish;
 }
+
+[debugproc,kbd]
+if_close;
+if (p_finduid(uid) = true) {
+    p_teleport(0_47_160_60_16);
+} else {
+    @please_finish;
+}

--- a/data/src/scripts/_test/scripts/cheats/cheat_tele.rs2
+++ b/data/src/scripts/_test/scripts/cheats/cheat_tele.rs2
@@ -75,3 +75,11 @@ if (p_finduid(uid) = true) {
 } else {
     @please_finish;
 }
+
+[debugproc,elvarg]
+if_close;
+if (p_finduid(uid) = true) {
+    p_teleport(0_44_150_30_36);
+} else {
+    @please_finish;
+}

--- a/data/src/scripts/areas/area_wilderness/scripts/king_black_dragon.rs2
+++ b/data/src/scripts/areas/area_wilderness/scripts/king_black_dragon.rs2
@@ -122,7 +122,7 @@ if ($random_attack = 0) {
 } else if ($random_attack = 1) {
     ~kbd_special_breath;
 } else {
-    ~npc_default_attack;
+    ~dragon_melee;
 }
 // ------------
 // far range fire breath

--- a/data/src/scripts/npc/scripts/dragon.rs2
+++ b/data/src/scripts/npc/scripts/dragon.rs2
@@ -57,9 +57,28 @@ if (~npc_can_attack_player = false) {
 if (random(4) = 0) {
     ~dragon_fire;
 } else {
-    ~npc_default_attack;
+    ~dragon_melee;
 }
 
+[proc,dragon_melee]
+if (stat(hitpoints) = 0) {
+    return;
+}
+if (%npc_action_delay > map_clock) return;
+if (~npc_can_attack_player = false) {
+    npc_setmode(null);
+    return;
+}
+anim(%com_defendanim, 0);
+if (random(2) = 0) {
+    npc_anim(dragon_attack, 0);
+} else {
+    npc_anim(dragon_head_attack, 0);
+}
+if (npc_param(attack_sound) ! null) {
+    sound_synth(npc_param(attack_sound), 0, 0);
+}
+~npc_meleeattack;
 
 [proc,dragon_fire]
 if_close;

--- a/data/src/scripts/player/scripts/damage.rs2
+++ b/data/src/scripts/player/scripts/damage.rs2
@@ -143,7 +143,7 @@ if (stat(hitpoints) = 0 & getqueue(player_death) < 1){
 def_int $rand;
 def_synth $sound;
 if (gender() = 0) {
-        $rand = random(2);
+        $rand = random(3);
         switch_int($rand) {
             case 0 : $sound = human_hit2;
             case 1 : $sound = human_hit3;
@@ -151,7 +151,7 @@ if (gender() = 0) {
             case default : $sound = human_hit2;
         }
     } else {
-        $rand = random(1);
+        $rand = random(2);
         switch_int($rand) {
             case 0 : $sound = female_hit;
             case 1 : $sound = female_hit2;
@@ -182,7 +182,7 @@ if (.stat(hitpoints) = 0){
 def_int $rand;
 def_synth $sound;
 if (.gender() = 0) {
-        $rand = random(2);
+        $rand = random(3);
         switch_int($rand) {
             case 0 : $sound = human_hit2;
             case 1 : $sound = human_hit3;
@@ -190,7 +190,7 @@ if (.gender() = 0) {
             case default : $sound = human_hit2;
         }
     } else {
-        $rand = random(1);
+        $rand = random(2);
         switch_int($rand) {
             case 0 : $sound = female_hit;
             case 1 : $sound = female_hit2;

--- a/data/src/scripts/quests/quest_dragon/scripts/elvarg.rs2
+++ b/data/src/scripts/quests/quest_dragon/scripts/elvarg.rs2
@@ -8,13 +8,12 @@ if (npc_findhero = false) {
 // Default drop from config.
 obj_add(npc_coord, npc_param(death_drop), 1, ^lootdrop_duration);
 // finish dragon slayer quest
-// this is currently 1t too slow for some reason:
 // https://youtu.be/zmYEl97Smxs?list=PLn23LiLYLb1aqrojPTi1_Np81LJku2Nd0&t=222
 if (%dragon_progress < ^dragon_complete) {
     queue(dragon_complete, 0);
 }
 
-// [ai_queue1,elvarg](int $arg) ~npc_default_retaliate_ap;
+[ai_queue1,elvarg](int $arg) ~npc_default_retaliate_ap;
 
 // https://twitter.com/JagexAsh/status/1756992041777561878
 // "AP -> OP: 1/2, subject to a line-of-walk check.
@@ -32,7 +31,7 @@ if (~npc_can_attack_player = false) {
 if (random(2) = 0 & lineofwalk(npc_coord, coord) = true) {
     npc_setmode(opplayer2);
 }
-~elvarg_dragon_fire;
+~elvarg_dragon_fire_ap;
 
 
 [ai_opplayer2,elvarg]
@@ -45,22 +44,20 @@ if (~npc_can_attack_player = false) {
     return;
 }
 // 1/8 chance to switch back to ap
-// if (random(8) = 0) {
-//     npc_setmode(applayer2);
-// }
+if (random(8) = 0) {
+    npc_setmode(applayer2);
+}
 
 // from 89 hits from 2 2006 videos: https://youtu.be/ucaYfz3ihWs?list=PLn23LiLYLb1aqrojPTi1_Np81LJku2Nd0
 // https://youtu.be/zmYEl97Smxs?list=PLn23LiLYLb1aqrojPTi1_Np81LJku2Nd0&t=104
 // seems like a 75% chance to melee, and 25% chance to dragon fire
-// these videos also show that elvarg likely didnt have an ap attack!
 if (random(4) = 0) {
-    ~elvarg_dragon_fire;
+    ~elvarg_dragon_fire_op;
 } else {
     ~dragon_melee;
-
 }
 
-[proc,elvarg_dragon_fire]
+[proc,elvarg_dragon_fire_op]
 if_close;
 spotanim_npc(spotanim_1, 92, 0);
 npc_anim(dragon_firebreath_middle_attack, 0);
@@ -76,6 +73,28 @@ stat_sub(prayer, 0 , 10); // 10%
 
 queue(damage_player, 0, $damage);
 queue(playerhit_n_retaliate, 0, npc_uid); // this should be a queue* command
+~npc_set_attack_vars;
+
+
+[proc,elvarg_dragon_fire_ap] // https://youtu.be/2TJp-tnFyxc?list=PLn23LiLYLb1aqrojPTi1_Np81LJku2Nd0&t=44
+if_close;
+npc_anim(dragon_firebreath_middle_attack, 0);
+sound_synth(fire_wave_all, 0, 0);
+%npc_action_delay = add(map_clock, 4);
+
+// yes its south west tile, as shorn in https://youtu.be/2TJp-tnFyxc?list=PLn23LiLYLb1aqrojPTi1_Np81LJku2Nd0&t=44
+def_int $duration = ~player_projectile(npc_coord, coord, uid, fire_blast_travel, 92, 31, 51, 16, -5, 64, 10);
+spotanim_pl(fire_blast_hit, 92, $duration);
+
+// damage player
+def_int $maxhit = ~elvarg_max_hit;
+def_int $damage = randominc($maxhit);
+
+// not sure if this was a thing, but this video has it https://youtu.be/ucaYfz3ihWs?list=PLn23LiLYLb1aqrojPTi1_Np81LJku2Nd0&t=130
+stat_sub(prayer, 0 , 10); // 10%
+
+queue(damage_player, calc($duration / 30), $damage);
+queue(playerhit_n_retaliate, calc($duration / 30), npc_uid); // this should be a queue* command
 ~npc_set_attack_vars;
 
 

--- a/data/src/scripts/quests/quest_dragon/scripts/elvarg.rs2
+++ b/data/src/scripts/quests/quest_dragon/scripts/elvarg.rs2
@@ -56,7 +56,7 @@ if (~npc_can_attack_player = false) {
 if (random(4) = 0) {
     ~elvarg_dragon_fire;
 } else {
-    ~npc_default_attack;
+    ~dragon_melee;
 
 }
 

--- a/data/src/scripts/skill_combat/scripts/npc/npc_combat.rs2
+++ b/data/src/scripts/skill_combat/scripts/npc/npc_combat.rs2
@@ -25,8 +25,8 @@ if (~npc_out_of_combat = true) {
     }
     return;
 }
-if (finduid(%npc_attacking_uid) = true) {
-    npc_setmode(opplayer2);
+if (finduid(%npc_attacking_uid) = true & npc_getmode ! applayer2) { 
+    npc_setmode(opplayer2); // only set mode to op if the npc is not currently ap
 }
 
 
@@ -189,6 +189,7 @@ error("style of <tostring($style)> not defined in switch for npc_combat_defenceb
 npc_queue(1, 0, $queue_delay);
 // if in singles and attacking another player, then delay npc action by 8 ticks
 if (~inzone_coord_pair_table(multiway_zones, npc_coord) = false & %npc_attacking_uid ! uid & %npc_attacking_uid ! null) {
+    mes("Somehow here!?");
     %npc_action_delay = add(map_clock, 8);
 }
 %npc_aggressive_player = uid;
@@ -205,6 +206,7 @@ if (~inzone_coord_pair_table(multiway_zones, npc_coord) = true) {
     return(true);
 }
 if (add(%lastcombat, 8) > map_clock & %aggressive_npc ! npc_uid) {
+    mes("Cannot attack player");
     return(false);
 }
 

--- a/data/src/scripts/skill_combat/scripts/npc/npc_combat.rs2
+++ b/data/src/scripts/skill_combat/scripts/npc/npc_combat.rs2
@@ -189,7 +189,6 @@ error("style of <tostring($style)> not defined in switch for npc_combat_defenceb
 npc_queue(1, 0, $queue_delay);
 // if in singles and attacking another player, then delay npc action by 8 ticks
 if (~inzone_coord_pair_table(multiway_zones, npc_coord) = false & %npc_attacking_uid ! uid & %npc_attacking_uid ! null) {
-    mes("Somehow here!?");
     %npc_action_delay = add(map_clock, 8);
 }
 %npc_aggressive_player = uid;
@@ -206,7 +205,6 @@ if (~inzone_coord_pair_table(multiway_zones, npc_coord) = true) {
     return(true);
 }
 if (add(%lastcombat, 8) > map_clock & %aggressive_npc ! npc_uid) {
-    mes("Cannot attack player");
     return(false);
 }
 

--- a/data/src/scripts/skill_combat/scripts/poison.rs2
+++ b/data/src/scripts/skill_combat/scripts/poison.rs2
@@ -32,7 +32,7 @@ def_int $rand;
 // not sure if this damage is supposed to be queued or not
 damage(uid, ^hitmark_poison, $damage);
 if (gender() = 0) {
-    $rand = random(2);
+    $rand = random(3);
     switch_int($rand) {
         case 0 : $sound = human_hit2;
         case 1 : $sound = human_hit3;
@@ -40,7 +40,7 @@ if (gender() = 0) {
         case default : $sound = human_hit2;
     }
 } else {
-    $rand = random(1);
+    $rand = random(2);
     switch_int($rand) {
         case 0 : $sound = female_hit;
         case 1 : $sound = female_hit2;

--- a/data/src/scripts/tutorial/scripts/locs/tut_organ.rs2
+++ b/data/src/scripts/tutorial/scripts/locs/tut_organ.rs2
@@ -1,5 +1,5 @@
 [oploc1,loc_416]
-if(random(1) = 0) {
+if(random(2) = 0) {
     midi_song("organ_music_1");
 } else {
     midi_song("organ_music_2");


### PR DESCRIPTION
- fix: change ~npc_default_retaliate_ap proc so the npc will only setmode to opplayer2 if its not currently ap'ing
- feat: 50% chance for dragons to headbutt you during op
- feat: video of elvarg ap found
- fix: random(1)'s replaced with random(2)'s