### PR TITLE
feat: new environment property SKIP_CRC for skipping crc packing checks

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,6 +21,8 @@ GAME_PORT=43594
 # website management
 # ADMIN_IP="127.0.0.1"
 
+# SKIP_CRC=false
+
 ## World settings
 
 WORLD_ID=0

--- a/src/lostcity/tools/packconfig/PackShared.ts
+++ b/src/lostcity/tools/packconfig/PackShared.ts
@@ -33,6 +33,7 @@ import { packHuntConfigs, parseHuntConfig } from '#lostcity/tools/packconfig/Hun
 import { packVarnConfigs, parseVarnConfig } from '#lostcity/tools/packconfig/VarnConfig.js';
 import { packVarsConfigs, parseVarsConfig } from '#lostcity/tools/packconfig/VarsConfig.js';
 import Jagfile from '#jagex2/io/Jagfile.js';
+import Environment from '#lostcity/util/Environment.js';
 
 export function isConfigBoolean(input: string): boolean {
     return input === 'yes' || input === 'no' || input === 'true' || input === 'false' || input === '1' || input === '0';
@@ -491,7 +492,7 @@ export function packConfigs() {
         console.log('Packing .seq');
         //console.time('Packed .seq');
         readConfigs('.seq', [], parseSeqConfig, packSeqConfigs, (dat: Packet, idx: Packet) => {
-            if (!Packet.checkcrc(dat, 1638136604) || !Packet.checkcrc(idx, 969051566)) {
+            if (!Environment.SKIP_CRC && (!Packet.checkcrc(dat, 1638136604) || !Packet.checkcrc(idx, 969051566))) {
                 console.error('.seq CRC check failed! Custom data detected.');
                 process.exit(1);
             }
@@ -512,7 +513,7 @@ export function packConfigs() {
         console.log('Packing .loc');
         //console.time('Packed .loc');
         readConfigs('.loc', [], parseLocConfig, packLocConfigs, (dat: Packet, idx: Packet) => {
-            if (!Packet.checkcrc(dat, 891497087) || !Packet.checkcrc(idx, -941401128)) {
+            if (!Environment.SKIP_CRC && (!Packet.checkcrc(dat, 891497087) || !Packet.checkcrc(idx, -941401128))) {
                 console.error('.loc CRC check failed! Custom data detected.');
                 process.exit(1);
             }
@@ -533,7 +534,7 @@ export function packConfigs() {
         console.log('Packing .flo');
         //console.time('Packed .flo');
         readConfigs('.flo', [], parseFloConfig, packFloConfigs, (dat: Packet, idx: Packet) => {
-            if (!Packet.checkcrc(dat, 1976597026) || !Packet.checkcrc(idx, 561308705)) {
+            if (!Environment.SKIP_CRC && (!Packet.checkcrc(dat, 1976597026) || !Packet.checkcrc(idx, 561308705))) {
                 console.error('.flo CRC check failed! Custom data detected.');
                 process.exit(1);
             }
@@ -554,7 +555,7 @@ export function packConfigs() {
         console.log('Packing .spotanim');
         //console.time('Packed .spotanim');
         readConfigs('.spotanim', [], parseSpotAnimConfig, packSpotAnimConfigs, (dat: Packet, idx: Packet) => {
-            if (!Packet.checkcrc(dat, -1279835623) || !Packet.checkcrc(idx, -1696140322)) {
+            if (!Environment.SKIP_CRC && (!Packet.checkcrc(dat, -1279835623) || !Packet.checkcrc(idx, -1696140322))) {
                 console.error('.spotanim CRC check failed! Custom data detected.');
                 process.exit(1);
             }
@@ -575,7 +576,7 @@ export function packConfigs() {
         console.log('Packing .npc');
         //console.time('Packed .npc');
         readConfigs('.npc', [], parseNpcConfig, packNpcConfigs, (dat: Packet, idx: Packet) => {
-            if (!Packet.checkcrc(dat, -2140681882) || !Packet.checkcrc(idx, -1986014643)) {
+            if (!Environment.SKIP_CRC && (!Packet.checkcrc(dat, -2140681882) || !Packet.checkcrc(idx, -1986014643))) {
                 console.error('.npc CRC check failed! Custom data detected.');
                 process.exit(1);
             }
@@ -596,7 +597,7 @@ export function packConfigs() {
         console.log('Packing .obj');
         //console.time('Packed .obj');
         readConfigs('.obj', [], parseObjConfig, packObjConfigs, (dat: Packet, idx: Packet) => {
-            if (!Packet.checkcrc(dat, -840233510) || !Packet.checkcrc(idx, 669212954)) {
+            if (!Environment.SKIP_CRC && (!Packet.checkcrc(dat, -840233510) || !Packet.checkcrc(idx, 669212954))) {
                 console.error('.obj CRC check failed! Custom data detected.');
                 process.exit(1);
             }
@@ -617,7 +618,7 @@ export function packConfigs() {
         console.log('Packing .idk');
         //console.time('Packed .idk');
         readConfigs('.idk', [], parseIdkConfig, packIdkConfigs, (dat: Packet, idx: Packet) => {
-            if (!Packet.checkcrc(dat, -359342366) || !Packet.checkcrc(idx, 667216411)) {
+            if (!Environment.SKIP_CRC && (!Packet.checkcrc(dat, -359342366) || !Packet.checkcrc(idx, 667216411))) {
                 console.error('.idk CRC check failed! Custom data detected.');
                 process.exit(1);
             }
@@ -638,7 +639,7 @@ export function packConfigs() {
         console.log('Packing .varp');
         //console.time('Packed .varp');
         readConfigs('.varp', [], parseVarpConfig, packVarpConfigs, (dat: Packet, idx: Packet) => {
-            if (!Packet.checkcrc(dat, 705633567) || !Packet.checkcrc(idx, -1843167599)) {
+            if (!Environment.SKIP_CRC && (!Packet.checkcrc(dat, 705633567) || !Packet.checkcrc(idx, -1843167599))) {
                 console.error('.varp CRC check failed! Custom data detected.');
                 process.exit(1);
             }

--- a/src/lostcity/util/Environment.ts
+++ b/src/lostcity/util/Environment.ts
@@ -1,5 +1,6 @@
 import 'dotenv/config';
 import { tryParseBoolean, tryParseInt, tryParseString } from './TryParse.js';
+import * as process from 'process';
 
 export default {
     PUBLIC_IP: tryParseString(process.env.PUBLIC_IP, ''),
@@ -31,5 +32,7 @@ export default {
     DB_PASS: tryParseString(process.env.DB_PASS, ''),
     DB_NAME: tryParseString(process.env.DB_NAME, ''),
 
-    ADMIN_IP: tryParseString(process.env.ADMIN_IP, '')
+    ADMIN_IP: tryParseString(process.env.ADMIN_IP, ''),
+
+    SKIP_CRC: tryParseBoolean(process.env.SKIP_CRC, false)
 };

--- a/src/lostcity/util/Environment.ts
+++ b/src/lostcity/util/Environment.ts
@@ -1,6 +1,5 @@
 import 'dotenv/config';
 import { tryParseBoolean, tryParseInt, tryParseString } from './TryParse.js';
-import * as process from 'process';
 
 export default {
     PUBLIC_IP: tryParseString(process.env.PUBLIC_IP, ''),


### PR DESCRIPTION
- Use new environment property `SKIP_CRC` to skip packing crc checks or not.
- `true` enables the skip. 
- It is `false` by default.