### PR TITLE
chore: update rsmod dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "ws": "^8.15.1"
       },
       "devDependencies": {
-        "@2004scape/rsmod-pathfinder": "^4.2.8",
+        "@2004scape/rsmod-pathfinder": "^4.2.9",
         "@swc/core": "1.3.101",
         "@swc/helpers": "^0.5.3",
         "@types/bcrypt": "^5.0.2",
@@ -54,9 +54,9 @@
       }
     },
     "node_modules/@2004scape/rsmod-pathfinder": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/@2004scape/rsmod-pathfinder/-/rsmod-pathfinder-4.2.8.tgz",
-      "integrity": "sha512-Y63cypXpTUr3oCcP5PZWCDZGCDYpR0+JRrIfhXgjdK/T/P0QPXn+iBdd3zhbt+AzZHqOpLzNvp9IWP6OT3C3Pg==",
+      "version": "4.2.9",
+      "resolved": "https://registry.npmjs.org/@2004scape/rsmod-pathfinder/-/rsmod-pathfinder-4.2.9.tgz",
+      "integrity": "sha512-GQ1Cte8lUp066h+rrFkJ0UBKFnkeIQQ8e+WlhROV9hEyeHWOv6VfVx4vi47UMp6pOaWyPaDjYhNcFSHmZkXTuQ==",
       "dev": true
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "ws": "^8.15.1"
   },
   "devDependencies": {
-    "@2004scape/rsmod-pathfinder": "^4.2.8",
+    "@2004scape/rsmod-pathfinder": "^4.2.9",
     "@swc/core": "1.3.101",
     "@swc/helpers": "^0.5.3",
     "@types/bcrypt": "^5.0.2",

--- a/src/lostcity/entity/PathingEntity.ts
+++ b/src/lostcity/entity/PathingEntity.ts
@@ -3,15 +3,12 @@ import World from '#lostcity/engine/World.js';
 import BlockWalk from '#lostcity/entity/BlockWalk.js';
 import Entity from '#lostcity/entity/Entity.js';
 import Loc from '#lostcity/entity/Loc.js';
-import Npc from '#lostcity/entity/Npc.js';
 import MoveRestrict from '#lostcity/entity/MoveRestrict.js';
-import Obj from '#lostcity/entity/Obj.js';
-import Player from '#lostcity/entity/Player.js';
 import { Direction, Position } from '#lostcity/entity/Position.js';
 
 import LocType from '#lostcity/cache/LocType.js';
 
-import {canTravel, CollisionFlag, CollisionType, hasLineOfSight, intersects, isFlagged, reached} from '@2004scape/rsmod-pathfinder';
+import {canTravel, CollisionFlag, CollisionType, hasLineOfSight, isFlagged, reached} from '@2004scape/rsmod-pathfinder';
 
 export default abstract class PathingEntity extends Entity {
     // constructor properties
@@ -290,21 +287,8 @@ export default abstract class PathingEntity extends Entity {
         return this.waypointIndex === 0;
     }
 
-    inOperableDistance(
-        target:
-            | Player
-            | Npc
-            | Loc
-            | Obj
-            | {
-                  x: number;
-                  z: number;
-                  level: number;
-                  width: number;
-                  length: number;
-              }
-    ): boolean {
-        if (!target || target.level !== this.level) {
+    inOperableDistance(target: Entity): boolean {
+        if (target.level !== this.level) {
             return false;
         }
         if (target instanceof PathingEntity) {
@@ -317,30 +301,16 @@ export default abstract class PathingEntity extends Entity {
         return reached(this.level, this.x, this.z, target.x, target.z, target.width, target.length, this.width, 0, shape);
     }
 
-    inApproachDistance(
-        range: number,
-        target:
-            | Player
-            | Npc
-            | Loc
-            | Obj
-            | {
-                  x: number;
-                  z: number;
-                  level: number;
-                  width: number;
-                  length: number;
-              }
-    ): boolean {
-        if (!target || target.level !== this.level) {
+    inApproachDistance(range: number, target: Entity): boolean {
+        if (target.level !== this.level) {
             return false;
         }
-        if (target instanceof PathingEntity && intersects(this.x, this.z, this.width, this.length, target.x, target.z, target.width, target.length)) {
+        if (target instanceof PathingEntity && Position.intersects(this.x, this.z, this.width, this.length, target.x, target.z, target.width, target.length)) {
             // pathing entity has a -2 shape basically (not allow on same tile) for ap.
             // you are not within ap distance of pathing entity if you are underneath it.
             return false;
         }
-        return hasLineOfSight(this.level, this.x, this.z, target.x, target.z, this.width, target.width, target.length, CollisionFlag.PLAYER) && Position.distanceTo(this, target) <= range;
+        return Position.distanceTo(this, target) <= range && hasLineOfSight(this.level, this.x, this.z, target.x, target.z, this.width, target.width, target.length, CollisionFlag.PLAYER);
     }
 
     getCollisionStrategy(): CollisionType | null {

--- a/src/lostcity/entity/Position.ts
+++ b/src/lostcity/entity/Position.ts
@@ -110,5 +110,13 @@ export const Position = {
 
     packCoord(level: number, x: number, z: number): number {
         return (z & 0x3fff) | ((x & 0x3fff) << 14) | ((level & 0x3) << 28);
+    },
+
+    intersects(srcX: number, srcZ: number, srcWidth: number, srcHeight: number, destX: number, destZ: number, destWidth: number, destHeight: number): boolean {
+        const srcHorizontal: number = srcX + srcWidth;
+        const srcVertical: number = srcZ + srcHeight;
+        const destHorizontal: number = destX + destWidth;
+        const destVertical: number = destZ + destHeight;
+        return !(destX >= srcHorizontal || destHorizontal <= srcX || destZ >= srcVertical || destVertical <= srcZ);
     }
 } as const;


### PR DESCRIPTION
- Update rsmod dependency which no longer exposes `intersects` function.
- Simplify `inOperableDistance` and `inApproachDistance`.