### PR TITLE
revert(content): macro_event reward lasting 3 hours on ground

### DIFF
--- a/data/src/scripts/macro events/scripts/general/macro_event_drunken_dwarf.rs2
+++ b/data/src/scripts/macro events/scripts/general/macro_event_drunken_dwarf.rs2
@@ -28,8 +28,8 @@ if (%macro_event = ^no_macro_event | %macro_event_uid ! npc_uid) {
     ~chatnpc(drunk, "'Ave a good 'un buddy!"); // osrs
     return;
 }
-~macro_event_give_reward(kebab, 1);
-~macro_event_give_reward(beer, 1);
+inv_add(inv, kebab, 1);
+inv_add(inv, beer, 1);
 %macro_event = ^no_macro_event;
 
 npc_queue(6, 0, 0); // say good bye

--- a/data/src/scripts/macro events/scripts/general/macro_event_genie.rs2
+++ b/data/src/scripts/macro events/scripts/general/macro_event_genie.rs2
@@ -30,7 +30,7 @@ if (%macro_event = ^no_macro_event | %macro_event_uid ! npc_uid) {
     return;
 }
 %macro_event = ^no_macro_event;
-~macro_event_give_reward(lamp, 1);
+inv_add(inv, lamp, 1);
 // delays are taken from this video: https://youtu.be/EN4c2hV65Qk?list=PLn23LiLYLb1Y3P9S9qZbijcJihiD416jT
 npc_queue(6, 0, 2);
 // sept 2006 https://imgur.com/undefined

--- a/data/src/scripts/macro events/scripts/general/macro_event_mysterious_old_man.rs2
+++ b/data/src/scripts/macro events/scripts/general/macro_event_mysterious_old_man.rs2
@@ -30,7 +30,7 @@ if (%macro_event = ^no_macro_event | %macro_event_uid ! npc_uid) {
     return;
 }
 %macro_event = ^no_macro_event;
-~macro_event_give_reward(~macro_event_mysterious_old_man_general_reward);
+inv_add(inv, ~macro_event_mysterious_old_man_general_reward);
 // dialogue taken from osrs. Neutral is a guess.
 npc_queue(6, 0, 2); // say goodbye to player
 ~chatnpc(neutral, "Ah, so you are there. I hoped you would talk to me, I get so lonely. Here, have a present! I must be going now though.");

--- a/data/src/scripts/macro events/scripts/general/macro_event_triffid.rs2
+++ b/data/src/scripts/macro events/scripts/general/macro_event_triffid.rs2
@@ -17,7 +17,7 @@ if (%npc_macro_event_status = ^triffid_growing) {
     mes("The fruit isn't ready to be picked yet...");
     return;
 }
-~macro_event_give_reward(strange_fruit, 1);
+inv_add(inv, strange_fruit, 1);
 sound_synth(pick, 0, 0);
 // https://youtu.be/ghfKpXe7N5s?t=24
 mes("You pick the fruit from the plant."); // osrs

--- a/data/src/scripts/macro events/scripts/macro_events.rs2
+++ b/data/src/scripts/macro events/scripts/macro_events.rs2
@@ -165,14 +165,6 @@ if (%macro_event < add(~macro_event_general_count, 1)){
     return(true);
 }
 
-[proc,macro_event_give_reward](namedobj $reward, int $count)
-if (inv_freespace(inv) < 1) {
-    // drop on the ground for 3 hours https://twitter.com/JagexAsh/status/1574393627421417478
-    obj_add(coord, $reward, $count, 18000);
-} else {
-    inv_add(inv, $reward, $count);
-}
-
 [proc,macro_event_lost_and_follow]()(boolean)
 if (finduid(%npc_attacking_uid) = false) {
     return(true);


### PR DESCRIPTION
In osrs, after receiving a reward from a random event and your inventory is full, it is dropped on the ground for 3h. This was supposedly added in osrs in ~2018.
![image](https://github.com/2004scape/Server/assets/61213166/913da50b-0b12-4169-82a0-2b34e3d01af2)
