### PR TITLE
fix(engine): npc interacting attempts & refactor interaction code

### DIFF
--- a/data/src/scripts/areas/area_alkharid/scripts/border_gate.rs2
+++ b/data/src/scripts/areas/area_alkharid/scripts/border_gate.rs2
@@ -54,7 +54,7 @@ inv_del(inv, coins, 10);
 
 [label,pass_toll_gate](coord $loc_coord)
 // close the dialogue
-if_close;
+//if_close;
 
 def_coord $coord = 0_51_50_4_27;
 def_boolean $enter_east = false;
@@ -70,9 +70,11 @@ if (coordx(coord) < coordx($coord)) {
 if ($loc_coord ! null & distance(coord, $loc_coord) <= 1) {
     if ($enter_east = false & (coord ! 0_51_50_4_28 & coord ! 0_51_50_4_27)) {
         p_teleport($loc_coord);
+        p_stopaction;
         p_delay(2);
         @enter_through_border_gate_toll($enter_east, $loc_coord);
     } else {
+        p_stopaction;
         p_delay(1);
         @enter_through_border_gate_toll($enter_east, $loc_coord);
     }
@@ -81,6 +83,7 @@ if ($loc_coord ! null & distance(coord, $loc_coord) <= 1) {
 def_int $change_x = calc(coordx($coord) - coordx(coord));
 def_int $change_z = calc(coordz($coord) - coordz(coord));
 ~agility_walk($change_x, $change_z);
+p_stopaction;
 p_delay(0);
 // open the gates and teleport through
 @enter_through_border_gate_toll($enter_east, $loc_coord);
@@ -117,6 +120,7 @@ while (loc_findnext = true) {
 sound_synth(grate_open, 0, 0);
 facesquare($destination);
 p_teleport($destination);
+p_stopaction;
 p_delay(0);
 
 [proc,open_border_gate_toll_left_closed]()
@@ -165,6 +169,7 @@ while (loc_findnext = true) {
 
 [label,guard_scout_toll_fence]
 if (random(4) ! 0) return;
+if (npc_getmode = playerfaceclose) return;
 
 def_coord $next_coord = movecoord(npc_coord, ~random_range(-1, 1), 0, ~random_range(-1, 1));
 

--- a/data/src/scripts/skill_agility/scripts/agility.rs2
+++ b/data/src/scripts/skill_agility/scripts/agility.rs2
@@ -37,6 +37,7 @@ def_coord $movement_coord = movecoord(coord, $move_x, 0, $move_z);
 p_teleport(movecoord(coord, $move_x, 0, $move_z));
 $change_x = calc($change_x - $move_x);
 $change_z = calc($change_z - $move_z);
+p_stopaction;
 p_delay(0);
 // recursive call
 ~agility_walk($change_x, $change_z);

--- a/src/lostcity/engine/script/ScriptState.ts
+++ b/src/lostcity/engine/script/ScriptState.ts
@@ -120,7 +120,7 @@ export default class ScriptState {
     dbRow: number = -1;
     dbRowQuery: number[] = [];
 
-    huntIterator: IterableIterator<Player> | null = null;
+    huntIterator: IterableIterator<Entity> | null = null;
     npcIterator: IterableIterator<Npc> | null = null;
     locIterator: IterableIterator<Loc> | null = null;
 

--- a/src/lostcity/engine/script/handlers/NpcOps.ts
+++ b/src/lostcity/engine/script/handlers/NpcOps.ts
@@ -18,7 +18,8 @@ import Obj from '#lostcity/entity/Obj.js';
 import { Position } from '#lostcity/entity/Position.js';
 import Npc from '#lostcity/entity/Npc.js';
 import NpcMode from '#lostcity/entity/NpcMode.js';
-import Player from '#lostcity/entity/Player.js';
+import Entity from '#lostcity/entity/Entity.js';
+import Interaction from '#lostcity/entity/Interaction.js';
 
 import Environment from '#lostcity/util/Environment.js';
 
@@ -235,7 +236,7 @@ const NpcOps: CommandHandlers = {
             return;
         }
 
-        let target: Player | Npc | Loc | Obj | null;
+        let target: Entity | null;
         if (mode >= NpcMode.OPNPC1) {
             target = state._activeNpc2;
         } else if (mode >= NpcMode.OPOBJ1) {
@@ -247,7 +248,11 @@ const NpcOps: CommandHandlers = {
         }
 
         if (target) {
-            state.activeNpc.setInteraction(target, mode);
+            if (target instanceof Npc || target instanceof Obj || target instanceof Loc) {
+                state.activeNpc.setInteraction(Interaction.SCRIPT, target, mode, {type: target.type, com: -1});
+            } else {
+                state.activeNpc.setInteraction(Interaction.SCRIPT, target, mode);
+            }
         } else {
             state.activeNpc.noMode();
         }

--- a/src/lostcity/engine/script/handlers/ObjOps.ts
+++ b/src/lostcity/engine/script/handlers/ObjOps.ts
@@ -25,6 +25,7 @@ import {
 } from '#lostcity/engine/script/ScriptValidators.js';
 
 const ActiveObj = [ScriptPointer.ActiveObj, ScriptPointer.ActiveObj2];
+const ActivePlayer = [ScriptPointer.ActivePlayer, ScriptPointer.ActivePlayer2];
 
 const ObjOps: CommandHandlers = {
     [ScriptOpcode.OBJ_ADD]: state => {
@@ -74,7 +75,11 @@ const ObjOps: CommandHandlers = {
     },
 
     [ScriptOpcode.OBJ_DEL]: state => {
-        World.removeObj(state.activeObj, state.activePlayer);
+        if (state.pointerGet(ActivePlayer[state.intOperand])) {
+            World.removeObj(state.activeObj, state.activePlayer);
+        } else {
+            World.removeObj(state.activeObj, null);
+        }
     },
 
     [ScriptOpcode.OBJ_COUNT]: state => {

--- a/src/lostcity/engine/script/handlers/PlayerOps.ts
+++ b/src/lostcity/engine/script/handlers/PlayerOps.ts
@@ -320,6 +320,11 @@ const PlayerOps: CommandHandlers = {
         if (state.activePlayer.target !== null) {
             return;
         }
+        if (state.activePlayer.hasWaypoints()) {
+            return;
+        }
+        state.activePlayer.clearInteraction();
+        state.activePlayer.closeModal();
         state.activePlayer.setInteraction(Interaction.SCRIPT, state.activeLoc, ServerTriggerType.APLOC1 + type);
     }),
 
@@ -331,6 +336,11 @@ const PlayerOps: CommandHandlers = {
         if (state.activePlayer.target !== null) {
             return;
         }
+        if (state.activePlayer.hasWaypoints()) {
+            return;
+        }
+        state.activePlayer.clearInteraction();
+        state.activePlayer.closeModal();
         state.activePlayer.setInteraction(Interaction.SCRIPT, state.activeNpc, ServerTriggerType.APNPC1 + type, {type: state.activeNpc.type, com: -1});
     }),
 
@@ -339,6 +349,11 @@ const PlayerOps: CommandHandlers = {
         if (state.activePlayer.target !== null) {
             return;
         }
+        if (state.activePlayer.hasWaypoints()) {
+            return;
+        }
+        state.activePlayer.clearInteraction();
+        state.activePlayer.closeModal();
         state.activePlayer.setInteraction(Interaction.SCRIPT, state.activeNpc, ServerTriggerType.APNPCT, {type: state.activeNpc.type, com: spellId});
     }),
 
@@ -835,6 +850,11 @@ const PlayerOps: CommandHandlers = {
         if (state.activePlayer.target !== null) {
             return;
         }
+        if (state.activePlayer.hasWaypoints()) {
+            return;
+        }
+        state.activePlayer.clearInteraction();
+        state.activePlayer.closeModal();
         state.activePlayer.setInteraction(Interaction.SCRIPT, state.activeObj, ServerTriggerType.APOBJ1 + type);
     }),
 
@@ -846,10 +866,15 @@ const PlayerOps: CommandHandlers = {
         if (state.activePlayer.target !== null) {
             return;
         }
+        if (state.activePlayer.hasWaypoints()) {
+            return;
+        }
         const target = state._activePlayer2;
         if (!target) {
             return;
         }
+        state.activePlayer.clearInteraction();
+        state.activePlayer.closeModal();
         state.activePlayer.setInteraction(Interaction.SCRIPT, target, ServerTriggerType.APPLAYER1 + type);
     }),
 
@@ -951,10 +976,15 @@ const PlayerOps: CommandHandlers = {
         if (state.activePlayer.target !== null) {
             return;
         }
+        if (state.activePlayer.hasWaypoints()) {
+            return;
+        }
         const target = state._activePlayer2;
         if (!target) {
             return;
         }
+        state.activePlayer.clearInteraction();
+        state.activePlayer.closeModal();
         state.activePlayer.setInteraction(Interaction.SCRIPT, target, ServerTriggerType.APPLAYERT, {type: -1, com: spellId});
     }),
 };

--- a/src/lostcity/engine/script/handlers/ServerOps.ts
+++ b/src/lostcity/engine/script/handlers/ServerOps.ts
@@ -15,8 +15,18 @@ import ScriptPointer from '#lostcity/engine/script/ScriptPointer.js';
 import {HuntIterator} from '#lostcity/engine/script/ScriptIterators.js';
 
 import { Position } from '#lostcity/entity/Position.js';
+import HuntModeType from '#lostcity/entity/hunt/HuntModeType.js';
+import Player from '#lostcity/entity/Player.js';
 
-import {CollisionFlag, hasLineOfSight, hasLineOfWalk, isFlagged, LocAngle, LocLayer, locShapeLayer} from '@2004scape/rsmod-pathfinder';
+import {
+    CollisionFlag,
+    hasLineOfSight,
+    hasLineOfWalk,
+    isFlagged,
+    LocAngle,
+    LocLayer,
+    locShapeLayer
+} from '@2004scape/rsmod-pathfinder';
 
 import {
     check,
@@ -71,7 +81,7 @@ const ServerOps: CommandHandlers = {
 
         const {level, x, z} = Position.unpackCoord(coord);
 
-        state.huntIterator = new HuntIterator(World.currentTick, level, x, z, distance, checkVis);
+        state.huntIterator = new HuntIterator(World.currentTick, level, x, z, distance, checkVis, HuntModeType.PLAYER);
     },
 
     [ScriptOpcode.HUNTNEXT]: state => {
@@ -79,6 +89,10 @@ const ServerOps: CommandHandlers = {
         if (!result || result.done) {
             state.pushInt(0);
             return;
+        }
+
+        if (!(result.value instanceof Player)) {
+            throw new Error('[ServerOps] huntnext command must result instance of Player.');
         }
 
         state.activePlayer = result.value;

--- a/src/lostcity/entity/PathingEntity.ts
+++ b/src/lostcity/entity/PathingEntity.ts
@@ -33,9 +33,9 @@ type TargetSubject = {
 export default abstract class PathingEntity extends Entity {
     // constructor properties
     protected readonly moveRestrict: MoveRestrict;
-    private readonly blockWalk: BlockWalk;
-    private readonly facecoord: number;
-    private readonly faceentity: number;
+    readonly blockWalk: BlockWalk;
+    private readonly coordmask: number;
+    private readonly entitymask: number;
     private readonly smart: boolean;
 
     // runtime properties
@@ -83,12 +83,12 @@ export default abstract class PathingEntity extends Entity {
     graphicHeight: number = -1;
     graphicDelay: number = -1;
 
-    protected constructor(level: number, x: number, z: number, width: number, length: number, moveRestrict: MoveRestrict, blockWalk: BlockWalk, facecoord: number, faceentity: number, smart: boolean) {
+    protected constructor(level: number, x: number, z: number, width: number, length: number, moveRestrict: MoveRestrict, blockWalk: BlockWalk, coordmask: number, entitymask: number, smart: boolean) {
         super(level, x, z, width, length);
         this.moveRestrict = moveRestrict;
         this.blockWalk = blockWalk;
-        this.facecoord = facecoord;
-        this.faceentity = faceentity;
+        this.coordmask = coordmask;
+        this.entitymask = entitymask;
         this.smart = smart;
     }
 
@@ -396,13 +396,13 @@ export default abstract class PathingEntity extends Entity {
             const pid: number = target.pid + 32768;
             if (this.faceEntity !== pid) {
                 this.faceEntity = pid;
-                this.mask |= this.faceentity;
+                this.mask |= this.entitymask;
             }
         } else if (target instanceof Npc) {
             const nid: number = target.nid;
             if (this.faceEntity !== nid) {
                 this.faceEntity = nid;
-                this.mask |= this.faceentity;
+                this.mask |= this.entitymask;
             }
         } else {
             const faceX: number = target.x * 2 + target.width;
@@ -410,7 +410,7 @@ export default abstract class PathingEntity extends Entity {
             if (this.faceX !== faceX || this.faceZ !== faceZ) {
                 this.faceX = faceX;
                 this.faceZ = faceZ;
-                this.mask |= this.facecoord;
+                this.mask |= this.coordmask;
             }
         }
         if (interaction === Interaction.SCRIPT) {
@@ -460,7 +460,7 @@ export default abstract class PathingEntity extends Entity {
             this.faceZ = -1;
             this.alreadyFacedCoord = false;
         } else if (this.alreadyFacedEntity && !this.target) {
-            this.mask |= this.faceentity;
+            this.mask |= this.entitymask;
             this.faceEntity = -1;
             this.alreadyFacedEntity = false;
         }

--- a/src/lostcity/entity/PathingEntity.ts
+++ b/src/lostcity/entity/PathingEntity.ts
@@ -2,19 +2,41 @@ import World from '#lostcity/engine/World.js';
 
 import BlockWalk from '#lostcity/entity/BlockWalk.js';
 import Entity from '#lostcity/entity/Entity.js';
+import Npc from '#lostcity/entity/Npc.js';
 import Loc from '#lostcity/entity/Loc.js';
+import Interaction from '#lostcity/entity/Interaction.js';
+import Player from '#lostcity/entity/Player.js';
+import NpcMode from '#lostcity/entity/NpcMode.js';
 import MoveRestrict from '#lostcity/entity/MoveRestrict.js';
 import MoveSpeed from '#lostcity/entity/MoveSpeed.js';
 import { Direction, Position } from '#lostcity/entity/Position.js';
 
 import LocType from '#lostcity/cache/LocType.js';
+import ServerTriggerType from '#lostcity/engine/script/ServerTriggerType.js';
 
-import {canTravel, CollisionFlag, CollisionType, hasLineOfSight, isFlagged, reached} from '@2004scape/rsmod-pathfinder';
+import {
+    canTravel,
+    CollisionFlag,
+    CollisionType,
+    findNaivePath,
+    findPath,
+    hasLineOfSight,
+    isFlagged,
+    reached
+} from '@2004scape/rsmod-pathfinder';
+
+type TargetSubject = {
+    type: number,
+    com: number;
+}
 
 export default abstract class PathingEntity extends Entity {
     // constructor properties
-    readonly moveRestrict: MoveRestrict;
-    readonly blockWalk: BlockWalk;
+    protected readonly moveRestrict: MoveRestrict;
+    private readonly blockWalk: BlockWalk;
+    private readonly facecoord: number;
+    private readonly faceentity: number;
+    private readonly smart: boolean;
 
     // runtime properties
     moveSpeed: MoveSpeed = MoveSpeed.INSTANT;
@@ -31,6 +53,17 @@ export default abstract class PathingEntity extends Entity {
 
     orientation: number = Direction.SOUTH;
 
+    interacted: boolean = false;
+    repathed: boolean = false;
+    target: Entity | null = null;
+    targetOp: number = -1;
+    targetSubject: TargetSubject = {type: -1, com: -1};
+    apRange: number = 10;
+    apRangeCalled: boolean = false;
+    alreadyFacedCoord: boolean = false;
+    alreadyFacedEntity: boolean = false;
+
+    mask: number = 0;
     exactStartX: number = -1;
     exactStartZ: number = -1;
     exactEndX: number = -1;
@@ -38,17 +71,31 @@ export default abstract class PathingEntity extends Entity {
     exactMoveStart: number = -1;
     exactMoveEnd: number = -1;
     exactMoveDirection: number = -1;
+    faceX: number = -1;
+    faceZ: number = -1;
+    faceEntity: number = -1;
+    damageTaken: number = -1;
+    damageType: number = -1;
+    animId: number = -1;
+    animDelay: number = -1;
+    chat: string | null = null;
+    graphicId: number = -1;
+    graphicHeight: number = -1;
+    graphicDelay: number = -1;
 
-    protected constructor(level: number, x: number, z: number, width: number, length: number, moveRestrict: MoveRestrict, blockWalk: BlockWalk) {
+    protected constructor(level: number, x: number, z: number, width: number, length: number, moveRestrict: MoveRestrict, blockWalk: BlockWalk, facecoord: number, faceentity: number, smart: boolean) {
         super(level, x, z, width, length);
         this.moveRestrict = moveRestrict;
         this.blockWalk = blockWalk;
+        this.facecoord = facecoord;
+        this.faceentity = faceentity;
+        this.smart = smart;
     }
 
     /**
      * Attempts to update movement for a PathingEntity.
      */
-    abstract updateMovement(): void;
+    abstract updateMovement(repathAllowed: boolean): boolean;
     abstract blockWalkFlag(): CollisionFlag;
     abstract defaultMoveSpeed(): MoveSpeed;
 
@@ -98,7 +145,7 @@ export default abstract class PathingEntity extends Entity {
      * @param previousZ Their previous recorded z position before movement.
      * @param previousLevel Their previous recorded level position before movement. This one is important for teleport.
      */
-    refreshZonePresence(previousX: number, previousZ: number, previousLevel: number): void {
+    private refreshZonePresence(previousX: number, previousZ: number, previousLevel: number): void {
         // only update collision map when the entity moves.
         if (this.x != previousX || this.z !== previousZ || this.level !== previousLevel) {
             // update collision map
@@ -138,7 +185,7 @@ export default abstract class PathingEntity extends Entity {
      *
      * Returns the final validated step direction.
      */
-    validateAndAdvanceStep(): number {
+    private validateAndAdvanceStep(): number {
         const dir: number | null = this.takeStep();
         if (dir === null) {
             return -1;
@@ -267,7 +314,7 @@ export default abstract class PathingEntity extends Entity {
         return this.waypointIndex === 0;
     }
 
-    inOperableDistance(target: Entity): boolean {
+    protected inOperableDistance(target: Entity): boolean {
         if (target.level !== this.level) {
             return false;
         }
@@ -278,8 +325,7 @@ export default abstract class PathingEntity extends Entity {
             return reached(this.level, this.x, this.z, target.x, target.z, target.width, target.length, this.width, target.angle, target.shape, forceapproach);
         }
         // instanceof Obj
-        const reachedAdjacent = reached(this.level, this.x, this.z, target.x, target.z, target.width, target.length, this.width, 0, -2);
-        const reachedTile = reached(this.level, this.x, this.z, target.x, target.z, target.width, target.length, this.width, 0, -1);
+        const reachedAdjacent: boolean = reached(this.level, this.x, this.z, target.x, target.z, target.width, target.length, this.width, 0, -2);
         if (isFlagged(target.x, target.z, target.level, CollisionFlag.WALK_BLOCKED)) {
             // picking up off of tables
             return reachedAdjacent;
@@ -288,10 +334,10 @@ export default abstract class PathingEntity extends Entity {
             // picking up while walktrigger prevents movement
             return true;
         }
-        return reachedTile;
+        return reached(this.level, this.x, this.z, target.x, target.z, target.width, target.length, this.width, 0, -1);
     }
 
-    inApproachDistance(range: number, target: Entity): boolean {
+    protected inApproachDistance(range: number, target: Entity): boolean {
         if (target.level !== this.level) {
             return false;
         }
@@ -303,32 +349,123 @@ export default abstract class PathingEntity extends Entity {
         return Position.distanceTo(this, target) <= range && hasLineOfSight(this.level, this.x, this.z, target.x, target.z, this.width, this.length, target.width, target.length, CollisionFlag.PLAYER);
     }
 
-    getCollisionStrategy(): CollisionType | null {
-        switch (this.moveRestrict) {
-            case MoveRestrict.NORMAL:
-                return CollisionType.NORMAL;
-            case MoveRestrict.BLOCKED:
-                return CollisionType.BLOCKED;
-            case MoveRestrict.BLOCKED_NORMAL:
-                return CollisionType.LINE_OF_SIGHT;
-            case MoveRestrict.INDOORS:
-                return CollisionType.INDOORS;
-            case MoveRestrict.OUTDOORS:
-                return CollisionType.OUTDOORS;
-            case MoveRestrict.NOMOVE:
-                return null;
-            case MoveRestrict.PASSTHRU:
-                return CollisionType.NORMAL;
+    protected pathToTarget(): void {
+        if (!this.target) {
+            return;
+        }
+
+        if (this.smart) {
+            if (this.target instanceof PathingEntity) {
+                this.queueWaypoints(findPath(this.level, this.x, this.z, this.target.x, this.target.z, this.width, this.target.width, this.target.length, this.target.orientation, -2));
+            } else if (this.target instanceof Loc) {
+                const forceapproach = LocType.get(this.target.type).forceapproach;
+                this.queueWaypoints(findPath(this.level, this.x, this.z, this.target.x, this.target.z, this.width, this.target.width, this.target.length, this.target.angle, this.target.shape, true, forceapproach));
+            } else {
+                this.queueWaypoints(findPath(this.level, this.x, this.z, this.target.x, this.target.z));
+            }
+            return;
+        }
+
+        const collisionStrategy: CollisionType | null = this.getCollisionStrategy();
+        if (collisionStrategy === null) {
+            // nomove moverestrict returns as null = no walking allowed.
+            return;
+        }
+
+        const extraFlag: CollisionFlag = this.blockWalkFlag();
+        if (extraFlag === CollisionFlag.NULL) {
+            // nomove moverestrict returns as null = no walking allowed.
+            return;
+        }
+        if (this.target instanceof PathingEntity) {
+            this.queueWaypoints(findNaivePath(this.level, this.x, this.z, this.target.x, this.target.z, this.width, this.length, this.target.width, this.target.length, extraFlag, collisionStrategy));
+        } else {
+            this.queueWaypoint(this.target.x, this.target.z);
         }
     }
 
-    resetPathingEntity(): void {
+    setInteraction(interaction: Interaction, target: Entity, op: ServerTriggerType | NpcMode, subject?: TargetSubject): void {
+        this.target = target;
+        this.targetOp = op;
+        this.targetSubject = subject ?? {type: -1, com: -1};
+        this.apRange = 10;
+        this.apRangeCalled = false;
+
+        // less packets out thanks to me :-)
+        if (target instanceof Player) {
+            const pid: number = target.pid + 32768;
+            if (this.faceEntity !== pid) {
+                this.faceEntity = pid;
+                this.mask |= this.faceentity;
+            }
+        } else if (target instanceof Npc) {
+            const nid: number = target.nid;
+            if (this.faceEntity !== nid) {
+                this.faceEntity = nid;
+                this.mask |= this.faceentity;
+            }
+        } else {
+            const faceX: number = target.x * 2 + target.width;
+            const faceZ: number = target.z * 2 + target.length;
+            if (this.faceX !== faceX || this.faceZ !== faceZ) {
+                this.faceX = faceX;
+                this.faceZ = faceZ;
+                this.mask |= this.facecoord;
+            }
+        }
+        if (interaction === Interaction.SCRIPT) {
+            this.pathToTarget();
+        }
+    }
+
+    clearInteraction(): void {
+        this.target = null;
+        this.targetOp = -1;
+        this.targetSubject = {type: -1, com: -1};
+        this.apRange = 10;
+        this.apRangeCalled = false;
+        this.alreadyFacedCoord = true;
+        this.alreadyFacedEntity = true;
+    }
+
+    protected getCollisionStrategy(): CollisionType | null {
+        if (this.moveRestrict === MoveRestrict.NORMAL) {
+            return CollisionType.NORMAL;
+        } else if (this.moveRestrict === MoveRestrict.BLOCKED) {
+            return CollisionType.BLOCKED;
+        } else if (this.moveRestrict === MoveRestrict.BLOCKED_NORMAL) {
+            return CollisionType.LINE_OF_SIGHT;
+        } else if (this.moveRestrict === MoveRestrict.INDOORS) {
+            return CollisionType.INDOORS;
+        } else if (this.moveRestrict === MoveRestrict.OUTDOORS) {
+            return CollisionType.OUTDOORS;
+        } else if (this.moveRestrict === MoveRestrict.NOMOVE) {
+            return null;
+        } else if (this.moveRestrict === MoveRestrict.PASSTHRU) {
+            return CollisionType.NORMAL;
+        }
+        return null;
+    }
+
+    protected resetPathingEntity(): void {
         this.moveSpeed = this.defaultMoveSpeed();
         this.walkDir = -1;
         this.runDir = -1;
         this.jump = false;
         this.lastX = this.x;
         this.lastZ = this.z;
+
+        if (this.alreadyFacedCoord && this.faceX !== -1 && !this.hasWaypoints()) {
+            this.faceX = -1;
+            this.faceZ = -1;
+            this.alreadyFacedCoord = false;
+        } else if (this.alreadyFacedEntity && !this.target) {
+            this.mask |= this.faceentity;
+            this.faceEntity = -1;
+            this.alreadyFacedEntity = false;
+        }
+
+        this.mask = 0;
         this.exactStartX = -1;
         this.exactStartZ = -1;
         this.exactEndX = -1;
@@ -336,6 +473,16 @@ export default abstract class PathingEntity extends Entity {
         this.exactMoveStart = -1;
         this.exactMoveEnd = -1;
         this.exactMoveDirection = -1;
+        this.animId = -1;
+        this.animDelay = -1;
+        this.animId = -1;
+        this.animDelay = -1;
+        this.chat = null;
+        this.damageTaken = -1;
+        this.damageType = -1;
+        this.graphicId = -1;
+        this.graphicHeight = -1;
+        this.graphicDelay = -1;
     }
 
     private takeStep(): number | null {

--- a/src/lostcity/network/225/incoming/handler/MoveClickHandler.ts
+++ b/src/lostcity/network/225/incoming/handler/MoveClickHandler.ts
@@ -7,6 +7,13 @@ import VarPlayerType from '#lostcity/cache/VarPlayerType.js';
 
 export default class MoveClickHandler extends MessageHandler<MoveClick> {
     handle(message: MoveClick, player: NetworkPlayer): boolean {
+        const start = message.path[0];
+        if (player.delayed() || message.ctrlHeld < 0 || message.ctrlHeld > 1 || Position.distanceToSW(player, { x: start.x, z: start.z }) > 104) {
+            player.unsetMapFlag();
+            player.userPath = [];
+            return false;
+        }
+
         if (Environment.CLIENT_PATHFINDER) {
             player.userPath = [];
 
@@ -16,13 +23,6 @@ export default class MoveClickHandler extends MessageHandler<MoveClick> {
         } else {
             const dest = message.path[message.path.length - 1];
             player.userPath = [Position.packCoord(player.level, dest.x, dest.z)];
-        }
-
-        const start = message.path[0];
-        if (player.delayed() || message.ctrlHeld < 0 || message.ctrlHeld > 1 || Position.distanceToSW(player, { x: start.x, z: start.z }) > 104) {
-            player.unsetMapFlag();
-            player.userPath = [];
-            return false;
         }
 
         if (!message.opClick) {

--- a/src/lostcity/network/225/incoming/handler/OpLocHandler.ts
+++ b/src/lostcity/network/225/incoming/handler/OpLocHandler.ts
@@ -10,6 +10,11 @@ export default class OpLocHandler extends MessageHandler<OpLoc> {
     handle(message: OpLoc, player: NetworkPlayer): boolean {
         const { x, z, loc: locId } = message;
 
+        if (player.delayed()) {
+            player.unsetMapFlag();
+            return false;
+        }
+
         const absLeftX = player.loadedX - 52;
         const absRightX = player.loadedX + 52;
         const absTopZ = player.loadedZ + 52;
@@ -42,6 +47,8 @@ export default class OpLocHandler extends MessageHandler<OpLoc> {
             mode = ServerTriggerType.APLOC5;
         }
 
+        player.clearInteraction();
+        player.closeModal();
         player.setInteraction(Interaction.ENGINE, loc, mode);
         player.opcalled = true;
         return true;

--- a/src/lostcity/network/225/incoming/handler/OpLocTHandler.ts
+++ b/src/lostcity/network/225/incoming/handler/OpLocTHandler.ts
@@ -10,6 +10,11 @@ export default class OpLocTHandler extends MessageHandler<OpLocT> {
     handle(message: OpLocT, player: NetworkPlayer): boolean {
         const { x, z, loc: locId, spellComponent: spellComId } = message;
 
+        if (player.delayed()) {
+            player.unsetMapFlag();
+            return false;
+        }
+
         const spellCom = Component.get(spellComId);
         if (typeof spellCom === 'undefined' || !player.isComponentVisible(spellCom)) {
             return false;
@@ -25,10 +30,6 @@ export default class OpLocTHandler extends MessageHandler<OpLocT> {
 
         const loc = World.getLoc(x, z, player.level, locId);
         if (!loc) {
-            return false;
-        }
-
-        if (player.delayed()) {
             return false;
         }
 

--- a/src/lostcity/network/225/incoming/handler/OpLocUHandler.ts
+++ b/src/lostcity/network/225/incoming/handler/OpLocUHandler.ts
@@ -11,6 +11,11 @@ export default class OpLocUHandler extends MessageHandler<OpLocU> {
     handle(message: OpLocU, player: NetworkPlayer): boolean {
         const { x, z, loc: locId, useObj: item, useSlot: slot, useComponent: comId } = message;
 
+        if (player.delayed()) {
+            player.unsetMapFlag();
+            return false;
+        }
+
         const com = Component.get(comId);
         if (typeof com === 'undefined' || !player.isComponentVisible(com)) {
             return false;
@@ -36,10 +41,6 @@ export default class OpLocUHandler extends MessageHandler<OpLocU> {
 
         const loc = World.getLoc(x, z, player.level, locId);
         if (!loc) {
-            return false;
-        }
-
-        if (player.delayed()) {
             return false;
         }
 

--- a/src/lostcity/network/225/incoming/handler/OpNpcHandler.ts
+++ b/src/lostcity/network/225/incoming/handler/OpNpcHandler.ts
@@ -10,6 +10,11 @@ export default class OpNpcHandler extends MessageHandler<OpNpc> {
     handle(message: OpNpc, player: NetworkPlayer): boolean {
         const { nid } = message;
 
+        if (player.delayed()) {
+            player.unsetMapFlag();
+            return false;
+        }
+
         const npc = World.getNpc(nid);
         if (!npc || npc.delayed()) {
             player.unsetMapFlag();
@@ -38,6 +43,8 @@ export default class OpNpcHandler extends MessageHandler<OpNpc> {
             mode = ServerTriggerType.APNPC5;
         }
 
+        player.clearInteraction();
+        player.closeModal();
         player.setInteraction(Interaction.ENGINE, npc, mode, { type: npc.type, com: -1 });
         player.opcalled = true;
         return true;

--- a/src/lostcity/network/225/incoming/handler/OpNpcTHandler.ts
+++ b/src/lostcity/network/225/incoming/handler/OpNpcTHandler.ts
@@ -10,6 +10,11 @@ export default class OpNpcTHandler extends MessageHandler<OpNpcT> {
     handle(message: OpNpcT, player: NetworkPlayer): boolean {
         const { nid, spellComponent: spellComId } = message;
 
+        if (player.delayed()) {
+            player.unsetMapFlag();
+            return false;
+        }
+
         const spellCom = Component.get(spellComId);
         if (typeof spellCom === 'undefined' || !player.isComponentVisible(spellCom)) {
             return false;
@@ -21,10 +26,6 @@ export default class OpNpcTHandler extends MessageHandler<OpNpcT> {
         }
 
         if (!player.npcs.has(npc.nid)) {
-            return false;
-        }
-
-        if (player.delayed()) {
             return false;
         }
 

--- a/src/lostcity/network/225/incoming/handler/OpNpcUHandler.ts
+++ b/src/lostcity/network/225/incoming/handler/OpNpcUHandler.ts
@@ -11,6 +11,11 @@ export default class OpNpcUHandler extends MessageHandler<OpNpcU> {
     handle(message: OpNpcU, player: NetworkPlayer): boolean {
         const { nid, useObj: item, useSlot: slot, useComponent: comId } = message;
 
+        if (player.delayed()) {
+            player.unsetMapFlag();
+            return false;
+        }
+
         const com = Component.get(comId);
         if (typeof com === 'undefined' || !player.isComponentVisible(com)) {
             return false;
@@ -32,10 +37,6 @@ export default class OpNpcUHandler extends MessageHandler<OpNpcU> {
         }
 
         if (!player.npcs.has(npc.nid)) {
-            return false;
-        }
-
-        if (player.delayed()) {
             return false;
         }
 

--- a/src/lostcity/network/225/incoming/handler/OpObjHandler.ts
+++ b/src/lostcity/network/225/incoming/handler/OpObjHandler.ts
@@ -10,6 +10,11 @@ export default class OpObjHandler extends MessageHandler<OpObj> {
     handle(message: OpObj, player: NetworkPlayer): boolean {
         const { x, z, obj: objId } = message;
 
+        if (player.delayed()) {
+            player.unsetMapFlag();
+            return false;
+        }
+
         const absLeftX = player.loadedX - 52;
         const absRightX = player.loadedX + 52;
         const absTopZ = player.loadedZ + 52;
@@ -43,6 +48,8 @@ export default class OpObjHandler extends MessageHandler<OpObj> {
             mode = ServerTriggerType.APOBJ5;
         }
 
+        player.clearInteraction();
+        player.closeModal();
         player.setInteraction(Interaction.ENGINE, obj, mode);
         player.opcalled = true;
         return true;

--- a/src/lostcity/network/225/incoming/handler/OpObjTHandler.ts
+++ b/src/lostcity/network/225/incoming/handler/OpObjTHandler.ts
@@ -10,6 +10,11 @@ export default class OpObjTHandler extends MessageHandler<OpObjT> {
     handle(message: OpObjT, player: NetworkPlayer): boolean {
         const { x, z, obj: objId, spellComponent: spellComId } = message;
 
+        if (player.delayed()) {
+            player.unsetMapFlag();
+            return false;
+        }
+
         const spellCom = Component.get(spellComId);
         if (typeof spellCom === 'undefined' || !player.isComponentVisible(spellCom)) {
             return false;
@@ -25,10 +30,6 @@ export default class OpObjTHandler extends MessageHandler<OpObjT> {
 
         const obj = World.getObj(x, z, player.level, objId);
         if (!obj) {
-            return false;
-        }
-
-        if (player.delayed()) {
             return false;
         }
 

--- a/src/lostcity/network/225/incoming/handler/OpObjUHandler.ts
+++ b/src/lostcity/network/225/incoming/handler/OpObjUHandler.ts
@@ -11,6 +11,11 @@ export default class OpObjUHandler extends MessageHandler<OpObjU> {
     handle(message: OpObjU, player: NetworkPlayer): boolean {
         const { x, z, obj: objId, useObj: item, useSlot: slot, useComponent: comId } = message;
 
+        if (player.delayed()) {
+            player.unsetMapFlag();
+            return false;
+        }
+
         const com = Component.get(comId);
         if (typeof com === 'undefined' || !player.isComponentVisible(com)) {
             return false;
@@ -36,10 +41,6 @@ export default class OpObjUHandler extends MessageHandler<OpObjU> {
 
         const obj = World.getObj(x, z, player.level, objId);
         if (!obj) {
-            return false;
-        }
-
-        if (player.delayed()) {
             return false;
         }
 

--- a/src/lostcity/network/225/incoming/handler/OpPlayerHandler.ts
+++ b/src/lostcity/network/225/incoming/handler/OpPlayerHandler.ts
@@ -9,6 +9,11 @@ export default class OpPlayerHandler extends MessageHandler<OpPlayer> {
     handle(message: OpPlayer, player: NetworkPlayer): boolean {
         const { pid } = message;
 
+        if (player.delayed()) {
+            player.unsetMapFlag();
+            return false;
+        }
+
         const other = World.getPlayer(pid);
         if (!other) {
             return false;
@@ -29,6 +34,8 @@ export default class OpPlayerHandler extends MessageHandler<OpPlayer> {
             mode = ServerTriggerType.APPLAYER4;
         }
 
+        player.clearInteraction();
+        player.closeModal();
         player.setInteraction(Interaction.ENGINE, other, mode);
         player.opcalled = true;
         return true;

--- a/src/lostcity/network/225/incoming/handler/OpPlayerTHandler.ts
+++ b/src/lostcity/network/225/incoming/handler/OpPlayerTHandler.ts
@@ -10,6 +10,11 @@ export default class OpPlayerTHandler extends MessageHandler<OpPlayerT> {
     handle(message: OpPlayerT, player: NetworkPlayer): boolean {
         const { pid, spellComponent: spellComId } = message;
 
+        if (player.delayed()) {
+            player.unsetMapFlag();
+            return false;
+        }
+
         const spellCom = Component.get(spellComId);
         if (typeof spellCom === 'undefined' || !player.isComponentVisible(spellCom)) {
             return false;
@@ -21,10 +26,6 @@ export default class OpPlayerTHandler extends MessageHandler<OpPlayerT> {
         }
 
         if (!player.players.has(other.uid)) {
-            return false;
-        }
-
-        if (player.delayed()) {
             return false;
         }
 

--- a/src/lostcity/network/225/incoming/handler/OpPlayerUHandler.ts
+++ b/src/lostcity/network/225/incoming/handler/OpPlayerUHandler.ts
@@ -11,6 +11,11 @@ export default class OpPlayerUHandler extends MessageHandler<OpPlayerU> {
     handle(message: OpPlayerU, player: NetworkPlayer): boolean {
         const { pid, useObj: item, useSlot: slot, useComponent: comId } = message;
 
+        if (player.delayed()) {
+            player.unsetMapFlag();
+            return false;
+        }
+
         const com = Component.get(comId);
         if (typeof com === 'undefined' || !player.isComponentVisible(com)) {
             return false;
@@ -32,10 +37,6 @@ export default class OpPlayerUHandler extends MessageHandler<OpPlayerU> {
         }
 
         if (!player.players.has(player.uid)) {
-            return false;
-        }
-
-        if (player.delayed()) {
             return false;
         }
 

--- a/src/lostcity/tools/packconfig/HuntConfig.ts
+++ b/src/lostcity/tools/packconfig/HuntConfig.ts
@@ -136,69 +136,128 @@ export function parseHuntConfig(key: string, value: string): ConfigValue | null 
                 return null;
         }
     } else if (key === 'find_newmode') {
-        switch (value) {
-            case 'opplayer1':
-                return NpcMode.OPPLAYER1;
-            case 'opplayer2':
-                return NpcMode.OPPLAYER2;
-            case 'opplayer3':
-                return NpcMode.OPPLAYER3;
-            case 'opplayer4':
-                return NpcMode.OPPLAYER4;
-            case 'opplayer5':
-                return NpcMode.OPPLAYER5;
-            case 'applayer1':
-                return NpcMode.APPLAYER1;
-            case 'applayer2':
-                return NpcMode.APPLAYER2;
-            case 'applayer3':
-                return NpcMode.APPLAYER3;
-            case 'applayer4':
-                return NpcMode.APPLAYER4;
-            case 'applayer5':
-                return NpcMode.APPLAYER5;
-            case 'queue1':
-                return NpcMode.QUEUE1;
-            case 'queue2':
-                return NpcMode.QUEUE2;
-            case 'queue3':
-                return NpcMode.QUEUE3;
-            case 'queue4':
-                return NpcMode.QUEUE4;
-            case 'queue5':
-                return NpcMode.QUEUE5;
-            case 'queue6':
-                return NpcMode.QUEUE6;
-            case 'queue7':
-                return NpcMode.QUEUE7;
-            case 'queue8':
-                return NpcMode.QUEUE8;
-            case 'queue9':
-                return NpcMode.QUEUE9;
-            case 'queue10':
-                return NpcMode.QUEUE10;
-            case 'queue11':
-                return NpcMode.QUEUE11;
-            case 'queue12':
-                return NpcMode.QUEUE12;
-            case 'queue13':
-                return NpcMode.QUEUE13;
-            case 'queue14':
-                return NpcMode.QUEUE14;
-            case 'queue15':
-                return NpcMode.QUEUE15;
-            case 'queue16':
-                return NpcMode.QUEUE16;
-            case 'queue17':
-                return NpcMode.QUEUE17;
-            case 'queue18':
-                return NpcMode.QUEUE18;
-            case 'queue19':
-                return NpcMode.QUEUE19;
-            case 'queue20':
-                return NpcMode.QUEUE20;
-            default:
-                return null;
+        if (value === 'opplayer1') {
+            return NpcMode.OPPLAYER1;
+        } else if (value === 'opplayer2') {
+            return NpcMode.OPPLAYER2;
+        } else if (value === 'opplayer3') {
+            return NpcMode.OPPLAYER3;
+        } else if (value === 'opplayer4') {
+            return NpcMode.OPPLAYER4;
+        } else if (value === 'opplayer5') {
+            return NpcMode.OPPLAYER5;
+        } else if (value === 'applayer1') {
+            return NpcMode.APPLAYER1;
+        } else if (value === 'applayer2') {
+            return NpcMode.APPLAYER2;
+        } else if (value === 'applayer3') {
+            return NpcMode.APPLAYER3;
+        } else if (value === 'applayer4') {
+            return NpcMode.APPLAYER4;
+        } else if (value === 'applayer5') {
+            return NpcMode.APPLAYER5;
+        } else if (value === 'queue1') {
+            return NpcMode.QUEUE1;
+        } else if (value === 'queue2') {
+            return NpcMode.QUEUE2;
+        } else if (value === 'queue3') {
+            return NpcMode.QUEUE3;
+        } else if (value === 'queue4') {
+            return NpcMode.QUEUE4;
+        } else if (value === 'queue5') {
+            return NpcMode.QUEUE5;
+        } else if (value === 'queue6') {
+            return NpcMode.QUEUE6;
+        } else if (value === 'queue7') {
+            return NpcMode.QUEUE7;
+        } else if (value === 'queue8') {
+            return NpcMode.QUEUE8;
+        } else if (value === 'queue9') {
+            return NpcMode.QUEUE9;
+        } else if (value === 'queue10') {
+            return NpcMode.QUEUE10;
+        } else if (value === 'queue11') {
+            return NpcMode.QUEUE11;
+        } else if (value === 'queue12') {
+            return NpcMode.QUEUE12;
+        } else if (value === 'queue13') {
+            return NpcMode.QUEUE13;
+        } else if (value === 'queue14') {
+            return NpcMode.QUEUE14;
+        } else if (value === 'queue15') {
+            return NpcMode.QUEUE15;
+        } else if (value === 'queue16') {
+            return NpcMode.QUEUE16;
+        } else if (value === 'queue17') {
+            return NpcMode.QUEUE17;
+        } else if (value === 'queue18') {
+            return NpcMode.QUEUE18;
+        } else if (value === 'queue19') {
+            return NpcMode.QUEUE19;
+        } else if (value === 'queue20') {
+            return NpcMode.QUEUE20;
+        } else if (value === 'opobj1') {
+            return NpcMode.OPOBJ1;
+        } else if (value === 'opobj2') {
+            return NpcMode.OPOBJ1;
+        } else if (value === 'opobj3') {
+            return NpcMode.OPOBJ3;
+        } else if (value === 'opobj4') {
+            return NpcMode.OPOBJ4;
+        } else if (value === 'opobj5') {
+            return NpcMode.OPOBJ5;
+        } else if (value === 'apobj1') {
+            return NpcMode.APOBJ1;
+        } else if (value === 'apobj2') {
+            return NpcMode.APOBJ2;
+        } else if (value === 'apobj3') {
+            return NpcMode.APOBJ3;
+        } else if (value === 'apobj4') {
+            return NpcMode.APOBJ4;
+        } else if (value === 'apobj5') {
+            return NpcMode.APOBJ5;
+        } else if (value === 'opnpc1') {
+            return NpcMode.OPNPC1;
+        } else if (value === 'opnpc2') {
+            return NpcMode.OPNPC2;
+        } else if (value === 'opnpc3') {
+            return NpcMode.OPNPC3;
+        } else if (value === 'opnpc4') {
+            return NpcMode.OPNPC4;
+        } else if (value === 'opnpc5') {
+            return NpcMode.OPNPC5;
+        } else if (value === 'apnpc1') {
+            return NpcMode.APNPC1;
+        } else if (value === 'apnpc2') {
+            return NpcMode.APNPC2;
+        } else if (value === 'apnpc3') {
+            return NpcMode.APNPC3;
+        } else if (value === 'apnpc4') {
+            return NpcMode.APNPC4;
+        } else if (value === 'apnpc5') {
+            return NpcMode.APNPC5;
+        } else if (value === 'oploc1') {
+            return NpcMode.OPLOC1;
+        } else if (value === 'oploc2') {
+            return NpcMode.OPLOC2;
+        } else if (value === 'oploc3') {
+            return NpcMode.OPLOC3;
+        } else if (value === 'oploc4') {
+            return NpcMode.OPLOC4;
+        } else if (value === 'oploc5') {
+            return NpcMode.OPLOC5;
+        } else if (value === 'aploc1') {
+            return NpcMode.APLOC1;
+        } else if (value === 'aploc2') {
+            return NpcMode.APLOC2;
+        } else if (value === 'aploc3') {
+            return NpcMode.APLOC3;
+        } else if (value === 'aploc4') {
+            return NpcMode.APLOC4;
+        } else if (value === 'aploc5') {
+            return NpcMode.APLOC5;
+        } else {
+            return null;
         }
     } else if (key === 'nobodynear') {
         switch (value) {


### PR DESCRIPTION
- All of the `op` packets all do the same thing now.
- Npc `aimode` now operates similarly to the player version where it attempts to interact more than once.
- Consolidated similar parts of interacting code into `PathingEntity`.
- Npcs can now target and also hunt different types of targets.
- No more `FaceEntity` and `FaceCoord` every tick.
- `HuntConfig` now packs all of the possible `NpcModes`