### PR TITLE
fix: prevent an additional object of the same id from being deleted when picking it up

### DIFF
--- a/src/lostcity/engine/World.ts
+++ b/src/lostcity/engine/World.ts
@@ -1189,12 +1189,9 @@ class World {
     }
 
     removeObj(obj: Obj, receiver: Player | null) {
-        // TODO
         // stackable objs when they overflow are created into another slot on the floor
-        // currently when you pickup from a tile with multiple stackable objs
-        // you will pickup one of them and the other one disappears
         const zone = this.getZone(obj.x, obj.z, obj.level);
-        zone.removeObj(obj, receiver, -1);
+        zone.removeObj(obj, receiver);
         obj.despawn = this.currentTick;
         obj.respawn = this.currentTick + ObjType.get(obj.type).respawnrate;
         if (zone.staticObjs.includes(obj)) {

--- a/src/lostcity/engine/zone/Zone.ts
+++ b/src/lostcity/engine/zone/Zone.ts
@@ -363,7 +363,7 @@ export default class Zone {
         this.lastEvent = World.currentTick;
     }
 
-    removeObj(obj: Obj, receiver: Player | null, subtractTick: number = 0) {
+    removeObj(obj: Obj, receiver: Player | null) {
         const event = new ZoneEvent(ServerProt.OBJ_DEL.id);
 
         const dynamicIndex = this.objs.indexOf(obj);
@@ -378,7 +378,7 @@ export default class Zone {
         event.buffer = Zone.objDel(obj.x, obj.z, obj.id, obj.count);
         event.x = obj.x;
         event.z = obj.z;
-        event.tick = World.currentTick - subtractTick;
+        event.tick = World.currentTick;
 
         this.updates.push(event);
         this.lastEvent = World.currentTick;


### PR DESCRIPTION
Fixes #165