### PR TITLE
fix(content): various mage arena fixes

### DIFF
--- a/data/src/scripts/areas/area_mage_arena/configs/mage_arena.npc
+++ b/data/src/scripts/areas/area_mage_arena/configs/mage_arena.npc
@@ -38,6 +38,11 @@ model6=model_274_idk
 model7=model_185_obj_wear
 head1=model_63_idk_head
 head2=model_84_idk_head
+param=owned_shop,lundails_arena_side_rune_shop
+param=shop_sell_multiplier,1000
+param=shop_buy_multiplier,600
+param=shop_delta,1
+param=shop_title,Lundail's Arena-side Rune Shop.
 
 [chamber_guardian]
 vislevel=hide

--- a/data/src/scripts/areas/area_mage_arena/scripts/battle_mage.rs2
+++ b/data/src/scripts/areas/area_mage_arena/scripts/battle_mage.rs2
@@ -1,3 +1,26 @@
+[opnpc2,_battle_mage]
+if (~inzone_coord_pair_table(mage_arena, coord) = true) {
+    // Lotta forums posts where people are confused whether 
+    // or not they can use auto cast. Some people say you can,
+    // some people say you cant. I assume you could autocast,
+    // but only if you cast a manual spell first (and have autocast on).
+    // Some guides say you cant click on npc's with autocast.
+    if (%magearena_progress < ^mage_arena_complete) {
+        mes("You are not ready to fight the battle mages."); // for some reason this message appears before the singles combat messages, if you're not casting spells
+    }
+    return;
+}
+@player_combat_start;
+
+[apnpc2,_battle_mage]
+if (~inzone_coord_pair_table(mage_arena, coord) = true) {
+    if (%magearena_progress < ^mage_arena_complete) {
+        mes("You are not ready to fight the battle mages."); // for some reason this message appears before the singles combat messages, if you're not casting spells
+    }
+    return;
+}
+@player_combat_start_ap;
+
 [ai_queue1,battle_mage_zamorak](int $arg) ~npc_default_retaliate_ap;
 [ai_queue1,battle_mage_saradomin](int $arg) ~npc_default_retaliate_ap;
 [ai_queue1,battle_mage_guthix](int $arg) ~npc_default_retaliate_ap;

--- a/data/src/scripts/areas/area_mage_arena/scripts/gundai.rs2
+++ b/data/src/scripts/areas/area_mage_arena/scripts/gundai.rs2
@@ -1,0 +1,11 @@
+[opnpc1,gundai]
+~chatplayer(quiz, "Hello, what are you doing out here?");
+~chatnpc(happy, "I'm a banker, the only one around these dangerous parts.");
+
+def_int $choice = ~p_choice2("Cool, I'd like to access my bank account please.", 1, "Well, now I know.", 2);
+if ($choice = 2) {
+    ~chatplayer(neutral, "Well, now I know.");
+    ~chatnpc(neutral, "Knowledge is power my friend.");
+    return;
+}
+@openbank;

--- a/data/src/scripts/areas/area_mage_arena/scripts/lundail.rs2
+++ b/data/src/scripts/areas/area_mage_arena/scripts/lundail.rs2
@@ -1,0 +1,19 @@
+[opnpc1,lundail]
+~chatnpc(happy, "Hello <text_gender("Sir", "Miss")>.");
+~chatnpc(neutral, "How can I help you, brave adventurer?");
+def_int $choice = ~p_choice2("What are you selling?", 1, "What's that big old building above us?", 2);
+if ($choice = 1) {
+    ~chatplayer(quiz, "What are you selling?");
+    ~chatnpc(neutral, "I sell runes. I've got some good stuff, some really powerful little rocks. Take a look.");
+    ~openshop_activenpc;
+    return;
+}
+
+~chatplayer(quiz, "What's that big old building above us?");
+~chatnpc(happy, "That, my friend, is the mage battle arena. Top mages come from all over Gielinor to compete in the arena.");
+~chatplayer(neutral, "Wow.");
+~chatnpc(confused, "Few return, most get fried, hence the smell.");
+~chatplayer(confused, "Hmmm.. I did notice.");
+
+[opnpc3,lundail]
+~openshop_activenpc;

--- a/data/src/scripts/player/configs/multiway.dbrow
+++ b/data/src/scripts/player/configs/multiway.dbrow
@@ -68,4 +68,6 @@ data=coord_pair,0_39_50_48_8,0_39_50_55_31
 data=coord_pair,0_49_154_16_0,0_51_154_30_63
 // kbd lair
 data=coord_pair,0_42_153_15_0,0_42_153_45_40
+// mage arena
+data=coord_pair,0_39_73_0_0,0_39_73_63_63
 // todo - more underground?

--- a/data/src/scripts/skill_combat/scripts/npc/npc_combat_magic.rs2
+++ b/data/src/scripts/skill_combat/scripts/npc/npc_combat_magic.rs2
@@ -41,7 +41,9 @@ if (npc_param(magicattack_anim) = null) {
     npc_anim(npc_param(magicattack_anim), 0);
 }
 // origin spell visual effect
-spotanim_npc(db_getfield($spell_data, magic_spell_table:spotanim_origin, 0), 92, 0);
+if (db_getfieldcount($spell_data, magic_spell_table:spotanim_origin) > 0) {
+    spotanim_npc(db_getfield($spell_data, magic_spell_table:spotanim_origin, 0), 92, 0);
+}
 // shoot spell projectile
 %npc_action_delay = add(map_clock, 5);
 def_int $duration = 64;

--- a/data/src/scripts/skill_combat/scripts/player/player_combat.rs2
+++ b/data/src/scripts/skill_combat/scripts/player/player_combat.rs2
@@ -1,27 +1,7 @@
-[opnpc2,_]
-if (~inzone_coord_pair_table(mage_arena, coord) = true) {
-    // Lotta forums posts where people are confused whether 
-    // or not they can use auto cast. Some people say you can,
-    // some people say you cant. I assume you could autocast,
-    // but only if you cast a manual spell first (and have autocast on).
-    // Some guides say you cant click on npc's with autocast.
-    if (npc_category = battle_mage & %magearena_progress < ^mage_arena_complete) {
-        mes("You are not ready to fight the battle mages."); // for some reason this message appears before the singles combat messages, if you're not casting spells
-    }
-    return;
-}
-if (~player_in_combat_check = false) {
-    return;
-}
-@player_combat_start;
+[opnpc2,_] @player_combat_start;
+[apnpc2,_] @player_combat_start_ap;
 
-[apnpc2,_]
-if (~inzone_coord_pair_table(mage_arena, coord) = true) {
-    if (npc_category = battle_mage & %magearena_progress < ^mage_arena_complete) {
-        mes("You are not ready to fight the battle mages."); // for some reason this message appears before the singles combat messages, if you're not casting spells
-    }
-    return;
-}
+[label,player_combat_start_ap]
 def_int $distance = npc_range(coord);
 def_int $attackrange = 0;
 if (inv_getobj(worn, ^wearpos_rhand) ! null) {
@@ -55,6 +35,9 @@ p_aprange($attackrange);
 @player_combat_start;
 
 [label,player_combat_start]
+if (~player_in_combat_check = false) {
+    return;
+}
 // facesquare(npc_coord);
 // TODO: Range and mage check
 if (%damagetype = ^ranged_style) {

--- a/data/src/scripts/skill_combat/scripts/player/spells/scripts/flames_of_zamorak.rs2
+++ b/data/src/scripts/skill_combat/scripts/player/spells/scripts/flames_of_zamorak.rs2
@@ -2,7 +2,7 @@
 [apnpct,magic:flames_of_zamorak] ~pvm_flames_of_zamorak;
 
 [proc,pvm_flames_of_zamorak]
-def_dbrow $spell_data = ~get_spell_data(^claws_of_guthix);
+def_dbrow $spell_data = ~get_spell_data(^flames_of_zamorak);
 if (~pvm_combat_spell_checks($spell_data) = false) {
     return;
 }


### PR DESCRIPTION
- makes the arena bank multi
- adds dialogue to gundai and lundail
- fixes issue with flames of zamorak spell
- fixes npc magic, not checking if spotanim is null before using
- moves mage arena + battle mage check from `[opnpc2,_]` to `[opnpc2,_battle_mage]`