### PR TITLE
fix(content): holy water missing proj_launch and proj_travel params

### DIFF
--- a/data/src/scripts/quests/quest_legends/configs/quest_legends.obj
+++ b/data/src/scripts/quests/quest_legends/configs/quest_legends.obj
@@ -313,6 +313,8 @@ param=levelrequire,1
 param=attackrange,4
 param=rangeattack_anim,human_holy_water_throw
 param=defend_anim,human_unarmedblock
+param=proj_launch,holy_water_launch
+param=proj_travel,holy_water_travel
 param=rangeattack_sound,thrown
 
 [obj_733]

--- a/data/src/scripts/skill_combat/scripts/player/player_ranged.rs2
+++ b/data/src/scripts/skill_combat/scripts/player/player_ranged.rs2
@@ -76,8 +76,16 @@ if (%damagestyle = ^style_ranged_rapid) {
     %action_delay = sub(%action_delay, 1);
 }
 p_opnpc(2);
+if ($ammo = obj_732) {
+    world_delay(calc($delay / 30 - 2));
+    if (map_blocked(npc_coord) = true) {
+        return;
+    }
+    obj_add(npc_coord, obj_733, 1, 200);
+    return;
+}
 if (random(5) ! 0) {
-    world_delay(calc($delay / 30));
+    world_delay(calc($delay / 30 - 2));
     if (map_blocked(npc_coord) = true) {
         return;
     }


### PR DESCRIPTION
- adds spotanim's to holy water
- throwing holy water drops glass
- arrows show up sooner on the ground