### PR TITLE
fix: create Workers elsewhere and mock for tests

### DIFF
--- a/src/lostcity/engine/Login.ts
+++ b/src/lostcity/engine/Login.ts
@@ -9,9 +9,10 @@ import Player from '#lostcity/entity/Player.js';
 
 import ClientSocket from '#lostcity/server/ClientSocket.js';
 import { PlayerLoading } from '#lostcity/entity/PlayerLoading.js';
+import { createWorker } from '#lostcity/util/WorkerFactory.js';
 
 class Login {
-    loginThread: Worker = new Worker('./src/lostcity/server/LoginThread.ts');
+    loginThread: Worker = createWorker('./src/lostcity/server/LoginThread.ts');
     loginRequests: Map<string, ClientSocket> = new Map();
     logoutRequests: Set<bigint> = new Set();
 

--- a/src/lostcity/engine/World.ts
+++ b/src/lostcity/engine/World.ts
@@ -56,6 +56,7 @@ import { ZoneEvent } from './zone/Zone.js';
 import LinkList from '#jagex2/datastruct/LinkList.js';
 import ClientProt from '#lostcity/server/ClientProt.js';
 import { NetworkPlayer, isNetworkPlayer } from '#lostcity/entity/NetworkPlayer.js';
+import { createWorker } from '#lostcity/util/WorkerFactory.js';
 
 class World {
     id = Environment.WORLD_ID as number;
@@ -88,7 +89,7 @@ class World {
     futureUpdates: Map<number, number[]> = new Map();
     queue: LinkList<EntityQueueState> = new LinkList();
 
-    friendThread: Worker = new Worker('./src/lostcity/server/FriendThread.ts');
+    friendThread: Worker = createWorker('./src/lostcity/server/FriendThread.ts');
 
     constructor() {
         this.players.fill(null);
@@ -1072,6 +1073,7 @@ class World {
 
     removeNpc(npc: Npc) {
         const zone = this.getZone(npc.x, npc.z, npc.level);
+        console.log('Removing npc', npc.nid, 'from zone', zone.index);
         zone.leave(npc);
 
         switch (npc.blockWalk) {

--- a/src/lostcity/util/WorkerFactory.ts
+++ b/src/lostcity/util/WorkerFactory.ts
@@ -1,0 +1,5 @@
+import { Worker } from 'node:worker_threads';
+
+export function createWorker(fileName: string) {
+    return new Worker(fileName);
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -9,6 +9,8 @@ const Configuration = defineConfig({
         globals: true,
         // Prevent test cross-contamination when mocking implementations
         mockReset: true,
+        // Files to run before tests
+        setupFiles: [ './vitest/mock-worker.ts' ]
     },
 });
 

--- a/vitest/mock-worker.ts
+++ b/vitest/mock-worker.ts
@@ -1,0 +1,10 @@
+import { vi } from 'vitest';
+
+vi.mock('#lostcity/util/WorkerFactory.js', async () => {
+    return {
+        createWorker: () => ({
+            on: vi.fn(),
+            postMessage: vi.fn()
+        })
+    };
+});


### PR DESCRIPTION
Previously any tests which ended up importing `Login.ts` or `World.ts` somewhere (lots of places, including `Player` class) would break on the worker creation

This allows us to mock it out so they can be tested (needed for upcoming Zone PR)