### PR TITLE
small updates some members npc check + fixed 1 animation

### DIFF
--- a/data/src/scripts/_unpack/all.npc
+++ b/data/src/scripts/_unpack/all.npc
@@ -1128,8 +1128,10 @@ param=magicdefence,-4
 param=rangedefence,16
 param=damagetype,^slash_style
 param=attack_anim,human_sword_slash
-// param=defend_anim,human_sword_defend2
+param=defend_anim,human_sword_defend2
 param=attack_sound,hacksword_slash
+// param=defend_sound,
+// osrs defend sound blade3_mail
 
 [wyson]
 name=Wyson the gardener
@@ -1160,7 +1162,7 @@ param=damagetype,^stab_style
 param=attack_anim,human_farmersfork_stab
 param=defend_anim,human_farmersfork_defend
 param=attack_sound,staff_stab
-// param=attack_sound,farmersfork_stab      original?
+// osrs attack sound farmersfork_stab
 
 [npc_38]
 name=Shipyard worker
@@ -8030,6 +8032,8 @@ resizeh=80
 resizev=80
 model1=model_3010_npc
 model2=model_3006_obj
+members=yes
+param=attack_anim,cat_attack
 param=death_anim,cat_death
 
 [npc_760]
@@ -8174,6 +8178,7 @@ op1=Search
 minimap=no
 model1=model_loc_0_8
 wanderrange=0
+members=yes
 moverestrict=nomove
 blockwalk=all
 
@@ -8446,6 +8451,7 @@ model5=model_428_idk
 model6=model_358_idk
 model7=model_444_obj_wear
 head1=model_113_idk_head
+members=yes
 param=death_sound,female_death
 
 [npc_781]
@@ -8468,6 +8474,7 @@ model2=model_2909_npc
 model3=model_2918_npc
 head1=model_139_npc_head
 wanderrange=2
+members=yes
 param=death_anim,midget_death
 
 [npc_782]
@@ -8486,6 +8493,7 @@ model2=model_2909_npc
 model3=model_2918_npc
 head1=model_139_npc_head
 moverestrict=indoors
+members=yes
 param=death_anim,midget_death
 
 [npc_784]
@@ -8504,6 +8512,7 @@ model2=model_2909_npc
 model3=model_2918_npc
 head1=model_139_npc_head
 moverestrict=indoors
+members=yes
 param=death_anim,midget_death
 
 [npc_788]
@@ -9140,7 +9149,6 @@ vislevel=1
 model1=model_2936_npc
 timer=1
 param=death_anim,dog_death
-// TODO sound
 
 [npc_822]
 vislevel=hide

--- a/data/src/scripts/areas/area_gnome/configs/gnome.npc
+++ b/data/src/scripts/areas/area_gnome/configs/gnome.npc
@@ -395,6 +395,7 @@ model2=model_2908_npc
 model3=model_2922_npc
 head1=model_19_npc_head
 wanderrange=1
+members=yes
 param=death_anim,midget_death
 param=death_sound,gnome_death
 

--- a/data/src/scripts/areas/area_varrock/configs/varrock.npc
+++ b/data/src/scripts/areas/area_varrock/configs/varrock.npc
@@ -928,4 +928,5 @@ model2=model_2909_npc
 model3=model_2918_npc
 head1=model_139_npc_head
 wanderrange=2
+members=yes
 param=death_anim,midget_death

--- a/data/src/scripts/macro events/configs/antimacro.npc
+++ b/data/src/scripts/macro events/configs/antimacro.npc
@@ -39,6 +39,8 @@ param=defend_anim,seq_354
 param=death_anim,seq_355
 param=death_drop,null
 param=attack_sound,triffid_attack
+// npc has no defend sound at all? or it uses the attack sound also as the defend sound.
+// I'm not sure, try to find out the information. TODO
 param=max_dealt,3
 param=combat_xp_multiplier,25
 // https://youtu.be/mah2N7nznSk?list=PLn23LiLYLb1aLE-R7X4IV6D0Jl-m2el9i for poison and hit points (estimated)


### PR DESCRIPTION
The npc listed below no longer appear on the f2p server.
gertrude, gertrude's cat
philop, shilop, cinnamon, Wilough
Crate (kitten crate)
--
and Soldier's defend animation fixed. my own mistake when I had accidentally marked it //.
![minimap gertrude](https://github.com/2004Scape/Server/assets/131913782/e1049cb9-2180-4f3b-b3d7-b38d6efcc80c)
![Varrock_Square](https://github.com/2004Scape/Server/assets/131913782/11023d31-3b4d-41c4-ab17-ca984b3c25c7)
