### PR TITLE
fix(engine): auto path to op/ap interactions

### DIFF
--- a/data/src/scripts/_test/scripts/engine/debug_addobj.rs2
+++ b/data/src/scripts/_test/scripts/engine/debug_addobj.rs2
@@ -1,0 +1,8 @@
+[debugproc,addobj]
+if_close;
+if (p_finduid(uid) = true) {
+    obj_add(movecoord(coord, 0, 0, 5), logs, 1, ^lootdrop_duration);
+    p_opobj(4);
+} else {
+    @please_finish;
+}

--- a/src/lostcity/entity/NetworkPlayer.ts
+++ b/src/lostcity/entity/NetworkPlayer.ts
@@ -1167,9 +1167,7 @@ export class NetworkPlayer extends Player {
                 this.mask |= Player.FACE_ENTITY;
             }
 
-            if (this.target) {
-                this.pathToTarget();
-            } else {
+            if (!this.target) {
                 this.queueWaypoints(findPath(this.level, this.x, this.z, pathfindX, pathfindZ));
             }
         }

--- a/src/lostcity/entity/Player.ts
+++ b/src/lostcity/entity/Player.ts
@@ -1046,6 +1046,7 @@ export default class Player extends PathingEntity {
             this.faceZ = target.z * 2 + 1;
             this.mask |= Player.FACE_COORD;
         }
+        this.pathToTarget();
     }
 
     clearInteraction() {
@@ -1102,22 +1103,26 @@ export default class Player extends PathingEntity {
 
         if (this.target.level !== this.level) {
             this.clearInteraction();
+            this.unsetMapFlag(); // assuming its right
             return;
         }
 
         // todo: clear interaction on npc_changetype
         if (this.target instanceof Npc && this.target.delayed()) {
             this.clearInteraction();
+            this.unsetMapFlag(); // assuming its right
             return;
         }
 
         if (this.target instanceof Obj && World.getObj(this.target.x, this.target.z, this.level, this.target.type) === null) {
             this.clearInteraction();
+            this.unsetMapFlag();
             return;
         }
 
         if (this.target instanceof Loc && World.getLoc(this.target.x, this.target.z, this.level, this.target.type) === null) {
             this.clearInteraction();
+            this.unsetMapFlag();
             return;
         }
 


### PR DESCRIPTION
- op/ap interactions now automatically path to the target same as the packet decoding versions.
- no longer continue walking if the target is no longer in the world