### PR TITLE
fix(engine): cheapfix deleting and adding dynamic npcs on the same tick

### DIFF
--- a/data/src/scripts/quests/quest_ball/scripts/witches_experiement.rs2
+++ b/data/src/scripts/quests/quest_ball/scripts/witches_experiement.rs2
@@ -6,6 +6,7 @@ if(npc_findhero = false) {
     return;
 }
 npc_add(^ball_experiment_spawn_coord, witches_experiment_p2, 500);
+~npc_set_attack_vars;
 npc_setmode(opplayer2);
 mes("The shapeshifters' body begins to deform!");
 mes("The shapeshifter turns into a spider!");
@@ -16,6 +17,7 @@ if(npc_findhero = false) {
     return;
 }
 npc_add(^ball_experiment_spawn_coord, witches_experiment_p3, 500);
+~npc_set_attack_vars;
 npc_setmode(opplayer2);
 mes("The shapeshifters' body begins to twist!");
 mes("The shapeshifter turns into a bear!");
@@ -26,6 +28,7 @@ if(npc_findhero = false) {
     return;
 }
 npc_add(^ball_experiment_spawn_coord, witches_experiment_p4, 500);
+~npc_set_attack_vars;
 npc_setmode(opplayer2);
 mes("The shapeshifters' body pulses!");
 mes("The shapeshifter turns into a wolf!");

--- a/src/lostcity/engine/World.ts
+++ b/src/lostcity/engine/World.ts
@@ -87,6 +87,7 @@ class World {
     playerIds: number[] = new Array(2048); // indexes into players
 
     npcs: (Npc | null)[] = new Array<Npc>(8192);
+    removeNpcs: Npc[] = [];
 
     trackedZones: number[] = [];
     zoneBuffers: Map<number, Packet> = new Map();
@@ -901,6 +902,11 @@ class World {
             npc.resetEntity(false);
         }
 
+        for (let i = 0; i < this.removeNpcs.length; i++) {
+            this.npcs[this.removeNpcs[i].nid] = null;
+        }
+        this.removeNpcs = [];
+
         for (let i = 0; i < this.invs.length; i++) {
             const inv = this.invs[i];
             if (!inv) {
@@ -1170,12 +1176,12 @@ class World {
                 break;
         }
 
+        const type = NpcType.get(npc.type);
+        npc.despawn = this.currentTick;
+        npc.respawn = this.currentTick + type.respawnrate;
+
         if (!npc.static) {
-            this.npcs[npc.nid] = null;
-        } else {
-            const type = NpcType.get(npc.type);
-            npc.despawn = this.currentTick;
-            npc.respawn = this.currentTick + type.respawnrate;
+            this.removeNpcs.push(npc);
         }
     }
 


### PR DESCRIPTION
Basically npc update uses `nid` which gets reused if an npc is deleted then a new npc is added on the same tick which results in that npc using the same `nid` as the one which was deleted which causes issues.