### PR TITLE
fix(content): delrith being unattackable outside of 2 zones

### DIFF
--- a/data/src/scripts/quests/quest_demon/scripts/delrith.rs2
+++ b/data/src/scripts/quests/quest_demon/scripts/delrith.rs2
@@ -43,14 +43,8 @@ if (%demon_progress < ^demon_complete) {
 
 [queue,delrith_death]
 if_close;
-npc_findallzone(0_50_52_25_38);
-while (npc_findnext = true) {
-    if (npc_type = delrith) npc_changetype(weakened_delrith);
-}
-
-npc_findallzone(0_50_52_30_44);
-while (npc_findnext = true) {
-    if (npc_type = delrith) npc_changetype(weakened_delrith);
+if (npc_find(coord, delrith, 8, 0) = true) {
+    npc_changetype(weakened_delrith);
 }
 
 p_stopaction;
@@ -79,20 +73,9 @@ p_delay(1);
 mes("Suddenly, the vortex closes!");
 p_delay(1);
 
-npc_findallzone(0_50_52_25_38);
-while (npc_findnext = true) {
-    if (npc_type = weakened_delrith) {
-        @restore_delrith;
-        return;
-    }
-}
-
-npc_findallzone(0_50_52_30_44);
-while (npc_findnext = true) {
-    if (npc_type = weakened_delrith) {
-        @restore_delrith;
-        return;
-    }
+if (npc_find(coord, weakened_delrith, 8, 0) = true) {
+    @restore_delrith;
+    return;
 }
 
 [label,restore_delrith]
@@ -105,22 +88,10 @@ mes("That was the wrong incantation");
 ~mesbox("As you chant, Delrith is sucked towards the vortex...|Back to the dark dimension from which he came...");
 if_close;
 
-npc_findallzone(0_50_52_25_38);
-while (npc_findnext = true) {
-    if (npc_type = weakened_delrith) {
-        gosub(npc_death);
-        queue(demon_slayer_complete, 1);
-        return;
-    }
-}
-
-npc_findallzone(0_50_52_30_44);
-while (npc_findnext = true) {
-    if (npc_type = weakened_delrith) {
-        gosub(npc_death);
-        queue(demon_slayer_complete, 1);
-        return;
-    }
+if (npc_find(coord, weakened_delrith, 8, 0) = true) {
+    gosub(npc_death);
+    queue(demon_slayer_complete, 1);
+    return;
 }
 
 // Everything below here is a guess. This is set up so if a player doesn't kill weakened delrith he becomes


### PR DESCRIPTION
Check by distance instead, allows you to kill it outside of the stonehenge circle. Not sure if this is correct but since there are no instances it would otherwise be unattackable outside of it. Alternatively it may have given a message but I don't know. That would be weird though as you'd have to wait for him to randomly walk back to the center before being able to fight again (changing wanderrange to 1 still causes it to walk too far both sides)