### PR TITLE
refactor(engine): cleanup script validators and handlers

### DIFF
--- a/src/lostcity/cache/DbRowType.ts
+++ b/src/lostcity/cache/DbRowType.ts
@@ -51,6 +51,10 @@ export default class DbRowType extends ConfigType {
         return this.get(id);
     }
 
+    static get count() {
+        return this.configs.length;
+    }
+
     static getInTable(tableId: number): DbRowType[] {
         return DbRowType.configs.filter(config => config.tableId === tableId);
     }

--- a/src/lostcity/cache/DbTableType.ts
+++ b/src/lostcity/cache/DbTableType.ts
@@ -50,6 +50,10 @@ export default class DbTableType extends ConfigType {
         return this.get(id);
     }
 
+    static get count() {
+        return this.configs.length;
+    }
+
     // ----
 
     types: number[][] = [];

--- a/src/lostcity/cache/FontType.ts
+++ b/src/lostcity/cache/FontType.ts
@@ -30,6 +30,10 @@ export default class FontType {
         return FontType.instances[id];
     }
 
+    static get count() {
+        return this.instances.length;
+    }
+
     // ----
 
     charMask: Uint8Array[] = new Array(94);

--- a/src/lostcity/cache/MesanimType.ts
+++ b/src/lostcity/cache/MesanimType.ts
@@ -49,6 +49,10 @@ export default class MesanimType extends ConfigType {
         return this.get(id);
     }
 
+    static get count() {
+        return this.configs.length;
+    }
+
     // ----
 
     len: number[] = new Array(4).fill(-1);

--- a/src/lostcity/cache/StructType.ts
+++ b/src/lostcity/cache/StructType.ts
@@ -50,6 +50,10 @@ export default class StructType extends ConfigType implements ParamHolder {
         return this.get(id);
     }
 
+    static get count() {
+        return this.configs.length;
+    }
+
     // ----
 
     params: ParamMap | null = null;

--- a/src/lostcity/cache/VarNpcType.ts
+++ b/src/lostcity/cache/VarNpcType.ts
@@ -51,7 +51,7 @@ export default class VarNpcType extends ConfigType {
     }
 
     static get count() {
-        return VarNpcType.configs.length;
+        return this.configs.length;
     }
 
     // ----

--- a/src/lostcity/cache/VarPlayerType.ts
+++ b/src/lostcity/cache/VarPlayerType.ts
@@ -69,7 +69,7 @@ export default class VarPlayerType extends ConfigType {
     }
 
     static get count() {
-        return VarPlayerType.configs.length;
+        return this.configs.length;
     }
 
     // ----

--- a/src/lostcity/cache/VarSharedType.ts
+++ b/src/lostcity/cache/VarSharedType.ts
@@ -49,7 +49,7 @@ export default class VarSharedType extends ConfigType {
     }
 
     static get count() {
-        return VarSharedType.configs.length;
+        return this.configs.length;
     }
 
     // ----

--- a/src/lostcity/engine/script/ScriptValidators.ts
+++ b/src/lostcity/engine/script/ScriptValidators.ts
@@ -11,158 +11,114 @@ import InvType from '#lostcity/cache/InvType.js';
 import CategoryType from '#lostcity/cache/CategoryType.js';
 import IdkType from '#lostcity/cache/IdkType.js';
 import HuntVis from '#lostcity/entity/hunt/HuntVis.js';
+import {LocAngle, LocShape} from '@2004scape/rsmod-pathfinder';
+import {Position} from '#lostcity/entity/Position.js';
+import {ConfigType} from '#lostcity/cache/ConfigType.js';
+import SeqType from '#lostcity/cache/SeqType.js';
+import VarPlayerType from '#lostcity/cache/VarPlayerType.js';
+import VarNpcType from '#lostcity/cache/VarNpcType.js';
+import VarSharedType from '#lostcity/cache/VarSharedType.js';
+import FontType from '#lostcity/cache/FontType.js';
+import MesanimType from '#lostcity/cache/MesanimType.js';
+import StructType from '#lostcity/cache/StructType.js';
+import DbRowType from '#lostcity/cache/DbRowType.js';
+import DbTableType from '#lostcity/cache/DbTableType.js';
 
-interface ScriptValidator<T> {
-    condition(input: T): boolean;
-    throwMessage(): string;
+interface ScriptValidator<T, R> {
+    validate(input: T): R;
 }
 
-class ScriptInputNumberNotNullValidator implements ScriptValidator<number> {
-    condition = (input: number): boolean => input !== -1;
-    throwMessage = (): string => 'An input number was null(-1).';
-}
-
-class ScriptInputStringNotNullValidator implements ScriptValidator<string> {
-    condition = (input: string): boolean => input.length > 0;
-    throwMessage = (): string => 'An input number was null(-1).';
-}
-
-class ScriptInputLocTypeValidator implements ScriptValidator<number> {
-    condition = (input: number): boolean => input >= 0 && input < LocType.count;
-    throwMessage = (): string => 'An input for a Loc type was not in a valid range which it is impossible to spawn a null Loc noob!';
-}
-
-class ScriptInputLocAngleValidator implements ScriptValidator<number> {
-    condition = (input: number): boolean => input >= 0 && input <= 3;
-    throwMessage = (): string => 'An input for a Loc angle was out of range. Range should be: 0 to 3.';
-}
-
-class ScriptInputLocShapeValidator implements ScriptValidator<number> {
-    condition = (input: number): boolean => input >= 0 && input <= 31;
-    throwMessage = (): string => 'An input for a Loc shape was out of range. Range should be: 0 to 31.';
-}
-
-class ScriptInputDurationValidator implements ScriptValidator<number> {
-    condition = (input: number): boolean => input > 0;
-    throwMessage = (): string => 'An input duration was out of range. Range should be greater than 0.';
-}
-
-class ScriptInputCoordValidator implements ScriptValidator<number> {
-    condition = (input: number): boolean => input >= 0 && input <= 0x3ffffffffff;
-    throwMessage = (): string => 'An input coord was out of range. Range should be: 0 to 4398046511103';
-}
-
-class ScriptInputParamTypeValidator implements ScriptValidator<number> {
-    condition = (input: number): boolean => input >= 0 && input < ParamType.count;
-    throwMessage = (): string => 'An input for a Param type was not in a valid range.';
-}
-
-class ScriptInputNpcTypeValidator implements ScriptValidator<number> {
-    condition = (input: number): boolean => input >= 0 && input < NpcType.count;
-    throwMessage = (): string => 'An input for a Npc type was not in a valid range.';
-}
-
-class ScriptInputNpcStatValidator implements ScriptValidator<number> {
-    condition = (input: number): boolean => input >= 0 && input < 6;
-    throwMessage = (): string => 'An input for a Npc stat was not in a valid range. Range should be: 0 to 5';
-}
-
-class ScriptInputQueueValidator implements ScriptValidator<number> {
-    condition = (input: number): boolean => input >= 0 && input < 20;
-    throwMessage = (): string => 'An input for an ai_queue was not in a valid range. Range should be: 0 to 19';
-}
-
-class ScriptInputHuntTypeValidator implements ScriptValidator<number> {
-    condition = (input: number): boolean => input >= 0 && input < HuntType.count;
-    throwMessage = (): string => 'An input for a Hunt type was not in a valid range.';
-}
-
-class ScriptInputNpcModeValidator implements ScriptValidator<number> {
-    condition = (input: number): boolean => input >= -1 && input <= NpcMode.APNPC5;
-    throwMessage = (): string => `An input for a Npc mode was not in a valid range. Range should be -1 to ${NpcMode.APNPC5}.`;
-}
-
-class ScriptInputHitTypeValidator implements ScriptValidator<number> {
-    condition = (input: number): boolean => input >= 0 && input <= 2;
-    throwMessage = (): string => 'An input for a hit type was not in a valid range. Range should be 0 to 2.';
-}
-
-class ScriptInputSpotAnimTypeValidator implements ScriptValidator<number> {
-    condition = (input: number): boolean => input >= 0 && input < SpotanimType.count;
-    throwMessage = (): string => 'An input for a SpotAnim type was not in a valid range.';
-}
-
-class ScriptInputEnumTypeValidator implements ScriptValidator<number> {
-    condition = (input: number): boolean => input >= 0 && input < EnumType.count;
-    throwMessage = (): string => 'An input for an Enum type was not in a valid range.';
-}
-
-class ScriptInputObjTypeValidator implements ScriptValidator<number> {
-    condition = (input: number): boolean => input >= 0 && input < ObjType.count;
-    throwMessage = (): string => 'An input for an Obj type was not in a valid range.';
-}
-
-class ScriptInputObjCountValidator implements ScriptValidator<number> {
-    condition = (input: number): boolean => input > 0 && input <= Inventory.STACK_LIMIT;
-    throwMessage = (): string => `An input for an Obj count was not in a valid range. Range should be: 1 to ${Inventory.STACK_LIMIT}.`;
-}
-
-class ScriptInputObjNotDummyValidator implements ScriptValidator<number> {
-    condition = (input: number): boolean => ObjType.get(input).dummyitem === 0;
-    throwMessage = (): string => 'An input for an Obj was a graphic_only dummyitem.';
-}
-
-class ScriptInputInvTypeValidator implements ScriptValidator<number> {
-    condition = (input: number): boolean => input >= 0 && input < InvType.count;
-    throwMessage = (): string => 'An input for an Inv type was not in a valid range.';
-}
-
-class ScriptInputCategoryTypeValidator implements ScriptValidator<number> {
-    condition = (input: number): boolean => input >= 0 && input < CategoryType.count;
-    throwMessage = (): string => 'An input for an Category type was not in a valid range.';
-}
-
-class ScriptInputIDKTypeValidator implements ScriptValidator<number> {
-    condition = (input: number): boolean => input >= 0 && input < IdkType.count;
-    throwMessage = (): string => 'An input for an IDK type was not in a valid range.';
-}
-
-class ScriptInputHuntVisValidator implements ScriptValidator<number> {
-    condition = (input: number): boolean => input >= HuntVis.OFF && input <= HuntVis.LINEOFWALK;
-    throwMessage = (): string => `An input for a a hunt vis was not in a valid range. Range should be: ${HuntVis.OFF} to ${HuntVis.LINEOFWALK}.`;
-}
-
-export const NumberNotNull: ScriptValidator<number> = new ScriptInputNumberNotNullValidator();
-export const StringNotNull: ScriptValidator<string> = new ScriptInputStringNotNullValidator();
-export const LocTypeValid: ScriptValidator<number> = new ScriptInputLocTypeValidator();
-export const LocAngleValid: ScriptValidator<number> = new ScriptInputLocAngleValidator();
-export const LocShapeValid: ScriptValidator<number> = new ScriptInputLocShapeValidator();
-export const DurationValid: ScriptValidator<number> = new ScriptInputDurationValidator();
-export const CoordValid: ScriptValidator<number> = new ScriptInputCoordValidator();
-export const ParamTypeValid: ScriptValidator<number> = new ScriptInputParamTypeValidator();
-export const NpcTypeValid: ScriptValidator<number> = new ScriptInputNpcTypeValidator();
-export const NpcStatValid: ScriptValidator<number> = new ScriptInputNpcStatValidator();
-export const QueueValid: ScriptValidator<number> = new ScriptInputQueueValidator();
-export const HuntTypeValid: ScriptValidator<number> = new ScriptInputHuntTypeValidator();
-export const NpcModeValid: ScriptValidator<number> = new ScriptInputNpcModeValidator();
-export const HitTypeValid: ScriptValidator<number> = new ScriptInputHitTypeValidator();
-export const SpotAnimTypeValid: ScriptValidator<number> = new ScriptInputSpotAnimTypeValidator();
-export const EnumTypeValid: ScriptValidator<number> = new ScriptInputEnumTypeValidator();
-export const ObjTypeValid: ScriptValidator<number> = new ScriptInputObjTypeValidator();
-export const ObjStackValid: ScriptValidator<number> = new ScriptInputObjCountValidator();
-export const ObjNotDummyValid: ScriptValidator<number> = new ScriptInputObjNotDummyValidator();
-export const InvTypeValid: ScriptValidator<number> = new ScriptInputInvTypeValidator();
-export const CategoryTypeValid: ScriptValidator<number> = new ScriptInputCategoryTypeValidator();
-export const IDKTypeValid: ScriptValidator<number> = new ScriptInputIDKTypeValidator();
-export const HuntVisValid: ScriptValidator<number> = new ScriptInputHuntVisValidator();
-
-export function check<T>(input: T, ...validators: ScriptValidator<T>[]): T {
-    for (let index: number = 0; index < validators.length; index++) {
-        const validator: ScriptValidator<T> = validators[index];
-        if (!validator.condition(input)) {
-            throw new Error(validator.throwMessage());
-        }
+class ScriptInputNumberNotNullValidator implements ScriptValidator<number, number> {
+    validate(input: number): number {
+        if (input !== -1) return input;
+        throw Error('An input number was null(-1).');
     }
-    return input;
 }
 
+class ScriptInputStringNotNullValidator implements ScriptValidator<string, string> {
+    validate(input: string): string {
+        if (input.length > 0) return input;
+        throw Error('An input string was null(-1).');
+    }
+}
+
+class ScriptInputConfigTypeValidator<T extends ConfigType | FontType> implements ScriptValidator<number, T> {
+    private readonly type: (input: number) => T;
+    private readonly count: (input: number) => boolean;
+    private readonly name: string;
+
+    constructor(type: (input: number) => T, count: (input: number) => boolean, name: string) {
+        this.type = type;
+        this.count = count;
+        this.name = name;
+    }
+
+    validate(input: number): T {
+        if (this.count(input)) return this.type(input);
+        throw new Error(`An input for a ${this.name} type was not valid to use. Input was ${input}.`);
+    }
+}
+
+class ScriptInputRangeValidator<T> implements ScriptValidator<number, T> {
+    protected readonly min: number;
+    protected readonly max: number;
+    protected readonly name: string;
+
+    constructor(min: number, max: number, name: string) {
+        this.min = min;
+        this.max = max;
+        this.name = name;
+    }
+
+    validate(input: number): T {
+        if (input >= this.min && input <= this.max) {
+            return input as T;
+        }
+        throw new Error(`An input for a ${this.name} was out of range. Range should be: ${this.min} to ${this.max}. Input was ${input}.`);
+    }
+}
+
+class ScriptInputCoordValidator extends ScriptInputRangeValidator<Position> {
+    validate(input: number): Position {
+        if (input >= this.min && input <= this.max) {
+            return Position.unpackCoord(input);
+        }
+        throw new Error(`An input for a ${this.name} was out of range. Range should be: ${this.min} to ${this.max}. Input was ${input}.`);
+    }
+}
+
+export const NumberNotNull: ScriptValidator<number, number> = new ScriptInputNumberNotNullValidator();
+export const StringNotNull: ScriptValidator<string, string> = new ScriptInputStringNotNullValidator();
+export const LocTypeValid: ScriptValidator<number, LocType> = new ScriptInputConfigTypeValidator(LocType.get, (input: number) => input >= 0 && input < LocType.count, 'Loc');
+export const LocAngleValid: ScriptValidator<number, LocAngle> = new ScriptInputRangeValidator(LocAngle.WEST, LocAngle.SOUTH, 'LocAngle');
+export const LocShapeValid: ScriptValidator<number, LocShape> = new ScriptInputRangeValidator(LocShape.WALL_STRAIGHT, LocShape.GROUND_DECOR, 'LocShape');
+export const DurationValid: ScriptValidator<number, number> = new ScriptInputRangeValidator(1, 2147483647, 'Duration');
+export const CoordValid: ScriptValidator<number, Position> = new ScriptInputCoordValidator(0, 2147483647, 'Coord');
+export const ParamTypeValid: ScriptValidator<number, ParamType> = new ScriptInputConfigTypeValidator(ParamType.get, (input: number) => input >= 0 && input < ParamType.count, 'Param');
+export const NpcTypeValid: ScriptValidator<number, NpcType> = new ScriptInputConfigTypeValidator(NpcType.get, (input: number) => input >= 0 && input < NpcType.count, 'Npc');
+export const NpcStatValid: ScriptValidator<number, number> = new ScriptInputRangeValidator(0, 6, 'NpcStat');
+export const QueueValid: ScriptValidator<number, number> = new ScriptInputRangeValidator(0, 19, 'AIQueue');
+export const HuntTypeValid: ScriptValidator<number, HuntType> = new ScriptInputConfigTypeValidator(HuntType.get, (input: number) => input >= 0 && input < HuntType.count, 'Hunt');
+export const NpcModeValid: ScriptValidator<number, number> = new ScriptInputRangeValidator(NpcMode.NULL, NpcMode.APNPC5, 'NpcMode');
+export const HitTypeValid: ScriptValidator<number, number> = new ScriptInputRangeValidator(0, 2, 'Hit');
+export const SpotAnimTypeValid: ScriptValidator<number, SpotanimType> = new ScriptInputConfigTypeValidator(SpotanimType.get, (input: number) => input >= 0 && input < SpotanimType.count, 'Spotanim');
+export const EnumTypeValid: ScriptValidator<number, EnumType> = new ScriptInputConfigTypeValidator(EnumType.get, (input: number) => input >= 0 && input < EnumType.count, 'Enum');
+export const ObjTypeValid: ScriptValidator<number, ObjType> = new ScriptInputConfigTypeValidator(ObjType.get, (input: number) => input >= 0 && input < ObjType.count, 'Obj');
+export const ObjStackValid: ScriptValidator<number, number> = new ScriptInputRangeValidator(1, Inventory.STACK_LIMIT, 'ObjStack');
+export const InvTypeValid: ScriptValidator<number, InvType> = new ScriptInputConfigTypeValidator(InvType.get, (input: number) => input >= 0 && input < InvType.count, 'Inv');
+export const CategoryTypeValid: ScriptValidator<number, CategoryType> = new ScriptInputConfigTypeValidator(CategoryType.get, (input: number) => input >= 0 && input < CategoryType.count, 'Cat');
+export const IDKTypeValid: ScriptValidator<number, IdkType> = new ScriptInputConfigTypeValidator(IdkType.get, (input: number) => input >= 0 && input < IdkType.count, 'Idk');
+export const HuntVisValid: ScriptValidator<number, HuntVis> = new ScriptInputRangeValidator(HuntVis.OFF, HuntVis.LINEOFWALK, 'HuntVis');
+export const SeqTypeValid: ScriptValidator<number, SeqType> = new ScriptInputConfigTypeValidator(SeqType.get, (input: number) => input >= 0 && input < SeqType.count, 'Seq');
+export const VarPlayerValid: ScriptValidator<number, VarPlayerType> = new ScriptInputConfigTypeValidator(VarPlayerType.get, (input: number) => input >= 0 && input < VarPlayerType.count, 'Varp');
+export const VarNpcValid: ScriptValidator<number, VarNpcType> = new ScriptInputConfigTypeValidator(VarNpcType.get, (input: number) => input >= 0 && input < VarNpcType.count, 'Varn');
+export const VarSharedValid: ScriptValidator<number, VarSharedType> = new ScriptInputConfigTypeValidator(VarSharedType.get, (input: number) => input >= 0 && input < VarSharedType.count, 'Vars');
+export const FontTypeValid: ScriptValidator<number, FontType> = new ScriptInputConfigTypeValidator(FontType.get, (input: number) => input >= 0 && input < FontType.count, 'Font');
+export const MesanimValid: ScriptValidator<number, MesanimType> = new ScriptInputConfigTypeValidator(MesanimType.get, (input: number) => input >= 0 && input < MesanimType.count, 'Mesanim');
+export const StructTypeValid: ScriptValidator<number, StructType> = new ScriptInputConfigTypeValidator(StructType.get, (input: number) => input >= 0 && input < StructType.count, 'Struct');
+export const DbRowTypeValid: ScriptValidator<number, DbRowType> = new ScriptInputConfigTypeValidator(DbRowType.get, (input: number) => input >= 0 && input < DbRowType.count, 'Dbrow');
+export const DbTableTypeValid: ScriptValidator<number, DbTableType> = new ScriptInputConfigTypeValidator(DbTableType.get, (input: number) => input >= 0 && input < DbTableType.count, 'Dbtable');
+
+export function check<T, R>(input: T, validator: ScriptValidator<T, R>): R {
+    return validator.validate(input);
+}

--- a/src/lostcity/engine/script/handlers/DbOps.ts
+++ b/src/lostcity/engine/script/handlers/DbOps.ts
@@ -5,6 +5,8 @@ import ScriptVarType from '#lostcity/cache/ScriptVarType.js';
 import ScriptOpcode from '#lostcity/engine/script/ScriptOpcode.js';
 import { CommandHandlers } from '#lostcity/engine/script/ScriptRunner.js';
 
+import {check, DbRowTypeValid, DbTableTypeValid} from '#lostcity/engine/script/ScriptValidators.js';
+
 const DebugOps: CommandHandlers = {
     [ScriptOpcode.DB_FIND_WITH_COUNT]: state => {
         throw new Error('unimplemented');
@@ -22,8 +24,7 @@ const DebugOps: CommandHandlers = {
 
         state.dbRow++;
 
-        const row = DbRowType.get(state.dbRowQuery[state.dbRow]);
-        state.pushInt(row.id);
+        state.pushInt(check(state.dbRowQuery[state.dbRow], DbRowTypeValid).id);
     },
 
     [ScriptOpcode.DB_GETFIELD]: state => {
@@ -33,8 +34,8 @@ const DebugOps: CommandHandlers = {
         const column = (tableColumnPacked >> 4) & 0x7f;
         const tuple = tableColumnPacked & 0x3f;
 
-        const rowType = DbRowType.get(row);
-        const tableType = DbTableType.get(table);
+        const rowType: DbRowType = check(row, DbRowTypeValid);
+        const tableType: DbTableType = check(table, DbTableTypeValid);
 
         let values: (string | number)[];
         if (rowType.tableId !== table) {
@@ -60,8 +61,8 @@ const DebugOps: CommandHandlers = {
         const column = (tableColumnPacked >> 4) & 0x7f;
         const tuple = tableColumnPacked & 0x3f;
 
-        const rowType = DbRowType.get(row);
-        const tableType = DbTableType.get(table);
+        const rowType: DbRowType = check(row, DbRowTypeValid);
+        const tableType: DbTableType = check(table, DbTableTypeValid);
 
         if (rowType.tableId !== table) {
             state.pushInt(0);
@@ -76,10 +77,7 @@ const DebugOps: CommandHandlers = {
     },
 
     [ScriptOpcode.DB_GETROWTABLE]: state => {
-        const row = state.popInt();
-        const rowType = DbRowType.get(row);
-
-        state.pushInt(rowType.tableId);
+        state.pushInt(check(state.popInt(), DbRowTypeValid).tableId);
     },
 
     [ScriptOpcode.DB_FINDBYINDEX]: state => {
@@ -99,7 +97,7 @@ const DebugOps: CommandHandlers = {
         const column = (tableColumnPacked >> 4) & 0x7f;
         const tuple = tableColumnPacked & 0x3f;
 
-        state.dbTable = DbTableType.get(table);
+        state.dbTable = check(table, DbTableTypeValid);
         state.dbRow = -1;
         state.dbRowQuery = [];
 

--- a/src/lostcity/engine/script/handlers/EnumOps.ts
+++ b/src/lostcity/engine/script/handlers/EnumOps.ts
@@ -9,9 +9,7 @@ const EnumOps: CommandHandlers = {
     [ScriptOpcode.ENUM]: state => {
         const [inputType, outputType, enumId, key] = state.popInts(4);
 
-        check(enumId, EnumTypeValid);
-
-        const enumType = EnumType.get(enumId);
+        const enumType: EnumType = check(enumId, EnumTypeValid);
 
         // verify types
         if (enumType.inputtype !== inputType || enumType.outputtype !== outputType) {
@@ -27,10 +25,7 @@ const EnumOps: CommandHandlers = {
     },
 
     [ScriptOpcode.ENUM_GETOUTPUTCOUNT]: state => {
-        const enumId = check(state.popInt(), EnumTypeValid);
-
-        const enumType = EnumType.get(enumId);
-        state.pushInt(enumType.values.size);
+        state.pushInt(check(state.popInt(), EnumTypeValid).values.size);
     }
 };
 

--- a/src/lostcity/engine/script/handlers/InvOps.ts
+++ b/src/lostcity/engine/script/handlers/InvOps.ts
@@ -1,5 +1,6 @@
 import InvType from '#lostcity/cache/InvType.js';
 import ObjType from '#lostcity/cache/ObjType.js';
+import CategoryType from '#lostcity/cache/CategoryType.js';
 
 import World from '#lostcity/engine/World.js';
 
@@ -11,8 +12,8 @@ import Obj from '#lostcity/entity/Obj.js';
 import { Position } from '#lostcity/entity/Position.js';
 
 import {
-    CategoryTypeValid,
     check,
+    CategoryTypeValid,
     CoordValid,
     DurationValid,
     InvTypeValid,
@@ -27,58 +28,54 @@ const ProtectedActivePlayer = [ScriptPointer.ProtectedActivePlayer, ScriptPointe
 const InvOps: CommandHandlers = {
     // inv config
     [ScriptOpcode.INV_ALLSTOCK]: state => {
-        const inv = check(state.popInt(), InvTypeValid);
+        const invType: InvType = check(state.popInt(), InvTypeValid);
 
-        const type = InvType.get(inv);
-        state.pushInt(type.allstock ? 1 : 0);
+        state.pushInt(invType.allstock ? 1 : 0);
     },
 
     // inv config
     [ScriptOpcode.INV_SIZE]: state => {
-        const inv = check(state.popInt(), InvTypeValid);
+        const invType: InvType = check(state.popInt(), InvTypeValid);
 
-        const type = InvType.get(inv);
-        state.pushInt(type.size);
+        state.pushInt(invType.size);
     },
 
     // inv config
     [ScriptOpcode.INV_STOCKBASE]: state => {
         const [inv, obj] = state.popInts(2);
 
-        const type = InvType.get(check(inv, InvTypeValid));
+        const invType: InvType = check(inv, InvTypeValid);
+        const objType: ObjType = check(obj, ObjTypeValid);
 
-        if (!type.stockobj || !type.stockcount) {
+        if (!invType.stockobj || !invType.stockcount) {
             state.pushInt(-1);
             return;
         }
 
-        const index = type.stockobj.indexOf(check(obj, ObjTypeValid));
-        state.pushInt(index >= 0 ? type.stockcount[index] : -1);
+        const index = invType.stockobj.indexOf(objType.id);
+        state.pushInt(index >= 0 ? invType.stockcount[index] : -1);
     },
 
     // inv write
     [ScriptOpcode.INV_ADD]: checkedHandler(ActivePlayer, state => {
         const [inv, objId, count] = state.popInts(3);
 
-        check(inv, InvTypeValid);
-        check(objId, ObjTypeValid/*, ObjNotDummyValid*/);
+        const invType: InvType = check(inv, InvTypeValid);
+        const objType: ObjType = check(objId, ObjTypeValid);
         check(count, ObjStackValid);
 
-        const obj = ObjType.get(objId);
-
-        const type = InvType.get(inv);
-        if (!state.pointerGet(ProtectedActivePlayer[state.intOperand]) && type.protect && type.scope !== InvType.SCOPE_SHARED) {
-            throw new Error(`$inv requires protected access: ${type.debugname}`);
+        if (!state.pointerGet(ProtectedActivePlayer[state.intOperand]) && invType.protect && invType.scope !== InvType.SCOPE_SHARED) {
+            throw new Error(`$inv requires protected access: ${invType.debugname}`);
         }
 
-        if (!type.dummyinv && obj.dummyitem !== 0) {
-            throw new Error(`dummyitem in non-dummyinv: ${obj.debugname} -> ${type.debugname}`);
+        if (!invType.dummyinv && objType.dummyitem !== 0) {
+            throw new Error(`dummyitem in non-dummyinv: ${objType.debugname} -> ${invType.debugname}`);
         }
 
         const player = state.activePlayer;
-        const overflow = count - player.invAdd(inv, objId, count);
+        const overflow = count - player.invAdd(invType.id, objType.id, count);
         if (overflow > 0) {
-            const floorObj = new Obj(player.level, player.x, player.z, objId, overflow);
+            const floorObj = new Obj(player.level, player.x, player.z, objType.id, overflow);
 
             World.addObj(floorObj, player, 200);
         }
@@ -92,82 +89,71 @@ const InvOps: CommandHandlers = {
 
     // inv write
     [ScriptOpcode.INV_CLEAR]: checkedHandler(ActivePlayer, state => {
-        const inv = check(state.popInt(), InvTypeValid);
+        const invType: InvType = check(state.popInt(), InvTypeValid);
 
-        const type = InvType.get(inv);
-        if (!state.pointerGet(ProtectedActivePlayer[state.intOperand]) && type.protect && type.scope !== InvType.SCOPE_SHARED) {
-            throw new Error(`$inv requires protected access: ${type.debugname}`);
+        if (!state.pointerGet(ProtectedActivePlayer[state.intOperand]) && invType.protect && invType.scope !== InvType.SCOPE_SHARED) {
+            throw new Error(`$inv requires protected access: ${invType.debugname}`);
         }
 
-        state.activePlayer.invClear(inv);
+        state.activePlayer.invClear(invType.id);
     }),
 
     // inv write
     [ScriptOpcode.INV_DEL]: checkedHandler(ActivePlayer, state => {
         const [inv, obj, count] = state.popInts(3);
 
-        check(inv, InvTypeValid);
-        check(obj, ObjTypeValid);
+        const invType: InvType = check(inv, InvTypeValid);
+        const objType: ObjType = check(obj, ObjTypeValid);
         check(count, ObjStackValid);
 
-        const type = InvType.get(inv);
-        if (!state.pointerGet(ProtectedActivePlayer[state.intOperand]) && type.protect && type.scope !== InvType.SCOPE_SHARED) {
-            throw new Error(`$inv requires protected access: ${type.debugname}`);
+        if (!state.pointerGet(ProtectedActivePlayer[state.intOperand]) && invType.protect && invType.scope !== InvType.SCOPE_SHARED) {
+            throw new Error(`$inv requires protected access: ${invType.debugname}`);
         }
 
-        state.activePlayer.invDel(inv, obj, count);
+        state.activePlayer.invDel(invType.id, objType.id, count);
     }),
 
     // inv write
     [ScriptOpcode.INV_DELSLOT]: checkedHandler(ActivePlayer, state => {
         const [inv, slot] = state.popInts(2);
 
-        check(inv, InvTypeValid);
+        const invType: InvType = check(inv, InvTypeValid);
 
-        const type = InvType.get(inv);
-        if (slot < 0 || slot >= type.size) {
-            throw new Error(`$slot is out of range: ${slot}`);
+        if (!state.pointerGet(ProtectedActivePlayer[state.intOperand]) && invType.protect && invType.scope !== InvType.SCOPE_SHARED) {
+            throw new Error(`$inv requires protected access: ${invType.debugname}`);
         }
 
-        if (!state.pointerGet(ProtectedActivePlayer[state.intOperand]) && type.protect && type.scope !== InvType.SCOPE_SHARED) {
-            throw new Error(`$inv requires protected access: ${type.debugname}`);
-        }
-
-        const obj = state.activePlayer.invGetSlot(inv, slot);
+        const obj = state.activePlayer.invGetSlot(invType.id, slot);
         if (!obj) {
             return;
         }
 
-        state.activePlayer.invDelSlot(inv, slot);
+        state.activePlayer.invDelSlot(invType.id, slot);
     }),
 
     // inv write
     [ScriptOpcode.INV_DROPITEM]: checkedHandler(ActivePlayer, state => {
         const [inv, coord, obj, count, duration] = state.popInts(5);
 
-        check(inv, InvTypeValid);
-        check(coord, CoordValid);
-        check(obj, ObjTypeValid);
+        const invType: InvType = check(inv, InvTypeValid);
+        const position: Position = check(coord, CoordValid);
+        const objType: ObjType = check(obj, ObjTypeValid);
         check(count, ObjStackValid);
         check(duration, DurationValid);
 
-        const type = InvType.get(inv);
-        if (!state.pointerGet(ProtectedActivePlayer[state.intOperand]) && type.protect && type.scope !== InvType.SCOPE_SHARED) {
-            throw new Error(`$inv requires protected access: ${type.debugname}`);
+        if (!state.pointerGet(ProtectedActivePlayer[state.intOperand]) && invType.protect && invType.scope !== InvType.SCOPE_SHARED) {
+            throw new Error(`$inv requires protected access: ${invType.debugname}`);
         }
 
-        const pos = Position.unpackCoord(coord);
-
         const player = state.activePlayer;
-        const completed = player.invDel(inv, obj, count);
+        const completed = player.invDel(invType.id, objType.id, count);
         if (completed == 0) {
             return;
         }
 
-        const objType = ObjType.get(obj);
-        player.playerLog('Dropped item from', type.debugname as string, objType.debugname as string);
+        player.playerLog('Dropped item from', invType.debugname as string, objType.debugname as string);
 
-        const floorObj = new Obj(pos.level, pos.x, pos.z, obj, completed);
+        const floorObj = new Obj(position.level, position.x, position.z, objType.id, completed);
         World.addObj(floorObj, player, duration);
     }),
 
@@ -175,121 +161,98 @@ const InvOps: CommandHandlers = {
     [ScriptOpcode.INV_DROPSLOT]: checkedHandler(ActivePlayer, state => {
         const [inv, coord, slot, duration] = state.popInts(4);
 
-        check(inv, InvTypeValid);
+        const invType: InvType = check(inv, InvTypeValid);
         check(duration, DurationValid);
-        check(coord, CoordValid);
+        const position: Position = check(coord, CoordValid);
 
-        const type = InvType.get(inv);
-        if (slot < 0 || slot >= type.size) {
-            throw new Error(`$slot is out of range: ${slot}`);
-        }
-
-        const obj = state.activePlayer.invGetSlot(inv, slot);
+        const obj = state.activePlayer.invGetSlot(invType.id, slot);
         if (!obj) {
             throw new Error('$slot is empty');
         }
 
-        if (!state.pointerGet(ProtectedActivePlayer[state.intOperand]) && type.protect && type.scope !== InvType.SCOPE_SHARED) {
-            throw new Error(`$inv requires protected access: ${type.debugname}`);
+        if (!state.pointerGet(ProtectedActivePlayer[state.intOperand]) && invType.protect && invType.scope !== InvType.SCOPE_SHARED) {
+            throw new Error(`$inv requires protected access: ${invType.debugname}`);
         }
 
-        const pos = Position.unpackCoord(coord);
-
         const player = state.activePlayer;
-        const completed = player.invDel(inv, obj.id, obj.count, slot);
+        const completed = player.invDel(invType.id, obj.id, obj.count, slot);
         if (completed == 0) {
             return;
         }
 
         const objType = ObjType.get(obj.id);
-        player.playerLog('Dropped item from', type.debugname as string, objType.debugname as string);
+        player.playerLog('Dropped item from', invType.debugname as string, objType.debugname as string);
 
-        const floorObj = new Obj(pos.level, pos.x, pos.z, obj.id, completed);
+        const floorObj = new Obj(position.level, position.x, position.z, obj.id, completed);
         World.addObj(floorObj, player, duration);
     }),
 
     // inv read
     [ScriptOpcode.INV_FREESPACE]: checkedHandler(ActivePlayer, state => {
-        const inv = check(state.popInt(), InvTypeValid);
+        const invType: InvType = check(state.popInt(), InvTypeValid);
 
-        state.pushInt(state.activePlayer.invFreeSpace(inv) as number);
+        state.pushInt(state.activePlayer.invFreeSpace(invType.id));
     }),
 
     // inv read
     [ScriptOpcode.INV_GETNUM]: checkedHandler(ActivePlayer, state => {
         const [inv, slot] = state.popInts(2);
 
-        check(inv, InvTypeValid);
-
-        const type = InvType.get(inv);
-        if (slot < 0 || slot >= type.size) {
-            throw new Error(`$slot is out of range: ${slot}`);
-        }
-
-        const obj = state.activePlayer.invGetSlot(inv, slot);
-        state.pushInt(obj?.count ?? 0);
+        const invType: InvType = check(inv, InvTypeValid);
+        state.pushInt(state.activePlayer.invGetSlot(invType.id, slot)?.count ?? 0);
     }),
 
     // inv read
     [ScriptOpcode.INV_GETOBJ]: checkedHandler(ActivePlayer, state => {
         const [inv, slot] = state.popInts(2);
 
-        check(inv, InvTypeValid);
-
-        const obj = state.activePlayer.invGetSlot(inv, slot);
-        state.pushInt(obj?.id ?? -1);
+        const invType: InvType = check(inv, InvTypeValid);
+        state.pushInt(state.activePlayer.invGetSlot(invType.id, slot)?.id ?? -1);
     }),
 
     // inv read
     [ScriptOpcode.INV_ITEMSPACE]: checkedHandler(ActivePlayer, state => {
         const [inv, obj, count, size] = state.popInts(4);
 
-        check(inv, InvTypeValid);
-        check(obj, ObjTypeValid);
+        const invType: InvType = check(inv, InvTypeValid);
+        const objType: ObjType = check(obj, ObjTypeValid);
         check(count, ObjStackValid);
 
-        const type = InvType.get(inv);
-        if (size < 0 || size > type.size) {
+        if (size < 0 || size > invType.size) {
             throw new Error(`$count is out of range: ${count}`);
         }
 
-        state.pushInt(state.activePlayer.invItemSpace(inv, obj, count, size) == 0 ? 1 : 0);
+        state.pushInt(state.activePlayer.invItemSpace(invType.id, objType.id, count, size) === 0 ? 1 : 0);
     }),
 
     // inv read
     [ScriptOpcode.INV_ITEMSPACE2]: checkedHandler(ActivePlayer, state => {
         const [inv, obj, count, size] = state.popInts(4);
 
-        check(inv, InvTypeValid);
-        check(obj, ObjTypeValid);
+        const invType: InvType = check(inv, InvTypeValid);
+        const objType: ObjType = check(obj, ObjTypeValid);
         check(count, ObjStackValid);
 
-        state.pushInt(state.activePlayer.invItemSpace(inv, obj, count, size));
+        state.pushInt(state.activePlayer.invItemSpace(invType.id, objType.id, count, size));
     }),
 
     // inv write
     [ScriptOpcode.INV_MOVEFROMSLOT]: checkedHandler(ActivePlayer, state => {
         const [fromInv, toInv, fromSlot] = state.popInts(3);
 
-        check(fromInv, InvTypeValid);
-        check(toInv, InvTypeValid);
+        const fromInvType: InvType = check(fromInv, InvTypeValid);
+        const toInvType: InvType = check(toInv, InvTypeValid);
 
-        const type = InvType.get(fromInv);
-        if (fromSlot < 0 || fromSlot >= type.size) {
-            throw new Error(`$from_slot is out of range: ${fromSlot}`);
+        if (!state.pointerGet(ProtectedActivePlayer[state.intOperand]) && fromInvType.protect && fromInvType.scope !== InvType.SCOPE_SHARED) {
+            throw new Error(`$inv requires protected access: ${fromInvType.debugname}`);
         }
 
-        if (!state.pointerGet(ProtectedActivePlayer[state.intOperand]) && type.protect && type.scope !== InvType.SCOPE_SHARED) {
-            throw new Error(`$inv requires protected access: ${type.debugname}`);
-        }
-
-        const type2 = InvType.get(toInv);
-        if (!state.pointerGet(ProtectedActivePlayer[state.intOperand]) && type2.protect && type.scope !== InvType.SCOPE_SHARED) {
-            throw new Error(`$inv requires protected access: ${type2.debugname}`);
+        if (!state.pointerGet(ProtectedActivePlayer[state.intOperand]) && toInvType.protect && fromInvType.scope !== InvType.SCOPE_SHARED) {
+            throw new Error(`$inv requires protected access: ${toInvType.debugname}`);
         }
 
         const player = state.activePlayer;
-        const { overflow, fromObj } = player.invMoveFromSlot(fromInv, toInv, fromSlot);
+        const { overflow, fromObj } = player.invMoveFromSlot(fromInvType.id, toInvType.id, fromSlot);
         if (overflow > 0) {
             const floorObj = new Obj(player.level, player.x, player.z, fromObj, overflow);
 
@@ -301,36 +264,26 @@ const InvOps: CommandHandlers = {
     [ScriptOpcode.INV_MOVETOSLOT]: checkedHandler(ActivePlayer, state => {
         const [fromInv, toInv, fromSlot, toSlot] = state.popInts(4);
 
-        check(fromInv, InvTypeValid);
-        check(toInv, InvTypeValid);
+        const fromInvType: InvType = check(fromInv, InvTypeValid);
+        const toInvType: InvType = check(toInv, InvTypeValid);
 
-        const type = InvType.get(fromInv);
-        if (fromSlot < 0 || fromSlot >= type.size) {
-            throw new Error(`$from_slot is out of range: ${fromSlot}`);
+        if (!state.pointerGet(ProtectedActivePlayer[state.intOperand]) && fromInvType.protect && fromInvType.scope !== InvType.SCOPE_SHARED) {
+            throw new Error(`$inv requires protected access: ${fromInvType.debugname}`);
         }
 
-        const type2 = InvType.get(toInv);
-        if (toSlot < 0 || toSlot >= type2.size) {
-            throw new Error(`$to_slot is out of range: ${toSlot}`);
+        if (!state.pointerGet(ProtectedActivePlayer[state.intOperand]) && toInvType.protect && fromInvType.scope !== InvType.SCOPE_SHARED) {
+            throw new Error(`$inv requires protected access: ${toInvType.debugname}`);
         }
 
-        if (!state.pointerGet(ProtectedActivePlayer[state.intOperand]) && type.protect && type.scope !== InvType.SCOPE_SHARED) {
-            throw new Error(`$inv requires protected access: ${type.debugname}`);
-        }
-
-        if (!state.pointerGet(ProtectedActivePlayer[state.intOperand]) && type2.protect && type.scope !== InvType.SCOPE_SHARED) {
-            throw new Error(`$inv requires protected access: ${type2.debugname}`);
-        }
-
-        state.activePlayer.invMoveToSlot(fromInv, toInv, fromSlot, toSlot);
+        state.activePlayer.invMoveToSlot(fromInvType.id, toInvType.id, fromSlot, toSlot);
     }),
 
     // inv write
     [ScriptOpcode.BOTH_MOVEINV]: checkedHandler(ActivePlayer, state => {
         const [from, to] = state.popInts(2);
 
-        check(from, InvTypeValid);
-        check(to, InvTypeValid);
+        const fromInvType: InvType = check(from, InvTypeValid);
+        const toInvType: InvType = check(to, InvTypeValid);
 
         const secondary = state.intOperand == 1;
 
@@ -346,14 +299,12 @@ const InvOps: CommandHandlers = {
             throw new Error('player is null');
         }
 
-        const type = InvType.get(from);
-        if (!state.pointerGet(ProtectedActivePlayer[secondary ? 1 : 0]) && type.protect && type.scope !== InvType.SCOPE_SHARED) {
-            throw new Error(`$from_inv requires protected access: ${type.debugname}`);
+        if (!state.pointerGet(ProtectedActivePlayer[secondary ? 1 : 0]) && fromInvType.protect && fromInvType.scope !== InvType.SCOPE_SHARED) {
+            throw new Error(`$from_inv requires protected access: ${fromInvType.debugname}`);
         }
 
-        const type2 = InvType.get(to);
-        if (!state.pointerGet(ProtectedActivePlayer[secondary ? 0 : 1]) && type2.protect && type.scope !== InvType.SCOPE_SHARED) {
-            throw new Error(`$to_inv requires protected access: ${type2.debugname}`);
+        if (!state.pointerGet(ProtectedActivePlayer[secondary ? 0 : 1]) && toInvType.protect && fromInvType.scope !== InvType.SCOPE_SHARED) {
+            throw new Error(`$to_inv requires protected access: ${toInvType.debugname}`);
         }
 
         const fromInv = fromPlayer.getInventory(from);
@@ -381,59 +332,54 @@ const InvOps: CommandHandlers = {
     [ScriptOpcode.INV_MOVEITEM]: checkedHandler(ActivePlayer, state => {
         const [fromInv, toInv, obj, count] = state.popInts(4);
 
-        check(fromInv, InvTypeValid);
-        check(toInv, InvTypeValid);
-        check(obj, ObjTypeValid);
+        const fromInvType: InvType = check(fromInv, InvTypeValid);
+        const toInvType: InvType = check(toInv, InvTypeValid);
+        const objType: ObjType = check(obj, ObjTypeValid);
         check(count, ObjStackValid);
 
-        const type = InvType.get(fromInv);
-        if (!state.pointerGet(ProtectedActivePlayer[state.intOperand]) && type.protect && type.scope !== InvType.SCOPE_SHARED) {
-            throw new Error(`$inv requires protected access: ${type.debugname}`);
+        if (!state.pointerGet(ProtectedActivePlayer[state.intOperand]) && fromInvType.protect && fromInvType.scope !== InvType.SCOPE_SHARED) {
+            throw new Error(`$inv requires protected access: ${fromInvType.debugname}`);
         }
 
-        const type2 = InvType.get(toInv);
-        if (!state.pointerGet(ProtectedActivePlayer[state.intOperand]) && type2.protect && type.scope !== InvType.SCOPE_SHARED) {
-            throw new Error(`$inv requires protected access: ${type2.debugname}`);
+        if (!state.pointerGet(ProtectedActivePlayer[state.intOperand]) && toInvType.protect && fromInvType.scope !== InvType.SCOPE_SHARED) {
+            throw new Error(`$inv requires protected access: ${toInvType.debugname}`);
         }
 
-        const completed = state.activePlayer.invDel(fromInv, obj, count);
+        const completed = state.activePlayer.invDel(fromInvType.id, objType.id, count);
         if (completed == 0) {
             return;
         }
 
-        state.activePlayer.invAdd(toInv, obj, completed);
+        state.activePlayer.invAdd(toInvType.id, objType.id, completed);
     }),
 
     // inv write
     [ScriptOpcode.INV_MOVEITEM_CERT]: checkedHandler(ActivePlayer, state => {
         const [fromInv, toInv, obj, count] = state.popInts(4);
 
-        check(fromInv, InvTypeValid);
-        check(toInv, InvTypeValid);
-        check(obj, ObjTypeValid);
+        const fromInvType = check(fromInv, InvTypeValid);
+        const toInvType = check(toInv, InvTypeValid);
+        const objType = check(obj, ObjTypeValid);
         check(count, ObjStackValid);
 
-        const type = InvType.get(fromInv);
-        if (!state.pointerGet(ProtectedActivePlayer[state.intOperand]) && type.protect && type.scope !== InvType.SCOPE_SHARED) {
-            throw new Error(`$inv requires protected access: ${type.debugname}`);
+        if (!state.pointerGet(ProtectedActivePlayer[state.intOperand]) && fromInvType.protect && fromInvType.scope !== InvType.SCOPE_SHARED) {
+            throw new Error(`$inv requires protected access: ${fromInvType.debugname}`);
         }
 
-        const type2 = InvType.get(toInv);
-        if (!state.pointerGet(ProtectedActivePlayer[state.intOperand]) && type2.protect && type.scope !== InvType.SCOPE_SHARED) {
-            throw new Error(`$inv requires protected access: ${type2.debugname}`);
+        if (!state.pointerGet(ProtectedActivePlayer[state.intOperand]) && toInvType.protect && fromInvType.scope !== InvType.SCOPE_SHARED) {
+            throw new Error(`$inv requires protected access: ${toInvType.debugname}`);
         }
 
-        const completed = state.activePlayer.invDel(fromInv, obj, count);
+        const completed = state.activePlayer.invDel(fromInvType.id, objType.id, count);
         if (completed == 0) {
             return;
         }
 
-        const objType = ObjType.get(obj);
-        let finalObj = obj;
+        let finalObj = objType.id;
         if (objType.certtemplate === -1 && objType.certlink >= 0) {
             finalObj = objType.certlink;
         }
-        const overflow = count - state.activePlayer.invAdd(toInv, finalObj, completed);
+        const overflow = count - state.activePlayer.invAdd(toInvType.id, finalObj, completed);
         if (overflow > 0) {
             const floorObj = new Obj(state.activePlayer.level, state.activePlayer.x, state.activePlayer.z, finalObj, overflow);
             World.addObj(floorObj, state.activePlayer, 200);
@@ -445,31 +391,28 @@ const InvOps: CommandHandlers = {
     [ScriptOpcode.INV_MOVEITEM_UNCERT]: checkedHandler(ActivePlayer, state => {
         const [fromInv, toInv, obj, count] = state.popInts(4);
 
-        check(fromInv, InvTypeValid);
-        check(toInv, InvTypeValid);
-        check(obj, ObjTypeValid);
+        const fromInvType: InvType = check(fromInv, InvTypeValid);
+        const toInvType: InvType = check(toInv, InvTypeValid);
+        const objType: ObjType = check(obj, ObjTypeValid);
         check(count, ObjStackValid);
 
-        const type = InvType.get(fromInv);
-        if (!state.pointerGet(ProtectedActivePlayer[state.intOperand]) && type.protect && type.scope !== InvType.SCOPE_SHARED) {
-            throw new Error(`$inv requires protected access: ${type.debugname}`);
+        if (!state.pointerGet(ProtectedActivePlayer[state.intOperand]) && fromInvType.protect && fromInvType.scope !== InvType.SCOPE_SHARED) {
+            throw new Error(`$inv requires protected access: ${fromInvType.debugname}`);
         }
 
-        const type2 = InvType.get(toInv);
-        if (!state.pointerGet(ProtectedActivePlayer[state.intOperand]) && type2.protect && type.scope !== InvType.SCOPE_SHARED) {
-            throw new Error(`$inv requires protected access: ${type2.debugname}`);
+        if (!state.pointerGet(ProtectedActivePlayer[state.intOperand]) && toInvType.protect && fromInvType.scope !== InvType.SCOPE_SHARED) {
+            throw new Error(`$inv requires protected access: ${toInvType.debugname}`);
         }
 
-        const completed = state.activePlayer.invDel(fromInv, obj, count);
+        const completed = state.activePlayer.invDel(fromInvType.id, objType.id, count);
         if (completed == 0) {
             return;
         }
 
-        const objType = ObjType.get(obj);
         if (objType.certtemplate >= 0 && objType.certlink >= 0) {
-            state.activePlayer.invAdd(toInv, objType.certlink, completed);
+            state.activePlayer.invAdd(toInvType.id, objType.certlink, completed);
         } else {
-            state.activePlayer.invAdd(toInv, obj, completed);
+            state.activePlayer.invAdd(toInvType.id, objType.id, completed);
         }
     }),
 
@@ -477,33 +420,26 @@ const InvOps: CommandHandlers = {
     [ScriptOpcode.INV_SETSLOT]: checkedHandler(ActivePlayer, state => {
         const [inv, slot, objId, count] = state.popInts(4);
 
-        check(inv, InvTypeValid);
-        check(objId, ObjTypeValid/*, ObjNotDummyValid*/);
+        const invType: InvType = check(inv, InvTypeValid);
+        const objType: ObjType = check(objId, ObjTypeValid);
         check(count, ObjStackValid);
 
-        const type = InvType.get(inv);
-        if (slot < 0 || slot >= type.size) {
-            throw new Error(`$slot is out of range: ${slot}`);
+        if (!state.pointerGet(ProtectedActivePlayer[state.intOperand]) && invType.protect && invType.scope !== InvType.SCOPE_SHARED) {
+            throw new Error(`$inv requires protected access: ${invType.debugname}`);
         }
 
-        const obj = ObjType.get(objId);
-
-        if (!state.pointerGet(ProtectedActivePlayer[state.intOperand]) && type.protect && type.scope !== InvType.SCOPE_SHARED) {
-            throw new Error(`$inv requires protected access: ${type.debugname}`);
+        if (!invType.dummyinv && objType.dummyitem !== 0) {
+            throw new Error(`dummyitem in non-dummyinv: ${objType.debugname} -> ${invType.debugname}`);
         }
 
-        if (!type.dummyinv && obj.dummyitem !== 0) {
-            throw new Error(`dummyitem in non-dummyinv: ${obj.debugname} -> ${type.debugname}`);
-        }
-
-        state.activePlayer.invSet(inv, objId, count, slot);
+        state.activePlayer.invSet(invType.id, objType.id, count, slot);
     }),
 
     // inv read
     [ScriptOpcode.INV_TOTAL]: checkedHandler(ActivePlayer, state => {
         const [inv, obj] = state.popInts(2);
 
-        check(inv, InvTypeValid);
+        const invType: InvType = check(inv, InvTypeValid);
 
         // todo: error instead?
         if (obj === -1) {
@@ -511,27 +447,27 @@ const InvOps: CommandHandlers = {
             return;
         }
 
-        state.pushInt(state.activePlayer.invTotal(inv, obj) as number);
+        state.pushInt(state.activePlayer.invTotal(invType.id, obj));
     }),
 
     // inv read
     [ScriptOpcode.INV_TOTALCAT]: checkedHandler(ActivePlayer, state => {
         const [inv, category] = state.popInts(2);
 
-        check(inv, InvTypeValid);
-        check(category, CategoryTypeValid);
+        const invType: InvType = check(inv, InvTypeValid);
+        const catType: CategoryType = check(category, CategoryTypeValid);
 
-        state.pushInt(state.activePlayer.invTotalCat(inv, category));
+        state.pushInt(state.activePlayer.invTotalCat(invType.id, catType.id));
     }),
 
     // inv protocol
     [ScriptOpcode.INV_TRANSMIT]: checkedHandler(ActivePlayer, state => {
         const [inv, com] = state.popInts(2);
 
-        check(inv, InvTypeValid);
+        const invType: InvType = check(inv, InvTypeValid);
         check(com, NumberNotNull);
 
-        state.activePlayer.invListenOnCom(inv, com, state.activePlayer.uid);
+        state.activePlayer.invListenOnCom(invType.id, com, state.activePlayer.uid);
     }),
 
     // inv protocol
@@ -539,10 +475,10 @@ const InvOps: CommandHandlers = {
         const [uid, inv, com] = state.popInts(3);
 
         check(uid, NumberNotNull);
-        check(inv, InvTypeValid);
+        const invType: InvType = check(inv, InvTypeValid);
         check(com, NumberNotNull);
 
-        state.activePlayer.invListenOnCom(inv, com, uid);
+        state.activePlayer.invListenOnCom(invType.id, com, uid);
     }),
 
     // inv protocol

--- a/src/lostcity/engine/script/handlers/LocConfigOps.ts
+++ b/src/lostcity/engine/script/handlers/LocConfigOps.ts
@@ -9,57 +9,41 @@ import {check, LocTypeValid, ParamTypeValid} from '#lostcity/engine/script/Scrip
 
 const LocConfigOps: CommandHandlers = {
     [ScriptOpcode.LC_NAME]: state => {
-        const locId = check(state.popInt(), LocTypeValid);
+        const locType: LocType = check(state.popInt(), LocTypeValid);
 
-        const locType = LocType.get(locId);
         state.pushString(locType.name ?? locType.debugname ?? 'null');
     },
 
     [ScriptOpcode.LC_PARAM]: state => {
         const [locId, paramId] = state.popInts(2);
 
-        const locType = LocType.get(check(locId, LocTypeValid));
-        const paramType = ParamType.get(check(paramId, ParamTypeValid));
+        const locType: LocType = check(locId, LocTypeValid);
+        const paramType: ParamType = check(paramId, ParamTypeValid);
         if (paramType.isString()) {
-            state.pushString(ParamHelper.getStringParam(paramId, locType, paramType.defaultString));
+            state.pushString(ParamHelper.getStringParam(paramType.id, locType, paramType.defaultString));
         } else {
-            state.pushInt(ParamHelper.getIntParam(paramId, locType, paramType.defaultInt));
+            state.pushInt(ParamHelper.getIntParam(paramType.id, locType, paramType.defaultInt));
         }
     },
 
     [ScriptOpcode.LC_CATEGORY]: state => {
-        const locId = check(state.popInt(), LocTypeValid);
-
-        const locType = LocType.get(locId);
-        state.pushInt(locType.category);
+        state.pushInt(check(state.popInt(), LocTypeValid).category);
     },
 
     [ScriptOpcode.LC_DESC]: state => {
-        const locId = check(state.popInt(), LocTypeValid);
-
-        const locType = LocType.get(locId);
-        state.pushString(locType.desc ?? 'null');
+        state.pushString(check(state.popInt(), LocTypeValid).desc ?? 'null');
     },
 
     [ScriptOpcode.LC_DEBUGNAME]: state => {
-        const locId = check(state.popInt(), LocTypeValid);
-
-        const locType = LocType.get(locId);
-        state.pushString(locType.debugname ?? 'null');
+        state.pushString(check(state.popInt(), LocTypeValid).debugname ?? 'null');
     },
 
     [ScriptOpcode.LC_WIDTH]: state => {
-        const locId = check(state.popInt(), LocTypeValid);
-
-        const locType = LocType.get(locId);
-        state.pushInt(locType.width ?? 0);
+        state.pushInt(check(state.popInt(), LocTypeValid).width);
     },
 
     [ScriptOpcode.LC_LENGTH]: state => {
-        const locId = check(state.popInt(), LocTypeValid);
-
-        const locType = LocType.get(locId);
-        state.pushInt(locType.length ?? 0);
+        state.pushInt(check(state.popInt(), LocTypeValid).length);
     }
 };
 

--- a/src/lostcity/engine/script/handlers/NpcConfigOps.ts
+++ b/src/lostcity/engine/script/handlers/NpcConfigOps.ts
@@ -9,20 +9,16 @@ import {check, NpcTypeValid, NumberNotNull, ParamTypeValid} from '#lostcity/engi
 
 const NpcConfigOps: CommandHandlers = {
     [ScriptOpcode.NC_NAME]: state => {
-        const npcId = check(state.popInt(), NpcTypeValid);
+        const npcType: NpcType = check(state.popInt(), NpcTypeValid);
 
-        const npcType = NpcType.get(npcId);
         state.pushString(npcType.name ?? npcType.debugname ?? 'null');
     },
 
     [ScriptOpcode.NC_PARAM]: state => {
         const [npcId, paramId] = state.popInts(2);
 
-        check(npcId, NpcTypeValid);
-        check(paramId, ParamTypeValid);
-
-        const npcType = NpcType.get(npcId);
-        const paramType = ParamType.get(paramId);
+        const npcType: NpcType = check(npcId, NpcTypeValid);
+        const paramType: ParamType = check(paramId, ParamTypeValid);
         if (paramType.isString()) {
             state.pushString(ParamHelper.getStringParam(paramId, npcType, paramType.defaultString));
         } else {
@@ -31,33 +27,22 @@ const NpcConfigOps: CommandHandlers = {
     },
 
     [ScriptOpcode.NC_CATEGORY]: state => {
-        const npcId = check(state.popInt(), NpcTypeValid);
-
-        const npcType = NpcType.get(npcId);
-        state.pushInt(npcType.category);
+        state.pushInt(check(state.popInt(), NpcTypeValid).category);
     },
 
     [ScriptOpcode.NC_DESC]: state => {
-        const npcId = check(state.popInt(), NpcTypeValid);
-
-        const npcType = NpcType.get(npcId);
-        state.pushString(npcType.desc ?? 'null');
+        state.pushString(check(state.popInt(), NpcTypeValid).desc ?? 'null');
     },
 
     [ScriptOpcode.NC_DEBUGNAME]: state => {
-        const npcId = check(state.popInt(), NpcTypeValid);
-
-        const npcType = NpcType.get(npcId);
-        state.pushString(npcType.debugname ?? 'null');
+        state.pushString(check(state.popInt(), NpcTypeValid).debugname ?? 'null');
     },
 
     [ScriptOpcode.NC_OP]: state => {
         const [npcId, op] = state.popInts(2);
 
-        check(npcId, NpcTypeValid);
+        const npcType: NpcType = check(npcId, NpcTypeValid);
         check(op, NumberNotNull);
-
-        const npcType = NpcType.get(npcId);
 
         if (!npcType.op) {
             state.pushString('');

--- a/src/lostcity/engine/script/handlers/NpcOps.ts
+++ b/src/lostcity/engine/script/handlers/NpcOps.ts
@@ -1,7 +1,7 @@
-import HuntType from '#lostcity/cache/HuntType.js';
 import ParamType from '#lostcity/cache/ParamType.js';
 import NpcType from '#lostcity/cache/NpcType.js';
 import { ParamHelper } from '#lostcity/cache/ParamHelper.js';
+import SpotanimType from '#lostcity/cache/SpotanimType.js';
 
 import World from '#lostcity/engine/World.js';
 
@@ -21,6 +21,7 @@ import Npc from '#lostcity/entity/Npc.js';
 import NpcMode from '#lostcity/entity/NpcMode.js';
 import Entity from '#lostcity/entity/Entity.js';
 import Interaction from '#lostcity/entity/Interaction.js';
+import HuntVis from '#lostcity/entity/hunt/HuntVis.js';
 
 import Environment from '#lostcity/util/Environment.js';
 
@@ -62,15 +63,11 @@ const NpcOps: CommandHandlers = {
     [ScriptOpcode.NPC_ADD]: state => {
         const [coord, id, duration] = state.popInts(3);
 
-        check(coord, CoordValid);
-        check(id, NpcTypeValid);
+        const position: Position = check(coord, CoordValid);
+        const npcType: NpcType = check(id, NpcTypeValid);
         check(duration, DurationValid);
 
-        const pos = Position.unpackCoord(coord);
-        const npcType = NpcType.get(id);
-
-        const npc = new Npc(pos.level, pos.x, pos.z, npcType.size, npcType.size, World.getNextNid(), npcType.id, npcType.moverestrict, npcType.blockwalk);
-
+        const npc = new Npc(position.level, position.x, position.z, npcType.size, npcType.size, World.getNextNid(), npcType.id, npcType.moverestrict, npcType.blockwalk);
         npc.static = false;
         npc.despawn = World.currentTick + duration;
         World.addNpc(npc);
@@ -79,7 +76,7 @@ const NpcOps: CommandHandlers = {
     },
 
     [ScriptOpcode.NPC_ANIM]: checkedHandler(ActiveNpc, state => {
-        const delay = state.popInt();
+        const delay = check(state.popInt(), NumberNotNull);
         const seq = state.popInt();
 
         state.activeNpc.playAnimation(seq, delay);
@@ -92,13 +89,12 @@ const NpcOps: CommandHandlers = {
     }),
 
     [ScriptOpcode.NPC_CATEGORY]: checkedHandler(ActiveNpc, state => {
-        const npc = NpcType.get(state.activeNpc.type);
-        state.pushInt(npc.category);
+        state.pushInt(check(state.activeNpc.type, NpcTypeValid).category);
     }),
 
     [ScriptOpcode.NPC_COORD]: checkedHandler(ActiveNpc, state => {
-        const npc = state.activeNpc;
-        state.pushInt(Position.packCoord(npc.level, npc.x, npc.z));
+        const position: Position = state.activeNpc;
+        state.pushInt(Position.packCoord(position.level, position.x, position.z));
     }),
 
     [ScriptOpcode.NPC_DEL]: checkedHandler(ActiveNpc, state => {
@@ -119,23 +115,21 @@ const NpcOps: CommandHandlers = {
     }),
 
     [ScriptOpcode.NPC_FACESQUARE]: checkedHandler(ActiveNpc, state => {
-        const coord = check(state.popInt(), CoordValid);
+        const position: Position = check(state.popInt(), CoordValid);
 
-        const pos = Position.unpackCoord(coord);
-        state.activeNpc.faceSquare(pos.x, pos.z);
+        state.activeNpc.faceSquare(position.x, position.z);
     }),
 
     [ScriptOpcode.NPC_FINDEXACT]: state => {
         const [coord, id] = state.popInts(2);
 
-        check(coord, CoordValid);
-        check(id, NpcTypeValid);
+        const position: Position = check(coord, CoordValid);
+        const npcType: NpcType = check(id, NpcTypeValid);
 
-        const {level, x, z} = Position.unpackCoord(coord);
-        state.npcIterator = new NpcIterator(World.currentTick, level, x, z, 0, 0, NpcIteratorType.ZONE);
+        state.npcIterator = new NpcIterator(World.currentTick, position.level, position.x, position.z, 0, 0, NpcIteratorType.ZONE);
 
         for (const npc of state.npcIterator) {
-            if(npc && npc.type === id && npc.x === x && npc.level === level && npc.z === z) {
+            if (npc.type === npcType.id && npc.x === position.x && npc.level === position.level && npc.z === position.z) {
                 state.activeNpc = npc;
                 state.pointerAdd(ActiveNpc[state.intOperand]);
                 state.pushInt(1);
@@ -165,46 +159,39 @@ const NpcOps: CommandHandlers = {
     }),
 
     [ScriptOpcode.NPC_PARAM]: checkedHandler(ActiveNpc, state => {
-        const paramId = state.popInt();
+        const paramType: ParamType = check(state.popInt(), ParamTypeValid);
 
-        check(paramId, ParamTypeValid);
-
-        const param = ParamType.get(paramId);
-        const npc = NpcType.get(state.activeNpc.type);
-        if (param.isString()) {
-            state.pushString(ParamHelper.getStringParam(paramId, npc, param.defaultString));
+        const npcType: NpcType = check(state.activeNpc.type, NpcTypeValid);
+        if (paramType.isString()) {
+            state.pushString(ParamHelper.getStringParam(paramType.id, npcType, paramType.defaultString));
         } else {
-            state.pushInt(ParamHelper.getIntParam(paramId, npc, param.defaultInt));
+            state.pushInt(ParamHelper.getIntParam(paramType.id, npcType, paramType.defaultInt));
         }
     }),
 
     [ScriptOpcode.NPC_QUEUE]: checkedHandler(ActiveNpc, state => {
-        const delay = state.popInt();
+        const delay = check(state.popInt(), NumberNotNull);
         const arg = state.popInt();
-        const queueId = state.popInt() - 1;
+        const queueId = check(state.popInt(), QueueValid);
 
-        check(queueId, QueueValid);
-
-        const type = NpcType.get(state.activeNpc.type);
-        const script = ScriptProvider.getByTrigger(ServerTriggerType.AI_QUEUE1 + queueId, type.id, type.category);
+        const npcType: NpcType = check(state.activeNpc.type, NpcTypeValid);
+        const script = ScriptProvider.getByTrigger(ServerTriggerType.AI_QUEUE1 + queueId - 1, npcType.id, npcType.category);
         if (script) {
             state.activeNpc.enqueueScript(script, delay, [arg]);
         }
     }),
 
     [ScriptOpcode.NPC_RANGE]: checkedHandler(ActiveNpc, state => {
-        const coord = check(state.popInt(), CoordValid);
+        const position: Position = check(state.popInt(), CoordValid);
 
-        const pos = Position.unpackCoord(coord);
         const npc = state.activeNpc;
-
-        if (pos.level !== npc.level) {
+        if (position.level !== npc.level) {
             state.pushInt(-1);
         } else {
             state.pushInt(
                 Position.distanceTo(npc, {
-                    x: pos.x,
-                    z: pos.z,
+                    x: position.x,
+                    z: position.z,
                     width: 1,
                     length: 1
                 })
@@ -221,10 +208,7 @@ const NpcOps: CommandHandlers = {
     }),
 
     [ScriptOpcode.NPC_SETHUNTMODE]: checkedHandler(ActiveNpc, state => {
-        const mode = check(state.popInt(), HuntTypeValid);
-
-        const huntType = HuntType.get(mode);
-        state.activeNpc.huntMode = huntType.id;
+        state.activeNpc.huntMode = check(state.popInt(), HuntTypeValid).id;
     }),
 
     [ScriptOpcode.NPC_SETMODE]: checkedHandler(ActiveNpc, state => {
@@ -286,7 +270,7 @@ const NpcOps: CommandHandlers = {
     }),
 
     [ScriptOpcode.NPC_TYPE]: checkedHandler(ActiveNpc, state => {
-        state.pushInt(state.activeNpc.type);
+        state.pushInt(check(state.activeNpc.type, NpcTypeValid).id);
     }),
 
     [ScriptOpcode.NPC_DAMAGE]: checkedHandler(ActiveNpc, state => {
@@ -297,9 +281,7 @@ const NpcOps: CommandHandlers = {
     }),
 
     [ScriptOpcode.NPC_NAME]: checkedHandler(ActiveNpc, state => {
-        const npcType = NpcType.get(state.activeNpc.type);
-
-        state.pushString(npcType.name ?? 'null');
+        state.pushString(check(state.activeNpc.type, NpcTypeValid).name ?? 'null');
     }),
 
     [ScriptOpcode.NPC_UID]: checkedHandler(ActiveNpc, state => {
@@ -307,37 +289,33 @@ const NpcOps: CommandHandlers = {
     }),
 
     [ScriptOpcode.NPC_SETTIMER]: checkedHandler(ActiveNpc, state => {
-        const interval = check(state.popInt(), NumberNotNull);
-
-        state.activeNpc.setTimer(interval);
+        state.activeNpc.setTimer(check(state.popInt(), NumberNotNull));
     }),
 
     [ScriptOpcode.SPOTANIM_NPC]: checkedHandler(ActiveNpc, state => {
-        const delay = state.popInt();
-        const height = state.popInt();
-        const spotanim = state.popInt();
+        const delay = check(state.popInt(), NumberNotNull);
+        const height = check(state.popInt(), NumberNotNull);
+        const spotanimType: SpotanimType = check(state.popInt(), SpotAnimTypeValid);
 
-        check(spotanim, SpotAnimTypeValid);
-
-        state.activeNpc.spotanim(spotanim, height, delay);
+        state.activeNpc.spotanim(spotanimType.id, height, delay);
     }),
 
     [ScriptOpcode.NPC_FIND]: state => {
-        const [coord, npcType, distance, checkVis] = state.popInts(4);
+        const [coord, npc, distance, checkVis] = state.popInts(4);
 
-        check(coord, CoordValid);
-        check(npcType, NpcTypeValid);
+        const position: Position = check(coord, CoordValid);
+        const npcType: NpcType = check(npc, NpcTypeValid);
         check(distance, NumberNotNull);
-        check(checkVis, HuntVisValid);
+        const huntvis: HuntVis = check(checkVis, HuntVisValid);
 
-        const {level, x, z} = Position.unpackCoord(coord);
         let closestNpc;
         let closestDistance = distance;
 
-        const npcs = new NpcIterator(World.currentTick, level, x, z, distance, checkVis, NpcIteratorType.DISTANCE);
+        const npcs = new NpcIterator(World.currentTick, position.level, position.x, position.z, distance, huntvis, NpcIteratorType.DISTANCE);
+
         for (const npc of npcs) {
-            if(npc && npc.type === npcType) {
-                const npcDistance = Position.distanceToSW({x, z}, npc);
+            if(npc && npc.type === npcType.id) {
+                const npcDistance = Position.distanceToSW(position, npc);
                 if (npcDistance <= closestDistance) {
                     closestNpc = npc;
                     closestDistance = npcDistance;
@@ -357,13 +335,11 @@ const NpcOps: CommandHandlers = {
     [ScriptOpcode.NPC_FINDALLANY]: state => {
         const [coord, distance, checkVis] = state.popInts(3);
 
-        check(coord, CoordValid);
+        const position: Position = check(coord, CoordValid);
         check(distance, NumberNotNull);
-        check(checkVis, HuntVisValid);
+        const huntvis: HuntVis = check(checkVis, HuntVisValid);
 
-        const {level, x, z} = Position.unpackCoord(coord);
-
-        state.npcIterator = new NpcIterator(World.currentTick, level, x, z, distance, checkVis, NpcIteratorType.DISTANCE);
+        state.npcIterator = new NpcIterator(World.currentTick, position.level, position.x, position.z, distance, huntvis, NpcIteratorType.DISTANCE);
         // not necessary but if we want to refer to the original npc again, we can
         if (state._activeNpc) {
             state._activeNpc2 = state._activeNpc;
@@ -372,11 +348,9 @@ const NpcOps: CommandHandlers = {
     },
 
     [ScriptOpcode.NPC_FINDALLZONE]: state => {
-        const coord: number = check(state.popInt(), CoordValid);
+        const position: Position = check(state.popInt(), CoordValid);
 
-        const {level, x, z} = Position.unpackCoord(coord);
-
-        state.npcIterator = new NpcIterator(World.currentTick, level, x, z, 0, 0, NpcIteratorType.ZONE);
+        state.npcIterator = new NpcIterator(World.currentTick, position.level, position.x, position.z, 0, 0, NpcIteratorType.ZONE);
         // not necessary but if we want to refer to the original npc again, we can
         if (state._activeNpc) {
             state._activeNpc2 = state._activeNpc;
@@ -398,23 +372,19 @@ const NpcOps: CommandHandlers = {
     },
 
     [ScriptOpcode.NPC_TELE]: checkedHandler(ActiveNpc, state => {
-        const coord = check(state.popInt(), CoordValid);
+        const position: Position = check(state.popInt(), CoordValid);
 
-        const pos = Position.unpackCoord(coord);
-        state.activeNpc.teleport(pos.x, pos.z, pos.level);
+        state.activeNpc.teleport(position.x, position.z, position.level);
     }),
 
     [ScriptOpcode.NPC_WALK]: checkedHandler(ActiveNpc, state => {
-        const coord = check(state.popInt(), CoordValid);
+        const position: Position = check(state.popInt(), CoordValid);
 
-        const pos = Position.unpackCoord(coord);
-        state.activeNpc.queueWaypoint(pos.x, pos.z);
+        state.activeNpc.queueWaypoint(position.x, position.z);
     }),
 
     [ScriptOpcode.NPC_CHANGETYPE]: checkedHandler(ActiveNpc, state => {
-        const id = check(state.popInt(), NpcTypeValid);
-
-        state.activeNpc.changeType(id);
+        state.activeNpc.changeType(check(state.popInt(), NpcTypeValid).id);
     }),
 
     [ScriptOpcode.NPC_GETMODE]: checkedHandler(ActiveNpc, state => {
@@ -422,9 +392,7 @@ const NpcOps: CommandHandlers = {
     }),
 
     [ScriptOpcode.NPC_HEROPOINTS]: checkedHandler([ScriptPointer.ActivePlayer, ...ActiveNpc], state => {
-        const damage = check(state.popInt(), NumberNotNull);
-
-        state.activeNpc.addHero(state.activePlayer.uid, damage);
+        state.activeNpc.addHero(state.activePlayer.uid, check(state.popInt(), NumberNotNull));
     }),
 
     [ScriptOpcode.NPC_WALKTRIGGER]: checkedHandler(ActiveNpc, state => {
@@ -468,8 +436,7 @@ const NpcOps: CommandHandlers = {
 
     // https://twitter.com/JagexAsh/status/1614498680144527360
     [ScriptOpcode.NPC_ATTACKRANGE]: checkedHandler(ActiveNpc, state => {
-        const type: NpcType = NpcType.get(state.activeNpc.type);
-        state.pushInt(type.attackrange);
+        state.pushInt(check(state.activeNpc.type, NpcTypeValid).attackrange);
     }),
 };
 

--- a/src/lostcity/engine/script/handlers/ObjConfigOps.ts
+++ b/src/lostcity/engine/script/handlers/ObjConfigOps.ts
@@ -9,124 +9,85 @@ import {check, ObjTypeValid, ParamTypeValid} from '#lostcity/engine/script/Scrip
 
 const ObjConfigOps: CommandHandlers = {
     [ScriptOpcode.OC_NAME]: state => {
-        const objId = check(state.popInt(), ObjTypeValid);
+        const objType: ObjType = check(state.popInt(), ObjTypeValid);
 
-        const objType = ObjType.get(objId);
         state.pushString(objType.name ?? objType.debugname ?? 'null');
     },
 
     [ScriptOpcode.OC_PARAM]: state => {
         const [objId, paramId] = state.popInts(2);
 
-        check(objId, ObjTypeValid);
-        check(paramId, ParamTypeValid);
-
-        const obj = ObjType.get(objId);
-        const param = ParamType.get(paramId);
-        if (param.isString()) {
-            state.pushString(ParamHelper.getStringParam(paramId, obj, param.defaultString));
+        const objType: ObjType = check(objId, ObjTypeValid);
+        const paramType: ParamType = check(paramId, ParamTypeValid);
+        if (paramType.isString()) {
+            state.pushString(ParamHelper.getStringParam(paramType.id, objType, paramType.defaultString));
         } else {
-            state.pushInt(ParamHelper.getIntParam(paramId, obj, param.defaultInt));
+            state.pushInt(ParamHelper.getIntParam(paramType.id, objType, paramType.defaultInt));
         }
     },
 
     [ScriptOpcode.OC_CATEGORY]: state => {
-        const objId = check(state.popInt(), ObjTypeValid);
-
-        const objType = ObjType.get(objId);
-        state.pushInt(objType.category);
+        state.pushInt(check(state.popInt(), ObjTypeValid).category);
     },
 
     [ScriptOpcode.OC_DESC]: state => {
-        const objId = check(state.popInt(), ObjTypeValid);
-
-        const objType = ObjType.get(objId);
-        state.pushString(objType.desc ?? 'null');
+        state.pushString(check(state.popInt(), ObjTypeValid).desc ?? 'null');
     },
 
     [ScriptOpcode.OC_MEMBERS]: state => {
-        const objId = check(state.popInt(), ObjTypeValid);
-
-        const objType = ObjType.get(objId);
-        state.pushInt(objType.members ? 1 : 0);
+        state.pushInt(check(state.popInt(), ObjTypeValid).members ? 1 : 0);
     },
 
     [ScriptOpcode.OC_WEIGHT]: state => {
-        const objId = check(state.popInt(), ObjTypeValid);
-
-        const objType = ObjType.get(objId);
-        state.pushInt(objType.weight);
+        state.pushInt(check(state.popInt(), ObjTypeValid).weight);
     },
 
     [ScriptOpcode.OC_WEARPOS]: state => {
-        const objId = check(state.popInt(), ObjTypeValid);
-
-        const objType = ObjType.get(objId);
-        state.pushInt(objType.wearpos);
+        state.pushInt(check(state.popInt(), ObjTypeValid).wearpos);
     },
 
     [ScriptOpcode.OC_WEARPOS2]: state => {
-        const objId = check(state.popInt(), ObjTypeValid);
-
-        const objType = ObjType.get(objId);
-        state.pushInt(objType.wearpos2);
+        state.pushInt(check(state.popInt(), ObjTypeValid).wearpos2);
     },
 
     [ScriptOpcode.OC_WEARPOS3]: state => {
-        const objId = check(state.popInt(), ObjTypeValid);
-
-        const objType = ObjType.get(objId);
-        state.pushInt(objType.wearpos3);
+        state.pushInt(check(state.popInt(), ObjTypeValid).wearpos3);
     },
 
     [ScriptOpcode.OC_COST]: state => {
-        const objId = check(state.popInt(), ObjTypeValid);
-
-        const obj = ObjType.get(objId);
-        state.pushInt(obj?.cost);
+        state.pushInt(check(state.popInt(), ObjTypeValid).cost);
     },
 
     [ScriptOpcode.OC_TRADEABLE]: state => {
-        const objId = check(state.popInt(), ObjTypeValid);
-
-        const obj = ObjType.get(objId);
-        state.pushInt(obj?.tradeable ? 1 : 0);
+        state.pushInt(check(state.popInt(), ObjTypeValid).tradeable ? 1 : 0);
     },
 
     [ScriptOpcode.OC_DEBUGNAME]: state => {
-        const objId = check(state.popInt(), ObjTypeValid);
-
-        const objType = ObjType.get(objId);
-        state.pushString(objType.debugname ?? 'null');
+        state.pushString(check(state.popInt(), ObjTypeValid).debugname ?? 'null');
     },
 
     [ScriptOpcode.OC_CERT]: state => {
-        const objId = check(state.popInt(), ObjTypeValid);
+        const objType: ObjType = check(state.popInt(), ObjTypeValid);
 
-        const objType = ObjType.get(objId);
         if (objType.certtemplate == -1 && objType.certlink >= 0) {
             state.pushInt(objType.certlink);
         } else {
-            state.pushInt(objId);
+            state.pushInt(objType.id);
         }
     },
 
     [ScriptOpcode.OC_UNCERT]: state => {
-        const objId = check(state.popInt(), ObjTypeValid);
+        const objType: ObjType = check(state.popInt(), ObjTypeValid);
 
-        const objType = ObjType.get(objId);
         if (objType.certtemplate >= 0 && objType.certlink >= 0) {
             state.pushInt(objType.certlink);
         } else {
-            state.pushInt(objId);
+            state.pushInt(objType.id);
         }
     },
 
     [ScriptOpcode.OC_STACKABLE]: state => {
-        const objId = check(state.popInt(), ObjTypeValid);
-
-        const objType = ObjType.get(objId);
-        state.pushInt(objType.stackable ? 1 : 0);
+        state.pushInt(check(state.popInt(), ObjTypeValid).stackable ? 1 : 0);
     }
 };
 

--- a/src/lostcity/engine/script/handlers/ObjOps.ts
+++ b/src/lostcity/engine/script/handlers/ObjOps.ts
@@ -13,12 +13,12 @@ import Obj from '#lostcity/entity/Obj.js';
 import { Position } from '#lostcity/entity/Position.js';
 
 import Environment from '#lostcity/util/Environment.js';
+
 import {
     check,
     CoordValid,
     DurationValid,
     InvTypeValid,
-    ObjNotDummyValid,
     ObjStackValid,
     ObjTypeValid,
     ParamTypeValid
@@ -35,14 +35,16 @@ const ObjOps: CommandHandlers = {
             return;
         }
 
-        check(objId, ObjTypeValid, ObjNotDummyValid);
+        const objType: ObjType = check(objId, ObjTypeValid);
         check(duration, DurationValid);
-        check(coord, CoordValid);
+        const position: Position = check(coord, CoordValid);
         check(count, ObjStackValid);
 
-        const {level, x, z} = Position.unpackCoord(coord);
-        const obj: Obj = new Obj(level, x, z, objId, count);
+        if (objType.dummyitem !== 0) {
+            throw new Error(`attempted to add dummy item: ${objType.debugname}`);
+        }
 
+        const obj: Obj = new Obj(position.level, position.x, position.z, objId, count);
         World.addObj(obj, state.activePlayer, duration);
         state.activeObj = obj;
         state.pointerAdd(ActiveObj[state.intOperand]);
@@ -57,21 +59,20 @@ const ObjOps: CommandHandlers = {
     },
 
     [ScriptOpcode.OBJ_PARAM]: state => {
-        const paramId = check(state.popInt(), ParamTypeValid);
+        const paramType: ParamType = check(state.popInt(), ParamTypeValid);
 
-        const param = ParamType.get(paramId);
-        const obj = ObjType.get(state.activeObj.type);
-        if (param.isString()) {
-            state.pushString(ParamHelper.getStringParam(paramId, obj, param.defaultString));
+        const objType: ObjType = check(state.activeObj.type, ObjTypeValid);
+        if (paramType.isString()) {
+            state.pushString(ParamHelper.getStringParam(paramType.id, objType, paramType.defaultString));
         } else {
-            state.pushInt(ParamHelper.getIntParam(paramId, obj, param.defaultInt));
+            state.pushInt(ParamHelper.getIntParam(paramType.id, objType, paramType.defaultInt));
         }
     },
 
     [ScriptOpcode.OBJ_NAME]: state => {
-        const obj = ObjType.get(state.activeObj.type);
+        const objType: ObjType = check(state.activeObj.type, ObjTypeValid);
 
-        state.pushString(obj.name ?? obj.debugname ?? 'null');
+        state.pushString(objType.name ?? objType.debugname ?? 'null');
     },
 
     [ScriptOpcode.OBJ_DEL]: state => {
@@ -83,29 +84,29 @@ const ObjOps: CommandHandlers = {
     },
 
     [ScriptOpcode.OBJ_COUNT]: state => {
-        state.pushInt(state.activeObj.count);
+        state.pushInt(check(state.activeObj.count, ObjStackValid));
     },
 
     [ScriptOpcode.OBJ_TYPE]: state => {
-        state.pushInt(state.activeObj.type);
+        state.pushInt(check(state.activeObj.type, ObjTypeValid).id);
     },
 
     [ScriptOpcode.OBJ_TAKEITEM]: state => {
-        const inv = check(state.popInt(), InvTypeValid);
+        const invType: InvType = check(state.popInt(), InvTypeValid);
 
         const obj = state.activeObj;
         if (World.getObj(obj.x, obj.z, obj.level, obj.id)) {
             const objType = ObjType.get(obj.type);
             state.activePlayer.playerLog('Picked up item', objType.debugname as string);
 
-            state.activePlayer.invAdd(inv, obj.id, obj.count);
+            state.activePlayer.invAdd(invType.id, obj.id, obj.count);
             World.removeObj(obj, state.activePlayer);
         }
     },
 
     [ScriptOpcode.OBJ_COORD]: state => {
-        const obj = state.activeObj;
-        state.pushInt(Position.packCoord(obj.level, obj.x, obj.z));
+        const position: Position = state.activeObj;
+        state.pushInt(Position.packCoord(position.level, position.x, position.z));
     }
 };
 

--- a/src/lostcity/engine/script/handlers/PlayerOps.ts
+++ b/src/lostcity/engine/script/handlers/PlayerOps.ts
@@ -1,4 +1,6 @@
 import IdkType from '#lostcity/cache/IdkType.js';
+import SpotanimType from '#lostcity/cache/SpotanimType.js';
+
 import World from '#lostcity/engine/World.js';
 
 import ScriptOpcode from '#lostcity/engine/script/ScriptOpcode.js';
@@ -12,10 +14,13 @@ import { PlayerQueueType, ScriptArgument } from '#lostcity/entity/EntityQueueReq
 import { PlayerTimerType } from '#lostcity/entity/EntityTimer.js';
 import { isNetworkPlayer } from '#lostcity/entity/NetworkPlayer.js';
 import { Position } from '#lostcity/entity/Position.js';
+import Interaction from '#lostcity/entity/Interaction.js';
 
 import ServerProt from '#lostcity/server/ServerProt.js';
 
 import Environment from '#lostcity/util/Environment.js';
+import ColorConversion from '#lostcity/util/ColorConversion.js';
+
 import * as rsmod from '@2004scape/rsmod-pathfinder';
 
 import {
@@ -27,10 +32,10 @@ import {
     NpcTypeValid,
     NumberNotNull,
     ObjTypeValid,
+    SeqTypeValid,
     SpotAnimTypeValid,
+    StringNotNull,
 } from '#lostcity/engine/script/ScriptValidators.js';
-import ColorConversion from '#lostcity/util/ColorConversion.js';
-import Interaction from '#lostcity/entity/Interaction.js';
 
 const ActivePlayer = [ScriptPointer.ActivePlayer, ScriptPointer.ActivePlayer2];
 const ProtectedActivePlayer = [ScriptPointer.ProtectedActivePlayer, ScriptPointer.ProtectedActivePlayer2];
@@ -73,7 +78,7 @@ const PlayerOps: CommandHandlers = {
 
     [ScriptOpcode.STRONGQUEUE]: checkedHandler(ActivePlayer, state => {
         const args = popScriptArgs(state);
-        const delay = state.popInt();
+        const delay = check(state.popInt(), NumberNotNull);
         const scriptId = state.popInt();
 
         const script = ScriptProvider.get(scriptId);
@@ -85,7 +90,7 @@ const PlayerOps: CommandHandlers = {
 
     [ScriptOpcode.WEAKQUEUE]: checkedHandler(ActivePlayer, state => {
         const args = popScriptArgs(state);
-        const delay = state.popInt();
+        const delay = check(state.popInt(), NumberNotNull);
         const scriptId = state.popInt();
 
         const script = ScriptProvider.get(scriptId);
@@ -97,7 +102,7 @@ const PlayerOps: CommandHandlers = {
 
     [ScriptOpcode.QUEUE]: checkedHandler(ActivePlayer, state => {
         const args = popScriptArgs(state);
-        const delay = state.popInt();
+        const delay = check(state.popInt(), NumberNotNull);
         const scriptId = state.popInt();
 
         const script = ScriptProvider.get(scriptId);
@@ -108,7 +113,7 @@ const PlayerOps: CommandHandlers = {
     }),
 
     [ScriptOpcode.ANIM]: checkedHandler(ActivePlayer, state => {
-        const delay = state.popInt();
+        const delay = check(state.popInt(), NumberNotNull);
         const seq = state.popInt();
 
         state.activePlayer.playAnimation(seq, delay);
@@ -119,17 +124,14 @@ const PlayerOps: CommandHandlers = {
     }),
 
     [ScriptOpcode.BUILDAPPEARANCE]: checkedHandler(ActivePlayer, state => {
-        const inv = check(state.popInt(), InvTypeValid);
-
-        state.activePlayer.generateAppearance(inv);
+        state.activePlayer.generateAppearance(check(state.popInt(), InvTypeValid).id);
     }),
 
     [ScriptOpcode.CAM_LOOKAT]: checkedHandler(ActivePlayer, state => {
         const [coord, height, rotationSpeed, rotationMultiplier] = state.popInts(4);
 
-        check(coord, CoordValid);
+        const pos: Position = check(coord, CoordValid);
 
-        const pos = Position.unpackCoord(coord);
         const localX = pos.x - Position.zoneOrigin(state.activePlayer.loadedX);
         const localZ = pos.z - Position.zoneOrigin(state.activePlayer.loadedZ);
 
@@ -139,9 +141,8 @@ const PlayerOps: CommandHandlers = {
     [ScriptOpcode.CAM_MOVETO]: checkedHandler(ActivePlayer, state => {
         const [coord, height, rotationSpeed, rotationMultiplier] = state.popInts(4);
 
-        check(coord, CoordValid);
+        const pos: Position = check(coord, CoordValid);
 
-        const pos = Position.unpackCoord(coord);
         const localX = pos.x - Position.zoneOrigin(state.activePlayer.loadedX);
         const localZ = pos.z - Position.zoneOrigin(state.activePlayer.loadedZ);
 
@@ -159,8 +160,8 @@ const PlayerOps: CommandHandlers = {
     }),
 
     [ScriptOpcode.COORD]: checkedHandler(ActivePlayer, state => {
-        const player = state.activePlayer;
-        state.pushInt(Position.packCoord(player.level, player.x, player.z));
+        const position: Position = state.activePlayer;
+        state.pushInt(Position.packCoord(position.level, position.x, position.z));
     }),
 
     [ScriptOpcode.DISPLAYNAME]: checkedHandler(ActivePlayer, state => {
@@ -168,9 +169,8 @@ const PlayerOps: CommandHandlers = {
     }),
 
     [ScriptOpcode.FACESQUARE]: checkedHandler(ActivePlayer, state => {
-        const coord = check(state.popInt(), CoordValid);
+        const pos: Position = check(state.popInt(), CoordValid);
 
-        const pos = Position.unpackCoord(coord);
         state.activePlayer.faceSquare(pos.x, pos.z);
     }),
 
@@ -303,7 +303,7 @@ const PlayerOps: CommandHandlers = {
     }),
 
     [ScriptOpcode.P_DELAY]: checkedHandler(ProtectedActivePlayer, state => {
-        state.activePlayer.delay = state.popInt() + 1;
+        state.activePlayer.delay = check(state.popInt(), NumberNotNull) + 1;
         state.execution = ScriptState.SUSPENDED;
         // TODO should this wipe any pointers?
     }),
@@ -313,7 +313,7 @@ const PlayerOps: CommandHandlers = {
     }),
 
     [ScriptOpcode.P_OPLOC]: checkedHandler(ProtectedActivePlayer, state => {
-        const type = state.popInt() - 1;
+        const type = check(state.popInt(), NumberNotNull) - 1;
         if (type < 0 || type >= 5) {
             throw new Error(`Invalid oploc: ${type + 1}`);
         }
@@ -329,7 +329,7 @@ const PlayerOps: CommandHandlers = {
     }),
 
     [ScriptOpcode.P_OPNPC]: checkedHandler(ProtectedActivePlayer, state => {
-        const type = state.popInt() - 1;
+        const type = check(state.popInt(), NumberNotNull) - 1;
         if (type < 0 || type >= 5) {
             throw new Error(`Invalid opnpc: ${type + 1}`);
         }
@@ -345,7 +345,7 @@ const PlayerOps: CommandHandlers = {
     }),
 
     [ScriptOpcode.P_OPNPCT]: checkedHandler(ProtectedActivePlayer, state => {
-        const spellId: number = state.popInt();
+        const spellId: number = check(state.popInt(), NumberNotNull);
         if (state.activePlayer.target !== null) {
             return;
         }
@@ -376,23 +376,20 @@ const PlayerOps: CommandHandlers = {
     }),
 
     [ScriptOpcode.P_TELEJUMP]: checkedHandler(ProtectedActivePlayer, state => {
-        const coord = check(state.popInt(), CoordValid);
+        const position: Position = check(state.popInt(), CoordValid);
 
-        const pos = Position.unpackCoord(coord);
-        state.activePlayer.teleJump(pos.x, pos.z, pos.level);
+        state.activePlayer.teleJump(position.x, position.z, position.level);
     }),
 
     [ScriptOpcode.P_TELEPORT]: checkedHandler(ProtectedActivePlayer, state => {
-        const coord = check(state.popInt(), CoordValid);
+        const position: Position = check(state.popInt(), CoordValid);
 
-        const pos = Position.unpackCoord(coord);
-        state.activePlayer.teleport(pos.x, pos.z, pos.level);
+        state.activePlayer.teleport(position.x, position.z, position.level);
     }),
 
     [ScriptOpcode.P_WALK]: checkedHandler(ProtectedActivePlayer, state => {
-        const coord = check(state.popInt(), CoordValid);
+        const pos: Position = check(state.popInt(), CoordValid);
 
-        const pos = Position.unpackCoord(coord);
         const player = state.activePlayer;
         player.queueWaypoints(rsmod.findPath(player.level, player.x, player.z, pos.x, pos.z, player.width, player.width, player.length, player.orientation));
         player.updateMovement(false); // try to walk immediately
@@ -451,11 +448,11 @@ const PlayerOps: CommandHandlers = {
     }),
 
     [ScriptOpcode.SPOTANIM_PL]: checkedHandler(ActivePlayer, state => {
-        const delay = state.popInt();
+        const delay = check(state.popInt(), NumberNotNull);
         const height = state.popInt();
-        const spotanim = check(state.popInt(), SpotAnimTypeValid);
+        const spotanimType: SpotanimType = check(state.popInt(), SpotAnimTypeValid);
 
-        state.activePlayer.spotanim(spotanim, height, delay);
+        state.activePlayer.spotanim(spotanimType.id, height, delay);
     }),
 
     [ScriptOpcode.STAT_HEAL]: checkedHandler(ActivePlayer, state => {
@@ -490,9 +487,7 @@ const PlayerOps: CommandHandlers = {
     }),
 
     [ScriptOpcode.IF_OPENCHAT]: checkedHandler(ActivePlayer, state => {
-        const com = check(state.popInt(), NumberNotNull);
-
-        state.activePlayer.openChat(com);
+        state.activePlayer.openChat(check(state.popInt(), NumberNotNull));
     }),
 
     [ScriptOpcode.IF_OPENMAINMODALSIDEOVERLAY]: checkedHandler(ActivePlayer, state => {
@@ -524,9 +519,7 @@ const PlayerOps: CommandHandlers = {
     }),
 
     [ScriptOpcode.IF_SETTABACTIVE]: checkedHandler(ActivePlayer, state => {
-        const tab = check(state.popInt(), NumberNotNull);
-
-        state.activePlayer.writeLowPriority(ServerProt.IF_SHOWSIDE, tab);
+        state.activePlayer.writeLowPriority(ServerProt.IF_SHOWSIDE, check(state.popInt(), NumberNotNull));
     }),
 
     [ScriptOpcode.IF_SETMODEL]: checkedHandler(ActivePlayer, state => {
@@ -547,9 +540,7 @@ const PlayerOps: CommandHandlers = {
     }),
 
     [ScriptOpcode.IF_SETTABFLASH]: checkedHandler(ActivePlayer, state => {
-        const tab = check(state.popInt(), NumberNotNull);
-
-        state.activePlayer.writeLowPriority(ServerProt.TUTORIAL_FLASHSIDE, tab);
+        state.activePlayer.writeLowPriority(ServerProt.TUTORIAL_FLASHSIDE, check(state.popInt(), NumberNotNull));
     }),
 
     [ScriptOpcode.IF_SETANIM]: checkedHandler(ActivePlayer, state => {
@@ -569,27 +560,19 @@ const PlayerOps: CommandHandlers = {
     }),
 
     [ScriptOpcode.IF_OPENMAINMODAL]: checkedHandler(ActivePlayer, state => {
-        const com = check(state.popInt(), NumberNotNull);
-
-        state.activePlayer.openMainModal(com);
+        state.activePlayer.openMainModal(check(state.popInt(), NumberNotNull));
     }),
 
     [ScriptOpcode.IF_OPENCHATSTICKY]: checkedHandler(ActivePlayer, state => {
-        const com = check(state.popInt(), NumberNotNull);
-
-        state.activePlayer.openChatSticky(com);
+        state.activePlayer.openChatSticky(check(state.popInt(), NumberNotNull));
     }),
 
     [ScriptOpcode.IF_OPENSIDEOVERLAY]: checkedHandler(ActivePlayer, state => {
-        const com = check(state.popInt(), NumberNotNull);
-
-        state.activePlayer.openSideOverlay(com);
+        state.activePlayer.openSideOverlay(check(state.popInt(), NumberNotNull));
     }),
 
     [ScriptOpcode.IF_SETPLAYERHEAD]: checkedHandler(ActivePlayer, state => {
-        const com = check(state.popInt(), NumberNotNull);
-
-        state.activePlayer.writeLowPriority(ServerProt.IF_SETPLAYERHEAD, com);
+        state.activePlayer.writeLowPriority(ServerProt.IF_SETPLAYERHEAD, check(state.popInt(), NumberNotNull));
     }),
 
     [ScriptOpcode.IF_SETTEXT]: checkedHandler(ActivePlayer, state => {
@@ -617,9 +600,7 @@ const PlayerOps: CommandHandlers = {
     }),
 
     [ScriptOpcode.IF_MULTIZONE]: checkedHandler(ActivePlayer, state => {
-        const multi = check(state.popInt(), NumberNotNull);
-
-        state.activePlayer.writeLowPriority(ServerProt.SET_MULTIWAY, multi === 1);
+        state.activePlayer.writeLowPriority(ServerProt.SET_MULTIWAY, check(state.popInt(), NumberNotNull) === 1);
     }),
 
     [ScriptOpcode.GIVEXP]: checkedHandler(ProtectedActivePlayer, state => {
@@ -660,12 +641,12 @@ const PlayerOps: CommandHandlers = {
     }),
 
     [ScriptOpcode.MIDI_SONG]: state => {
-        state.activePlayer.playSong(state.popString());
+        state.activePlayer.playSong(check(state.popString(), StringNotNull));
     },
 
     [ScriptOpcode.MIDI_JINGLE]: state => {
-        const delay = state.popInt();
-        const name = state.popString();
+        const delay = check(state.popInt(), NumberNotNull);
+        const name = check(state.popString(), StringNotNull);
         state.activePlayer.playJingle(delay, name);
     },
 
@@ -682,9 +663,7 @@ const PlayerOps: CommandHandlers = {
     }),
 
     [ScriptOpcode.CLEARSOFTTIMER]: checkedHandler(ActivePlayer, state => {
-        const timerId = state.popInt();
-
-        state.activePlayer.clearTimer(timerId);
+        state.activePlayer.clearTimer(state.popInt());
     }),
 
     [ScriptOpcode.SETTIMER]: checkedHandler(ActivePlayer, state => {
@@ -700,18 +679,14 @@ const PlayerOps: CommandHandlers = {
     }),
 
     [ScriptOpcode.CLEARTIMER]: checkedHandler(ActivePlayer, state => {
-        const timerId = state.popInt();
-
-        state.activePlayer.clearTimer(timerId);
+        state.activePlayer.clearTimer(state.popInt());
     }),
 
     [ScriptOpcode.HINT_COORD]: state => {
         const [offset, coord, height] = state.popInts(3);
 
-        check(coord, CoordValid);
-
-        const pos = Position.unpackCoord(coord);
-        state.activePlayer.hintTile(offset, pos.x, pos.z, height);
+        const position: Position = check(coord, CoordValid);
+        state.activePlayer.hintTile(offset, position.x, position.z, height);
     },
 
     [ScriptOpcode.HINT_STOP]: state => {
@@ -725,8 +700,8 @@ const PlayerOps: CommandHandlers = {
     [ScriptOpcode.P_EXACTMOVE]: checkedHandler(ProtectedActivePlayer, state => {
         const [start, end, startCycle, endCycle, direction] = state.popInts(5);
 
-        const startPos = Position.unpackCoord(check(start, CoordValid));
-        const endPos = Position.unpackCoord(check(end, CoordValid));
+        const startPos: Position = check(start, CoordValid);
+        const endPos: Position = check(end, CoordValid);
 
         state.activePlayer.unsetMapFlag();
         state.activePlayer.exactMove(startPos.x, startPos.z, endPos.x, endPos.z, startCycle, endCycle, direction);
@@ -757,17 +732,11 @@ const PlayerOps: CommandHandlers = {
     [ScriptOpcode.P_LOCMERGE]: checkedHandler(ProtectedActivePlayer, state => {
         const [startCycle, endCycle, southEast, northWest] = state.popInts(4);
 
-        const se = Position.unpackCoord(check(southEast, CoordValid));
-        const nw = Position.unpackCoord(check(northWest, CoordValid));
-
-        const east = se.x;
-        const south = se.z;
-
-        const west = nw.x;
-        const north = nw.z;
+        const se: Position = check(southEast, CoordValid);
+        const nw: Position = check(northWest, CoordValid);
 
         const loc = state.activeLoc;
-        World.getZone(loc.x, loc.z, loc.level).mergeLoc(loc, state.activePlayer, startCycle, endCycle, south, east, north, west);
+        World.getZone(loc.x, loc.z, loc.level).mergeLoc(loc, state.activePlayer, startCycle, endCycle, se.z, se.x, nw.z, nw.x);
     }),
 
     [ScriptOpcode.LAST_LOGIN_INFO]: state => {
@@ -791,31 +760,31 @@ const PlayerOps: CommandHandlers = {
     },
 
     [ScriptOpcode.BAS_READYANIM]: state => {
-        state.activePlayer.basReadyAnim = state.popInt();
+        state.activePlayer.basReadyAnim = check(state.popInt(), SeqTypeValid).id;
     },
 
     [ScriptOpcode.BAS_TURNONSPOT]: state => {
-        state.activePlayer.basTurnOnSpot = state.popInt();
+        state.activePlayer.basTurnOnSpot = check(state.popInt(), SeqTypeValid).id;
     },
 
     [ScriptOpcode.BAS_WALK_F]: state => {
-        state.activePlayer.basWalkForward = state.popInt();
+        state.activePlayer.basWalkForward = check(state.popInt(), SeqTypeValid).id;
     },
 
     [ScriptOpcode.BAS_WALK_B]: state => {
-        state.activePlayer.basWalkBackward = state.popInt();
+        state.activePlayer.basWalkBackward = check(state.popInt(), SeqTypeValid).id;
     },
 
     [ScriptOpcode.BAS_WALK_L]: state => {
-        state.activePlayer.basWalkLeft = state.popInt();
+        state.activePlayer.basWalkLeft = check(state.popInt(), SeqTypeValid).id;
     },
 
     [ScriptOpcode.BAS_WALK_R]: state => {
-        state.activePlayer.basWalkRight = state.popInt();
+        state.activePlayer.basWalkRight = check(state.popInt(), SeqTypeValid).id;
     },
 
     [ScriptOpcode.BAS_RUNNING]: state => {
-        state.activePlayer.basRunning = state.popInt();
+        state.activePlayer.basRunning = check(state.popInt(), SeqTypeValid).id;
     },
 
     [ScriptOpcode.GENDER]: state => {
@@ -823,15 +792,11 @@ const PlayerOps: CommandHandlers = {
     },
 
     [ScriptOpcode.HINT_NPC]: state => {
-        const npc_uid = check(state.popInt(), NumberNotNull);
-
-        state.activePlayer.hintNpc(npc_uid);
+        state.activePlayer.hintNpc(check(state.popInt(), NumberNotNull));
     },
 
     [ScriptOpcode.HINT_PLAYER]: state => {
-        const player_uid = check(state.popInt(), NumberNotNull);
-
-        state.activePlayer.hintPlayer(player_uid);
+        state.activePlayer.hintPlayer(check(state.popInt(), NumberNotNull));
     },
 
     [ScriptOpcode.HEADICONS_GET]: state => {
@@ -839,11 +804,11 @@ const PlayerOps: CommandHandlers = {
     },
 
     [ScriptOpcode.HEADICONS_SET]: state => {
-        state.activePlayer.headicons = state.popInt();
+        state.activePlayer.headicons = check(state.popInt(), NumberNotNull);
     },
 
     [ScriptOpcode.P_OPOBJ]: checkedHandler(ProtectedActivePlayer, state => {
-        const type = state.popInt() - 1;
+        const type = check(state.popInt(), NumberNotNull) - 1;
         if (type < 0 || type >= 5) {
             throw new Error(`Invalid opobj: ${type + 1}`);
         }
@@ -859,7 +824,7 @@ const PlayerOps: CommandHandlers = {
     }),
 
     [ScriptOpcode.P_OPPLAYER]: checkedHandler(ProtectedActivePlayer, state => {
-        const type = state.popInt() - 1;
+        const type = check(state.popInt(), NumberNotNull) - 1;
         if (type < 0 || type >= 5) {
             throw new Error(`Invalid opplayer: ${type + 1}`);
         }
@@ -879,9 +844,7 @@ const PlayerOps: CommandHandlers = {
     }),
 
     [ScriptOpcode.ALLOWDESIGN]: state => {
-        const allow = check(state.popInt(), NumberNotNull);
-
-        state.activePlayer.allowDesign = allow === 1;
+        state.activePlayer.allowDesign = check(state.popInt(), NumberNotNull) === 1;
     },
 
     [ScriptOpcode.LAST_TARGETSLOT]: state => {
@@ -917,11 +880,10 @@ const PlayerOps: CommandHandlers = {
     },
 
     [ScriptOpcode.HEALENERGY]: state => {
-        const amount = state.popInt(); // 100=1%, 1000=10%, 10000=100%
+        const amount = check(state.popInt(), NumberNotNull); // 100=1%, 1000=10%, 10000=100%
 
         const player = state.activePlayer;
-        const energy = Math.min(Math.max(player.runenergy + amount, 0), 10000);
-        player.runenergy = energy;
+        player.runenergy = Math.min(Math.max(player.runenergy + amount, 0), 10000);
     },
 
     [ScriptOpcode.AFK_EVENT]: state => {
@@ -936,15 +898,13 @@ const PlayerOps: CommandHandlers = {
     [ScriptOpcode.SETIDKIT]: (state) => {
         const [idkit, color] = state.popInts(2);
 
-        check(idkit, IDKTypeValid);
+        const idkType: IdkType = check(idkit, IDKTypeValid);
 
-        const idk = IdkType.get(idkit);
-
-        let slot = idk.type;
+        let slot = idkType.type;
         if (state.activePlayer.gender === 1) {
             slot -= 7;
         }
-        state.activePlayer.body[slot] = idkit;
+        state.activePlayer.body[slot] = idkType.id;
 
         // 0 - hair
         // 1 - torso
@@ -952,17 +912,17 @@ const PlayerOps: CommandHandlers = {
         // 3 - boots
         // 4 - jaw
         let colorSlot = -1;
-        if (idk.type === 0) {
+        if (idkType.type === 0) {
             colorSlot = 0;
-        } else if (idk.type === 1) {
+        } else if (idkType.type === 1) {
             colorSlot = 4;
-        } else if (idk.type === 2 || idk.type === 3) {
+        } else if (idkType.type === 2 || idkType.type === 3) {
             colorSlot = 1;
-        } else if (idk.type === 4) {
+        } else if (idkType.type === 4) {
             /* no-op (no hand recoloring) */
-        } else if (idk.type === 5) {
+        } else if (idkType.type === 5) {
             colorSlot = 2;
-        } else if (idk.type === 6) {
+        } else if (idkType.type === 6) {
             colorSlot = 3;
         }
 
@@ -972,7 +932,7 @@ const PlayerOps: CommandHandlers = {
     },
 
     [ScriptOpcode.P_OPPLAYERT]: checkedHandler(ProtectedActivePlayer, state => {
-        const spellId = state.popInt();
+        const spellId = check(state.popInt(), NumberNotNull);
         if (state.activePlayer.target !== null) {
             return;
         }

--- a/src/lostcity/engine/script/handlers/ServerOps.ts
+++ b/src/lostcity/engine/script/handlers/ServerOps.ts
@@ -1,10 +1,7 @@
-import FontType from '#lostcity/cache/FontType.js';
-import LocType from '#lostcity/cache/LocType.js';
-import MesanimType from '#lostcity/cache/MesanimType.js';
 import { ParamHelper } from '#lostcity/cache/ParamHelper.js';
 import ParamType from '#lostcity/cache/ParamType.js';
-import SeqType from '#lostcity/cache/SeqType.js';
 import StructType from '#lostcity/cache/StructType.js';
+import SpotanimType from '#lostcity/cache/SpotanimType.js';
 
 import World from '#lostcity/engine/World.js';
 
@@ -17,6 +14,8 @@ import {HuntIterator} from '#lostcity/engine/script/ScriptIterators.js';
 import { Position } from '#lostcity/entity/Position.js';
 import HuntModeType from '#lostcity/entity/hunt/HuntModeType.js';
 import Player from '#lostcity/entity/Player.js';
+import Npc from '#lostcity/entity/Npc.js';
+import HuntVis from '#lostcity/entity/hunt/HuntVis.js';
 
 import * as rsmod from '@2004scape/rsmod-pathfinder';
 import {CollisionFlag, LocLayer, LocAngle} from '@2004scape/rsmod-pathfinder';
@@ -24,11 +23,16 @@ import {CollisionFlag, LocLayer, LocAngle} from '@2004scape/rsmod-pathfinder';
 import {
     check,
     CoordValid,
+    FontTypeValid,
     HuntVisValid,
+    LocTypeValid,
+    MesanimValid,
     NumberNotNull,
-    SpotAnimTypeValid
+    ParamTypeValid,
+    SeqTypeValid,
+    SpotAnimTypeValid,
+    StructTypeValid
 } from '#lostcity/engine/script/ScriptValidators.js';
-import Npc from '#lostcity/entity/Npc.js';
 
 const ActivePlayer = [ScriptPointer.ActivePlayer, ScriptPointer.ActivePlayer2];
 const ActiveNpc = [ScriptPointer.ActiveNpc, ScriptPointer.ActiveNpc2];
@@ -45,8 +49,8 @@ const ServerOps: CommandHandlers = {
     [ScriptOpcode.MAP_PLAYERCOUNT]: state => {
         const [c1, c2] = state.popInts(2);
 
-        const from = Position.unpackCoord(check(c1, CoordValid));
-        const to = Position.unpackCoord(check(c2, CoordValid));
+        const from: Position = check(c1, CoordValid);
+        const to: Position = check(c2, CoordValid);
     
         let count = 0;
         for (let x = Math.floor(from.x / 8); x <= Math.ceil(to.x / 8); x++) {
@@ -70,13 +74,11 @@ const ServerOps: CommandHandlers = {
     [ScriptOpcode.HUNTALL]: state => {
         const [coord, distance, checkVis] = state.popInts(3);
 
-        check(coord, CoordValid);
+        const position: Position = check(coord, CoordValid);
         check(distance, NumberNotNull);
-        check(checkVis, HuntVisValid);
+        const huntvis: HuntVis = check(checkVis, HuntVisValid);
 
-        const {level, x, z} = Position.unpackCoord(coord);
-
-        state.huntIterator = new HuntIterator(World.currentTick, level, x, z, distance, checkVis, HuntModeType.PLAYER);
+        state.huntIterator = new HuntIterator(World.currentTick, position.level, position.x, position.z, distance, huntvis, HuntModeType.PLAYER);
     },
 
     [ScriptOpcode.HUNTNEXT]: state => {
@@ -98,13 +100,11 @@ const ServerOps: CommandHandlers = {
     [ScriptOpcode.NPC_HUNTALL]: state => {
         const [coord, distance, checkVis] = state.popInts(3);
 
-        check(coord, CoordValid);
+        const position: Position = check(coord, CoordValid);
         check(distance, NumberNotNull);
-        check(checkVis, HuntVisValid);
+        const huntvis: HuntVis = check(checkVis, HuntVisValid);
 
-        const {level, x, z} = Position.unpackCoord(coord);
-
-        state.huntIterator = new HuntIterator(World.currentTick, level, x, z, distance, checkVis, HuntModeType.NPC);
+        state.huntIterator = new HuntIterator(World.currentTick, position.level, position.x, position.z, distance, huntvis, HuntModeType.NPC);
     },
 
     [ScriptOpcode.NPC_HUNTNEXT]: state => {
@@ -126,9 +126,9 @@ const ServerOps: CommandHandlers = {
     [ScriptOpcode.INZONE]: state => {
         const [c1, c2, c3] = state.popInts(3);
 
-        const from = Position.unpackCoord(check(c1, CoordValid));
-        const to = Position.unpackCoord(check(c2, CoordValid));
-        const pos = Position.unpackCoord(check(c3, CoordValid));
+        const from: Position = check(c1, CoordValid);
+        const to: Position = check(c2, CoordValid);
+        const pos: Position = check(c3, CoordValid);
 
         if (pos.x < from.x || pos.x > to.x) {
             state.pushInt(0);
@@ -144,8 +144,13 @@ const ServerOps: CommandHandlers = {
     [ScriptOpcode.LINEOFWALK]: state => {
         const [c1, c2] = state.popInts(2);
 
-        const from = Position.unpackCoord(check(c1, CoordValid));
-        const to = Position.unpackCoord(check(c2, CoordValid));
+        const from: Position = check(c1, CoordValid);
+        const to: Position = check(c2, CoordValid);
+
+        if (from.level !== to.level) {
+            state.pushInt(0);
+            return;
+        }
 
         state.pushInt(rsmod.hasLineOfWalk(from.level, from.x, from.z, to.x, to.z, 1, 1, 1, 1) ? 1 : 0);
     },
@@ -162,42 +167,36 @@ const ServerOps: CommandHandlers = {
     [ScriptOpcode.SPOTANIM_MAP]: state => {
         const [spotanim, coord, height, delay] = state.popInts(4);
 
-        check(spotanim, SpotAnimTypeValid);
+        const position: Position = check(coord, CoordValid);
+        const spotanimType: SpotanimType = check(spotanim, SpotAnimTypeValid);
 
-        const {level, x, z} = Position.unpackCoord(check(coord, CoordValid));
-
-        World.getZone(x, z, level).animMap(x, z, spotanim, height, delay);
+        World.getZone(position.x, position.z, position.level).animMap(position.x, position.z, spotanimType.id, height, delay);
     },
 
     [ScriptOpcode.DISTANCE]: state => {
         const [c1, c2] = state.popInts(2);
 
-        const from = Position.unpackCoord(check(c1, CoordValid));
-        const to = Position.unpackCoord(check(c2, CoordValid));
+        const from: Position = check(c1, CoordValid);
+        const to: Position = check(c2, CoordValid);
 
-        const dx = Math.abs(from.x - to.x);
-        const dz = Math.abs(from.z - to.z);
-
-        state.pushInt(Math.max(dx, dz));
+        state.pushInt(Position.distanceToSW(from, to));
     },
 
     [ScriptOpcode.MOVECOORD]: state => {
         const [coord, x, y, z] = state.popInts(4);
 
-        const pos = Position.unpackCoord(check(coord, CoordValid));
-        state.pushInt(Position.packCoord(pos.level + y, pos.x + x, pos.z + z));
+        const position: Position = check(coord, CoordValid);
+        state.pushInt(Position.packCoord(position.level + y, position.x + x, position.z + z));
     },
 
     [ScriptOpcode.SEQLENGTH]: state => {
-        const seq = state.popInt();
-
-        state.pushInt(SeqType.get(seq).duration);
+        state.pushInt(check(state.popInt(), SeqTypeValid).duration);
     },
 
     [ScriptOpcode.SPLIT_INIT]: state => {
         const [maxWidth, linesPerPage, fontId, mesanimId] = state.popInts(4);
         const text = state.popString();
-        const font = FontType.get(fontId);
+        const font = check(fontId, FontTypeValid);
         const lines = font.split(text, maxWidth);
 
         state.splitPages = [];
@@ -230,34 +229,31 @@ const ServerOps: CommandHandlers = {
             return;
         }
 
-        const mesanimType = MesanimType.get(state.splitMesanim);
-        state.pushInt(mesanimType.len[state.splitPages[page].length - 1]);
+        state.pushInt(check(state.splitMesanim, MesanimValid).len[state.splitPages[page].length - 1]);
     },
 
     [ScriptOpcode.STRUCT_PARAM]: state => {
         const [structId, paramId] = state.popInts(2);
-        const param = ParamType.get(paramId);
-        const struct = StructType.get(structId);
-        if (param.isString()) {
-            state.pushString(ParamHelper.getStringParam(paramId, struct, param.defaultString));
+
+        const paramType: ParamType = check(paramId, ParamTypeValid);
+        const structType: StructType = check(structId, StructTypeValid);
+        if (paramType.isString()) {
+            state.pushString(ParamHelper.getStringParam(paramType.id, structType, paramType.defaultString));
         } else {
-            state.pushInt(ParamHelper.getIntParam(paramId, struct, param.defaultInt));
+            state.pushInt(ParamHelper.getIntParam(paramType.id, structType, paramType.defaultInt));
         }
     },
 
     [ScriptOpcode.COORDX]: state => {
-        const coord = check(state.popInt(), CoordValid);
-        state.pushInt(Position.unpackCoord(coord).x);
+        state.pushInt(check(state.popInt(), CoordValid).x);
     },
 
     [ScriptOpcode.COORDY]: state => {
-        const coord = check(state.popInt(), CoordValid);
-        state.pushInt(Position.unpackCoord(coord).level);
+        state.pushInt(check(state.popInt(), CoordValid).level);
     },
 
     [ScriptOpcode.COORDZ]: state => {
-        const coord = check(state.popInt(), CoordValid);
-        state.pushInt(Position.unpackCoord(coord).z);
+        state.pushInt(check(state.popInt(), CoordValid).z);
     },
 
     [ScriptOpcode.PLAYERCOUNT]: state => {
@@ -265,24 +261,27 @@ const ServerOps: CommandHandlers = {
     },
 
     [ScriptOpcode.MAP_BLOCKED]: state => {
-        const coord = check(state.popInt(), CoordValid);
+        const position: Position = check(state.popInt(), CoordValid);
 
-        const pos = Position.unpackCoord(coord);
-        state.pushInt(rsmod.isFlagged(pos.x, pos.z, pos.level, CollisionFlag.WALK_BLOCKED) ? 1 : 0);
+        state.pushInt(rsmod.isFlagged(position.x, position.z, position.level, CollisionFlag.WALK_BLOCKED) ? 1 : 0);
     },
 
     [ScriptOpcode.MAP_INDOORS]: state => {
-        const coord = check(state.popInt(), CoordValid);
+        const position: Position = check(state.popInt(), CoordValid);
 
-        const pos = Position.unpackCoord(coord);
-        state.pushInt(rsmod.isFlagged(pos.x, pos.z, pos.level, CollisionFlag.ROOF) ? 1 : 0);
+        state.pushInt(rsmod.isFlagged(position.x, position.z, position.level, CollisionFlag.ROOF) ? 1 : 0);
     },
 
     [ScriptOpcode.LINEOFSIGHT]: state => {
         const [c1, c2] = state.popInts(2);
 
-        const from = Position.unpackCoord(check(c1, CoordValid));
-        const to = Position.unpackCoord(check(c2, CoordValid));
+        const from: Position = check(c1, CoordValid);
+        const to: Position = check(c2, CoordValid);
+
+        if (from.level !== to.level) {
+            state.pushInt(0);
+            return;
+        }
 
         state.pushInt(rsmod.hasLineOfSight(from.level, from.x, from.z, to.x, to.z, 1, 1, 1, 1) ? 1 : 0);
     },
@@ -295,24 +294,22 @@ const ServerOps: CommandHandlers = {
     [ScriptOpcode.PROJANIM_PL]: state => {
         const [srcCoord, uid, spotanim, srcHeight, dstHeight, delay, duration, peak, arc] = state.popInts(9);
 
-        check(srcCoord, CoordValid);
-        check(spotanim, SpotAnimTypeValid);
+        const srcPos: Position = check(srcCoord, CoordValid);
+        const spotanimType: SpotanimType = check(spotanim, SpotAnimTypeValid);
 
         const player = World.getPlayerByUid(uid);
         if (!player) {
             throw new Error(`attempted to use invalid player uid: ${uid}`);
         }
 
-        const srcPos = Position.unpackCoord(srcCoord);
-        const zone = World.getZone(srcPos.x, srcPos.z, srcPos.level);
-        zone.mapProjAnim(srcPos.x, srcPos.z, player.x, player.z, -player.pid - 1, spotanim, srcHeight + 100, dstHeight + 100, delay, duration, peak, arc);
+        World.getZone(srcPos.x, srcPos.z, srcPos.level).mapProjAnim(srcPos.x, srcPos.z, player.x, player.z, -player.pid - 1, spotanimType.id, srcHeight + 100, dstHeight + 100, delay, duration, peak, arc);
     },
 
     [ScriptOpcode.PROJANIM_NPC]: state => {
         const [srcCoord, npcUid, spotanim, srcHeight, dstHeight, delay, duration, peak, arc] = state.popInts(9);
 
-        check(srcCoord, CoordValid);
-        check(spotanim, SpotAnimTypeValid);
+        const srcPos: Position = check(srcCoord, CoordValid);
+        const spotanimType: SpotanimType = check(spotanim, SpotAnimTypeValid);
 
         const slot = npcUid & 0xffff;
         const expectedType = (npcUid >> 16) & 0xffff;
@@ -322,33 +319,28 @@ const ServerOps: CommandHandlers = {
             throw new Error(`attempted to use invalid npc uid: ${npcUid}`);
         }
 
-        const srcPos = Position.unpackCoord(srcCoord);
-        const zone = World.getZone(srcPos.x, srcPos.z, srcPos.level);
-        zone.mapProjAnim(srcPos.x, srcPos.z, npc.x, npc.z, npc.nid + 1, spotanim, srcHeight + 100, dstHeight + 100, delay, duration, peak, arc);
+        World.getZone(srcPos.x, srcPos.z, srcPos.level).mapProjAnim(srcPos.x, srcPos.z, npc.x, npc.z, npc.nid + 1, spotanimType.id, srcHeight + 100, dstHeight + 100, delay, duration, peak, arc);
     },
 
     [ScriptOpcode.PROJANIM_MAP]: state => {
         const [srcCoord, dstCoord, spotanim, srcHeight, dstHeight, delay, duration, peak, arc] = state.popInts(9);
 
-        check(spotanim, SpotAnimTypeValid);
+        const spotanimType: SpotanimType = check(spotanim, SpotAnimTypeValid);
+        const srcPos: Position = check(srcCoord, CoordValid);
+        const dstPos: Position = check(dstCoord, CoordValid);
 
-        const srcPos = Position.unpackCoord(check(srcCoord, CoordValid));
-        const dstPos = Position.unpackCoord(check(dstCoord, CoordValid));
-        const zone = World.getZone(srcPos.x, srcPos.z, srcPos.level);
-        zone.mapProjAnim(srcPos.x, srcPos.z, dstPos.x, dstPos.z, 0, spotanim, srcHeight + 100, dstHeight, delay, duration, peak, arc);
+        World.getZone(srcPos.x, srcPos.z, srcPos.level).mapProjAnim(srcPos.x, srcPos.z, dstPos.x, dstPos.z, 0, spotanimType.id, srcHeight + 100, dstHeight, delay, duration, peak, arc);
     },
 
     [ScriptOpcode.MAP_LOCADDUNSAFE]: state => {
-        const coord = check(state.popInt(), CoordValid);
-
-        const pos = Position.unpackCoord(coord);
+        const pos: Position = check(state.popInt(), CoordValid);
 
         const zone = World.getZone(pos.x, pos.z, pos.level);
         const locs = zone.staticLocs.concat(zone.locs);
 
         for (let index = 0; index < locs.length; index++) {
             const loc = locs[index];
-            const type = LocType.get(loc.type);
+            const type = check(loc.type, LocTypeValid);
 
             if (type.active !== 1) {
                 continue;

--- a/src/lostcity/entity/Position.ts
+++ b/src/lostcity/entity/Position.ts
@@ -11,6 +11,8 @@ export const Direction = {
 // TODO (jkm) consider making this an enum
 type Direction = (typeof Direction)[keyof typeof Direction];
 
+export type Position = {level: number, x: number, z: number};
+
 // TODO (jkm) consider making this a class
 export const Position = {
     zone: (pos: number) => pos >> 3,
@@ -107,7 +109,7 @@ export const Position = {
         return 0;
     },
 
-    unpackCoord(coord: number): { level: number; x: number; z: number } {
+    unpackCoord(coord: number): Position {
         const level = (coord >> 28) & 0x3;
         const x = (coord >> 14) & 0x3fff;
         const z = coord & 0x3fff;


### PR DESCRIPTION
- Adds a new type `export type Position = {level: number, x: number, z: number};` 
- The ScriptValidators now return the specific types they are checking
- Removes a bunch of redundant code throughout the script handlers.
- Adds few additional checks like for vars or mesanims.

From:
```ts
    [ScriptOpcode.LC_CATEGORY]: state => {
        const locId = check(state.popInt(), LocTypeValid);

        const locType = LocType.get(locId);
        state.pushInt(locType.category);
    },
```

To:
```ts
    [ScriptOpcode.LC_CATEGORY]: state => {
        state.pushInt(check(state.popInt(), LocTypeValid).category);
    },
```