### PR TITLE
fix(content): fixed placing items on tables being broken

### DIFF
--- a/data/src/scripts/engine.rs2
+++ b/data/src/scripts/engine.rs2
@@ -299,6 +299,8 @@
 [command,lc_category](loc $loc)(category)
 [command,lc_desc](loc $loc)(string)
 [command,lc_debugname](loc $loc)(string)
+[command,lc_width](loc $loc)(int)
+[command,lc_length](loc $loc)(int)
 
 // Obj config ops (4200-4299)
 [command,oc_name](obj $obj)(string)

--- a/data/src/scripts/general_use/configs/tables.loc
+++ b/data/src/scripts/general_use/configs/tables.loc
@@ -176,6 +176,7 @@ model=model_loc_611
 width=2
 length=2
 blockrange=no
+category=unusable_table
 
 [loc_612]
 name=Counter

--- a/data/src/scripts/general_use/configs/tables.loc
+++ b/data/src/scripts/general_use/configs/tables.loc
@@ -176,7 +176,6 @@ model=model_loc_611
 width=2
 length=2
 blockrange=no
-category=usable_table
 
 [loc_612]
 name=Counter

--- a/data/src/scripts/general_use/scripts/tables.rs2
+++ b/data/src/scripts/general_use/scripts/tables.rs2
@@ -4,7 +4,6 @@ sound_synth(put_down, 0, 0);
 
 def_coord $obj_coord = loc_coord;
 
-// todo: lc command for length/width?
 def_int $width = lc_width(loc_type);
 def_int $length = lc_length(loc_type);
 

--- a/data/src/scripts/general_use/scripts/tables.rs2
+++ b/data/src/scripts/general_use/scripts/tables.rs2
@@ -1,5 +1,3 @@
-
-
 [oplocu,_usable_table]
 anim(human_pickuptable, 0);
 sound_synth(put_down, 0, 0);
@@ -7,8 +5,8 @@ sound_synth(put_down, 0, 0);
 def_coord $obj_coord = loc_coord;
 
 // todo: lc command for length/width?
-def_int $width = 1;
-def_int $length = 1;
+def_int $width = lc_width(loc_type);
+def_int $length = lc_length(loc_type);
 
 def_int $x = calc(coordx(loc_coord) - coordx(coord));
 def_int $z = calc(coordz(loc_coord) - coordz(coord));
@@ -26,7 +24,3 @@ inv_dropslot(inv, $obj_coord, last_useslot, 1000);
 
 [oplocu,_unusable_table]
 mes("The table appears to be in use.");
-
-
-
-

--- a/src/lostcity/engine/script/ScriptOpcode.ts
+++ b/src/lostcity/engine/script/ScriptOpcode.ts
@@ -264,6 +264,8 @@ enum ScriptOpcode {
     LC_NAME,
     LC_OP,
     LC_PARAM,
+    LC_WIDTH,
+    LC_LENGTH,
 
     // Obj config ops (4200-4299)
     OC_CATEGORY = 4200, // official

--- a/src/lostcity/engine/script/handlers/LocConfigOps.ts
+++ b/src/lostcity/engine/script/handlers/LocConfigOps.ts
@@ -46,6 +46,20 @@ const LocConfigOps: CommandHandlers = {
 
         const locType = LocType.get(locId);
         state.pushString(locType.debugname ?? 'null');
+    },
+
+    [ScriptOpcode.LC_WIDTH]: state => {
+        const locId = check(state.popInt(), LocTypeValid);
+
+        const locType = LocType.get(locId);
+        state.pushInt(locType.width ?? 0);
+    },
+
+    [ScriptOpcode.LC_LENGTH]: state => {
+        const locId = check(state.popInt(), LocTypeValid);
+
+        const locType = LocType.get(locId);
+        state.pushInt(locType.length ?? 0);
     }
 };
 


### PR DESCRIPTION
sometimes items would drop on the wrong square
- adds lc_width and lc_length commands
- removes ability to put items on picnic tables