### PR TITLE
fix(content): no longer remember attackstyles after logout

### DIFF
--- a/data/src/scripts/_unpack/all.varp
+++ b/data/src/scripts/_unpack/all.varp
@@ -32,7 +32,6 @@ protect=no
 
 [attackstyle]
 transmit=yes
-scope=perm
 
 [com_stabattack]
 protect=no
@@ -128,7 +127,6 @@ transmit=yes
 
 [attackstyle_magic]
 transmit=yes
-scope=perm
 
 [varp_109]
 


### PR DESCRIPTION
https://runescape.wiki/w/Update:Game_Improvements
`We've also rejigged the combat selection so now you'll stick to the same fighting style after you log out. This means that when you log in again, you'll automatically use your preferred style - no more defending yourself by hitting someone over the head with a staff when you have plenty of runes!`