### PR TITLE
fix(content): wrong message when partyroomoffer is full

### DIFF
--- a/data/src/scripts/minigames/game_partyroom/scripts/partyroom_chest.rs2
+++ b/data/src/scripts/minigames/game_partyroom/scripts/partyroom_chest.rs2
@@ -56,7 +56,7 @@ def_int $total = inv_total(inv, $obj);
 if ($amount < $total) $total = $amount;
 if(oc_stackable($obj) = false & $total > inv_freespace(partyroomoffer)) $total = inv_freespace(partyroomoffer);
 if($total = 0 | inv_itemspace(partyroomoffer, $obj, $total, inv_size(partyroomoffer)) = false) {
-    mes("You cannot offer any more items until you've confirmed the current ones.");
+    mes("You must accept the current items before adding any more."); // 2006 https://www.youtube.com/watch?v=Ve5UF8B3BMw&t=194s
     return;
 }
 inv_moveitem(inv, partyroomoffer, $obj, $total);


### PR DESCRIPTION
https://youtu.be/Ve5UF8B3BMw?t=194
![image](https://github.com/2004scape/Server/assets/61213166/07a77d17-f528-4073-9dd8-5639f1990f13)