### PR TITLE
refactor(engine): additional enum types for some script validators

### DIFF
--- a/src/lostcity/engine/GameMap.ts
+++ b/src/lostcity/engine/GameMap.ts
@@ -11,7 +11,7 @@ import World from '#lostcity/engine/World.js';
 
 import Npc from '#lostcity/entity/Npc.js';
 import Obj from '#lostcity/entity/Obj.js';
-import {EntityLifeCycle} from '#lostcity/entity/EntityLifeCycle.js';
+import EntityLifeCycle from '#lostcity/entity/EntityLifeCycle.js';
 
 export default class GameMap {
     readonly collisionManager = new CollisionManager();

--- a/src/lostcity/engine/World.ts
+++ b/src/lostcity/engine/World.ts
@@ -48,7 +48,7 @@ import Loc from '#lostcity/entity/Loc.js';
 import Npc from '#lostcity/entity/Npc.js';
 import Obj from '#lostcity/entity/Obj.js';
 import Player from '#lostcity/entity/Player.js';
-import {EntityLifeCycle} from '#lostcity/entity/EntityLifeCycle.js';
+import EntityLifeCycle from '#lostcity/entity/EntityLifeCycle.js';
 import {NpcList, PlayerList} from '#lostcity/entity/EntityList.js';
 import { NetworkPlayer, isNetworkPlayer } from '#lostcity/entity/NetworkPlayer.js';
 import { EntityQueueState } from '#lostcity/entity/EntityQueueRequest.js';
@@ -68,7 +68,6 @@ import { makeCrcs } from '#lostcity/server/CrcTable.js';
 import { preloadClient } from '#lostcity/server/PreloadedPacks.js';
 
 import * as rsmod from '@2004scape/rsmod-pathfinder';
-import * as console from 'console';
 
 class World {
     id = Environment.WORLD_ID as number;

--- a/src/lostcity/engine/collision/CollisionManager.ts
+++ b/src/lostcity/engine/collision/CollisionManager.ts
@@ -7,7 +7,7 @@ import ZoneManager from '#lostcity/engine/zone/ZoneManager.js';
 import LocType from '#lostcity/cache/config/LocType.js';
 
 import Loc from '#lostcity/entity/Loc.js';
-import {EntityLifeCycle} from '#lostcity/entity/EntityLifeCycle.js';
+import EntityLifeCycle from '#lostcity/entity/EntityLifeCycle.js';
 
 import * as rsmod from '@2004scape/rsmod-pathfinder';
 import {LocAngle, LocLayer} from '@2004scape/rsmod-pathfinder';

--- a/src/lostcity/engine/script/ScriptValidators.ts
+++ b/src/lostcity/engine/script/ScriptValidators.ts
@@ -23,6 +23,9 @@ import MesanimType from '#lostcity/cache/config/MesanimType.js';
 import StructType from '#lostcity/cache/config/StructType.js';
 import DbRowType from '#lostcity/cache/config/DbRowType.js';
 import DbTableType from '#lostcity/cache/config/DbTableType.js';
+import NpcStat from '#lostcity/entity/NpcStat.js';
+import HitType from '#lostcity/entity/HitType.js';
+import PlayerStat from '#lostcity/entity/PlayerStat.js';
 
 interface ScriptValidator<T, R> {
     validate(input: T): R;
@@ -96,11 +99,12 @@ export const DurationValid: ScriptValidator<number, number> = new ScriptInputRan
 export const CoordValid: ScriptValidator<number, Position> = new ScriptInputCoordValidator(0, 2147483647, 'Coord');
 export const ParamTypeValid: ScriptValidator<number, ParamType> = new ScriptInputConfigTypeValidator(ParamType.get, (input: number) => input >= 0 && input < ParamType.count, 'Param');
 export const NpcTypeValid: ScriptValidator<number, NpcType> = new ScriptInputConfigTypeValidator(NpcType.get, (input: number) => input >= 0 && input < NpcType.count, 'Npc');
-export const NpcStatValid: ScriptValidator<number, number> = new ScriptInputRangeValidator(0, 6, 'NpcStat');
+export const NpcStatValid: ScriptValidator<number, NpcStat> = new ScriptInputRangeValidator(NpcStat.HITPOINTS, NpcStat.RANGED, 'NpcStat');
+export const PlayerStatValid: ScriptValidator<number, PlayerStat> = new ScriptInputRangeValidator(PlayerStat.ATTACK, PlayerStat.RUNECRAFT, 'PlayerStat');
 export const QueueValid: ScriptValidator<number, number> = new ScriptInputRangeValidator(0, 19, 'AIQueue');
 export const HuntTypeValid: ScriptValidator<number, HuntType> = new ScriptInputConfigTypeValidator(HuntType.get, (input: number) => input >= 0 && input < HuntType.count, 'Hunt');
-export const NpcModeValid: ScriptValidator<number, number> = new ScriptInputRangeValidator(NpcMode.NULL, NpcMode.APNPC5, 'NpcMode');
-export const HitTypeValid: ScriptValidator<number, number> = new ScriptInputRangeValidator(0, 2, 'Hit');
+export const NpcModeValid: ScriptValidator<number, NpcMode> = new ScriptInputRangeValidator(NpcMode.NULL, NpcMode.APNPC5, 'NpcMode');
+export const HitTypeValid: ScriptValidator<number, HitType> = new ScriptInputRangeValidator(HitType.BLOCK, HitType.POISON, 'Hit');
 export const SpotAnimTypeValid: ScriptValidator<number, SpotanimType> = new ScriptInputConfigTypeValidator(SpotanimType.get, (input: number) => input >= 0 && input < SpotanimType.count, 'Spotanim');
 export const EnumTypeValid: ScriptValidator<number, EnumType> = new ScriptInputConfigTypeValidator(EnumType.get, (input: number) => input >= 0 && input < EnumType.count, 'Enum');
 export const ObjTypeValid: ScriptValidator<number, ObjType> = new ScriptInputConfigTypeValidator(ObjType.get, (input: number) => input >= 0 && input < ObjType.count, 'Obj');

--- a/src/lostcity/engine/script/handlers/InvOps.ts
+++ b/src/lostcity/engine/script/handlers/InvOps.ts
@@ -10,7 +10,7 @@ import {ActivePlayer, checkedHandler, ProtectedActivePlayer} from '#lostcity/eng
 
 import Obj from '#lostcity/entity/Obj.js';
 import {Position} from '#lostcity/entity/Position.js';
-import {EntityLifeCycle} from '#lostcity/entity/EntityLifeCycle.js';
+import EntityLifeCycle from '#lostcity/entity/EntityLifeCycle.js';
 
 import {
     CategoryTypeValid,

--- a/src/lostcity/engine/script/handlers/LocOps.ts
+++ b/src/lostcity/engine/script/handlers/LocOps.ts
@@ -13,7 +13,7 @@ import Zone from '#lostcity/engine/zone/Zone.js';
 
 import Loc from '#lostcity/entity/Loc.js';
 import { Position } from '#lostcity/entity/Position.js';
-import {EntityLifeCycle} from '#lostcity/entity/EntityLifeCycle.js';
+import EntityLifeCycle from '#lostcity/entity/EntityLifeCycle.js';
 
 import {
     check,

--- a/src/lostcity/engine/script/handlers/NpcOps.ts
+++ b/src/lostcity/engine/script/handlers/NpcOps.ts
@@ -22,7 +22,7 @@ import NpcMode from '#lostcity/entity/NpcMode.js';
 import Entity from '#lostcity/entity/Entity.js';
 import Interaction from '#lostcity/entity/Interaction.js';
 import HuntVis from '#lostcity/entity/hunt/HuntVis.js';
-import {EntityLifeCycle} from '#lostcity/entity/EntityLifeCycle.js';
+import EntityLifeCycle from '#lostcity/entity/EntityLifeCycle.js';
 
 import Environment from '#lostcity/util/Environment.js';
 

--- a/src/lostcity/engine/script/handlers/ObjOps.ts
+++ b/src/lostcity/engine/script/handlers/ObjOps.ts
@@ -11,7 +11,7 @@ import { CommandHandlers } from '#lostcity/engine/script/ScriptRunner.js';
 
 import Obj from '#lostcity/entity/Obj.js';
 import { Position } from '#lostcity/entity/Position.js';
-import {EntityLifeCycle} from '#lostcity/entity/EntityLifeCycle.js';
+import EntityLifeCycle from '#lostcity/entity/EntityLifeCycle.js';
 
 import Environment from '#lostcity/util/Environment.js';
 

--- a/src/lostcity/engine/script/handlers/PlayerOps.ts
+++ b/src/lostcity/engine/script/handlers/PlayerOps.ts
@@ -16,6 +16,7 @@ import { isNetworkPlayer } from '#lostcity/entity/NetworkPlayer.js';
 import { Position } from '#lostcity/entity/Position.js';
 import CameraInfo from '#lostcity/entity/CameraInfo.js';
 import Interaction from '#lostcity/entity/Interaction.js';
+import PlayerStat from '#lostcity/entity/PlayerStat.js';
 
 import ServerProt from '#lostcity/server/ServerProt.js';
 
@@ -38,7 +39,6 @@ import {
     SpotAnimTypeValid,
     StringNotNull,
 } from '#lostcity/engine/script/ScriptValidators.js';
-import PlayerStat from '#lostcity/entity/PlayerStat.js';
 
 const PlayerOps: CommandHandlers = {
     [ScriptOpcode.FINDUID]: state => {

--- a/src/lostcity/engine/script/handlers/PlayerOps.ts
+++ b/src/lostcity/engine/script/handlers/PlayerOps.ts
@@ -33,10 +33,12 @@ import {
     NpcTypeValid,
     NumberNotNull,
     ObjTypeValid,
+    PlayerStatValid,
     SeqTypeValid,
     SpotAnimTypeValid,
     StringNotNull,
 } from '#lostcity/engine/script/ScriptValidators.js';
+import PlayerStat from '#lostcity/entity/PlayerStat.js';
 
 const PlayerOps: CommandHandlers = {
     [ScriptOpcode.FINDUID]: state => {
@@ -390,13 +392,13 @@ const PlayerOps: CommandHandlers = {
     }),
 
     [ScriptOpcode.STAT]: checkedHandler(ActivePlayer, state => {
-        const stat = check(state.popInt(), NumberNotNull);
+        const stat: PlayerStat = check(state.popInt(), PlayerStatValid);
 
         state.pushInt(state.activePlayer.levels[stat]);
     }),
 
     [ScriptOpcode.STAT_BASE]: checkedHandler(ActivePlayer, state => {
-        const stat = check(state.popInt(), NumberNotNull);
+        const stat: PlayerStat = check(state.popInt(), PlayerStatValid);
 
         state.pushInt(state.activePlayer.baseLevels[stat]);
     }),
@@ -404,7 +406,7 @@ const PlayerOps: CommandHandlers = {
     [ScriptOpcode.STAT_ADD]: checkedHandler(ActivePlayer, state => {
         const [stat, constant, percent] = state.popInts(3);
 
-        check(stat, NumberNotNull);
+        check(stat, PlayerStatValid);
         check(constant, NumberNotNull);
         check(percent, NumberNotNull);
 
@@ -420,7 +422,7 @@ const PlayerOps: CommandHandlers = {
     [ScriptOpcode.STAT_SUB]: checkedHandler(ActivePlayer, state => {
         const [stat, constant, percent] = state.popInts(3);
 
-        check(stat, NumberNotNull);
+        check(stat, PlayerStatValid);
         check(constant, NumberNotNull);
         check(percent, NumberNotNull);
 
@@ -441,7 +443,7 @@ const PlayerOps: CommandHandlers = {
     [ScriptOpcode.STAT_HEAL]: checkedHandler(ActivePlayer, state => {
         const [stat, constant, percent] = state.popInts(3);
 
-        check(stat, NumberNotNull);
+        check(stat, PlayerStatValid);
         check(constant, NumberNotNull);
         check(percent, NumberNotNull);
 

--- a/src/lostcity/entity/Entity.ts
+++ b/src/lostcity/entity/Entity.ts
@@ -1,4 +1,4 @@
-import {EntityLifeCycle} from '#lostcity/entity/EntityLifeCycle.js';
+import EntityLifeCycle from '#lostcity/entity/EntityLifeCycle.js';
 
 export default abstract class Entity {
     // constructor

--- a/src/lostcity/entity/EntityLifeCycle.ts
+++ b/src/lostcity/entity/EntityLifeCycle.ts
@@ -1,5 +1,7 @@
-export enum EntityLifeCycle {
+enum EntityLifeCycle {
     FOREVER, // never respawns or despawns, is always in the world.
     RESPAWN, // entity added from engine that respawns later.
     DESPAWN // entity added from script that despawns later.
 }
+
+export default EntityLifeCycle;

--- a/src/lostcity/entity/HitType.ts
+++ b/src/lostcity/entity/HitType.ts
@@ -1,0 +1,7 @@
+enum HitType {
+    BLOCK,
+    DAMAGE,
+    POISON
+}
+
+export default HitType;

--- a/src/lostcity/entity/Loc.ts
+++ b/src/lostcity/entity/Loc.ts
@@ -1,5 +1,5 @@
 import NonPathingEntity from '#lostcity/entity/NonPathingEntity.js';
-import {EntityLifeCycle} from '#lostcity/entity/EntityLifeCycle.js';
+import EntityLifeCycle from '#lostcity/entity/EntityLifeCycle.js';
 
 export default class Loc extends NonPathingEntity {
     // constructor properties

--- a/src/lostcity/entity/Npc.ts
+++ b/src/lostcity/entity/Npc.ts
@@ -32,26 +32,20 @@ import {HuntIterator} from '#lostcity/engine/script/ScriptIterators.js';
 import MoveSpeed from '#lostcity/entity/MoveSpeed.js';
 import Entity from '#lostcity/entity/Entity.js';
 import Interaction from '#lostcity/entity/Interaction.js';
-import {EntityLifeCycle} from '#lostcity/entity/EntityLifeCycle.js';
+import EntityLifeCycle from '#lostcity/entity/EntityLifeCycle.js';
 
 import * as rsmod from '@2004scape/rsmod-pathfinder';
 import {CollisionFlag, CollisionType} from '@2004scape/rsmod-pathfinder';
+import NpcStat from '#lostcity/entity/NpcStat.js';
 
 export default class Npc extends PathingEntity {
-    static ANIM = 0x2;
-    static FACE_ENTITY = 0x4;
-    static SAY = 0x8;
-    static DAMAGE = 0x10;
-    static CHANGE_TYPE = 0x20;
-    static SPOTANIM = 0x40;
-    static FACE_COORD = 0x80;
-
-    static HITPOINTS = 0;
-    static ATTACK = 1;
-    static STRENGTH = 2;
-    static DEFENCE = 3;
-    static MAGIC = 4;
-    static RANGED = 5;
+    static readonly ANIM = 0x2;
+    static readonly FACE_ENTITY = 0x4;
+    static readonly SAY = 0x8;
+    static readonly DAMAGE = 0x10;
+    static readonly CHANGE_TYPE = 0x20;
+    static readonly SPOTANIM = 0x40;
+    static readonly FACE_COORD = 0x80;
 
     // constructor properties
     nid: number;
@@ -60,8 +54,8 @@ export default class Npc extends PathingEntity {
     origType: number;
     startX: number;
     startZ: number;
-    levels: Uint8Array;
-    baseLevels: Uint8Array;
+    levels: Uint8Array = new Uint8Array(6);
+    baseLevels: Uint8Array = new Uint8Array(6);
 
     // runtime variables
     vars: Int32Array;
@@ -96,9 +90,6 @@ export default class Npc extends PathingEntity {
         this.origType = type;
 
         const npcType = NpcType.get(type);
-
-        this.levels = new Uint8Array(6);
-        this.baseLevels = new Uint8Array(6);
 
         for (let index = 0; index < npcType.stats.length; index++) {
             const level = npcType.stats[index];
@@ -812,12 +803,12 @@ export default class Npc extends PathingEntity {
         this.damageTaken = damage;
         this.damageType = type;
 
-        const current = this.levels[Npc.HITPOINTS];
+        const current = this.levels[NpcStat.HITPOINTS];
         if (current - damage <= 0) {
-            this.levels[Npc.HITPOINTS] = 0;
+            this.levels[NpcStat.HITPOINTS] = 0;
             this.damageTaken = current;
         } else {
-            this.levels[Npc.HITPOINTS] = current - damage;
+            this.levels[NpcStat.HITPOINTS] = current - damage;
         }
 
         this.mask |= Npc.DAMAGE;
@@ -917,8 +908,8 @@ export default class Npc extends PathingEntity {
         if (mask & Npc.DAMAGE) {
             out.p1(this.damageTaken);
             out.p1(this.damageType);
-            out.p1(this.levels[Npc.HITPOINTS]);
-            out.p1(this.baseLevels[Npc.HITPOINTS]);
+            out.p1(this.levels[NpcStat.HITPOINTS]);
+            out.p1(this.baseLevels[NpcStat.HITPOINTS]);
         }
 
         if (mask & Npc.CHANGE_TYPE) {

--- a/src/lostcity/entity/Npc.ts
+++ b/src/lostcity/entity/Npc.ts
@@ -33,10 +33,10 @@ import MoveSpeed from '#lostcity/entity/MoveSpeed.js';
 import Entity from '#lostcity/entity/Entity.js';
 import Interaction from '#lostcity/entity/Interaction.js';
 import EntityLifeCycle from '#lostcity/entity/EntityLifeCycle.js';
+import NpcStat from '#lostcity/entity/NpcStat.js';
 
 import * as rsmod from '@2004scape/rsmod-pathfinder';
 import {CollisionFlag, CollisionType} from '@2004scape/rsmod-pathfinder';
-import NpcStat from '#lostcity/entity/NpcStat.js';
 
 export default class Npc extends PathingEntity {
     static readonly ANIM = 0x2;

--- a/src/lostcity/entity/NpcStat.ts
+++ b/src/lostcity/entity/NpcStat.ts
@@ -1,0 +1,10 @@
+enum NpcStat {
+    HITPOINTS,
+    ATTACK,
+    STRENGTH,
+    DEFENCE,
+    MAGIC,
+    RANGED
+}
+
+export default NpcStat;

--- a/src/lostcity/entity/Obj.ts
+++ b/src/lostcity/entity/Obj.ts
@@ -1,5 +1,5 @@
 import NonPathingEntity from '#lostcity/entity/NonPathingEntity.js';
-import {EntityLifeCycle} from '#lostcity/entity/EntityLifeCycle.js';
+import EntityLifeCycle from '#lostcity/entity/EntityLifeCycle.js';
 
 export default class Obj extends NonPathingEntity {
     // constructor properties

--- a/src/lostcity/entity/PathingEntity.ts
+++ b/src/lostcity/entity/PathingEntity.ts
@@ -11,7 +11,7 @@ import NpcMode from '#lostcity/entity/NpcMode.js';
 import MoveRestrict from '#lostcity/entity/MoveRestrict.js';
 import MoveSpeed from '#lostcity/entity/MoveSpeed.js';
 import { Direction, Position } from '#lostcity/entity/Position.js';
-import {EntityLifeCycle} from '#lostcity/entity/EntityLifeCycle.js';
+import EntityLifeCycle from '#lostcity/entity/EntityLifeCycle.js';
 
 import LocType from '#lostcity/cache/config/LocType.js';
 

--- a/src/lostcity/entity/PlayerLoading.ts
+++ b/src/lostcity/entity/PlayerLoading.ts
@@ -10,6 +10,8 @@ import World from '#lostcity/engine/World.js';
 
 import { NetworkPlayer } from '#lostcity/entity/NetworkPlayer.js';
 import Player, { getExpByLevel, getLevelByExp } from '#lostcity/entity/Player.js';
+import PlayerStat from '#lostcity/entity/PlayerStat.js';
+
 import Environment from '#lostcity/util/Environment.js';
 
 export class PlayerLoading {
@@ -48,9 +50,9 @@ export class PlayerLoading {
             }
 
             // hitpoints starts at level 10
-            player.stats[Player.HITPOINTS] = getExpByLevel(10);
-            player.baseLevels[Player.HITPOINTS] = 10;
-            player.levels[Player.HITPOINTS] = 10;
+            player.stats[PlayerStat.HITPOINTS] = getExpByLevel(10);
+            player.baseLevels[PlayerStat.HITPOINTS] = 10;
+            player.levels[PlayerStat.HITPOINTS] = 10;
             return player;
         }
 

--- a/src/lostcity/entity/PlayerStat.ts
+++ b/src/lostcity/entity/PlayerStat.ts
@@ -1,0 +1,25 @@
+enum PlayerStat {
+    ATTACK,
+    DEFENCE,
+    STRENGTH,
+    HITPOINTS,
+    RANGED,
+    PRAYER,
+    MAGIC,
+    COOKING,
+    WOODCUTTING,
+    FLETCHING,
+    FISHING,
+    FIREMAKING,
+    CRAFTING,
+    SMITHING,
+    MINING,
+    HERBLORE,
+    AGILITY,
+    THIEVING,
+    STAT18,
+    STAT19,
+    RUNECRAFT
+}
+
+export default PlayerStat;

--- a/src/lostcity/network/225/incoming/handler/ClientCheatHandler.ts
+++ b/src/lostcity/network/225/incoming/handler/ClientCheatHandler.ts
@@ -21,6 +21,7 @@ import { tryParseInt } from '#lostcity/util/TryParse.js';
 import ScriptVarType from '#lostcity/cache/config/ScriptVarType.js';
 import { Position } from '#lostcity/entity/Position.js';
 import ScriptRunner from '#lostcity/engine/script/ScriptRunner.js';
+import PlayerStat from '#lostcity/entity/PlayerStat.js';
 
 export default class ClientCheatHandler extends MessageHandler<ClientCheat> {
     handle(message: ClientCheat, player: Player): boolean {
@@ -186,7 +187,7 @@ export default class ClientCheatHandler extends MessageHandler<ClientCheat> {
             player.stats[stat] = exp;
         } else if (cmd === 'minlevel') {
             for (let i = 0; i < Player.SKILLS.length; i++) {
-                if (i === Player.HITPOINTS) {
+                if (i === PlayerStat.HITPOINTS) {
                     player.setLevel(i, 10);
                 } else {
                     player.setLevel(i, 1);

--- a/src/lostcity/tools/server/drops.ts
+++ b/src/lostcity/tools/server/drops.ts
@@ -9,7 +9,7 @@ import ServerTriggerType from '#lostcity/engine/script/ServerTriggerType.js';
 import Npc from '#lostcity/entity/Npc.js';
 import { PlayerLoading } from '#lostcity/entity/PlayerLoading.js';
 import ObjType from '#lostcity/cache/config/ObjType.js';
-import {EntityLifeCycle} from '#lostcity/entity/EntityLifeCycle.js';
+import EntityLifeCycle from '#lostcity/entity/EntityLifeCycle.js';
 
 import Environment from '#lostcity/util/Environment.js';
 


### PR DESCRIPTION
- Creates a `PlayerStat`, `NpcStat` and `HitType` enums for script validators. The stats are redundant.
- `EntityLifeCycle` default exports.
- Set the Player and Npc masks as readonly and add `static readonly BIG_UPDATE = 0x80;` for a player mask.