### PR TITLE
fix(engine): allow cors again for separate localhost webclients

### DIFF
--- a/src/lostcity/web.ts
+++ b/src/lostcity/web.ts
@@ -17,6 +17,10 @@ MIME_TYPES.set('.sf2', 'application/octet-stream');
 
 // we don't need/want a full blown website or API on the game server
 const web = http.createServer(async (req, res) => {
+    if (!Environment.SKIP_CORS) {
+        res.setHeader('Access-Control-Allow-Origin', '*');
+    }
+
     if (req.method !== 'GET') {
         res.writeHead(405);
         res.end();


### PR DESCRIPTION
This was removed with fastify in https://github.com/2004Scape/Server/commit/0ca570e0da87793753c21f6b1e4db220fa4128ae