### PR TITLE
refactor(engine): performance optimizations

### DIFF
--- a/src/jagex2/io/Packet.ts
+++ b/src/jagex2/io/Packet.ts
@@ -215,11 +215,7 @@ export default class Packet extends Hashable {
         this.p1(value ? 1 : 0);
     }
 
-    pjstr(str: string | null, terminator: number = 10): void {
-        if (str === null) {
-            str = 'null';
-        }
-
+    pjstr(str: string, terminator: number = 10): void {
         const length: number = str.length;
         for (let i: number = 0; i < length; i++) {
             this.#view.setUint8(this.pos++, str.charCodeAt(i));
@@ -228,8 +224,11 @@ export default class Packet extends Hashable {
     }
 
     pdata(src: Uint8Array, offset: number, length: number): void {
-        this.data.set(src.subarray(offset, offset + length), this.pos);
-        this.pos += length - offset;
+        const view: DataView = this.#view;
+        const total: number = offset + length;
+        for (let i: number = offset; i < total; i++) {
+            view.setUint8(this.pos++, src[i]);
+        }
     }
 
     psize4(size: number): void {
@@ -325,8 +324,11 @@ export default class Packet extends Hashable {
     }
 
     gdata(dest: Uint8Array, offset: number, length: number): void {
-        dest.set(this.data.subarray(this.pos, this.pos + length), offset);
-        this.pos += length;
+        const view: DataView = this.#view;
+        const total: number = offset + length;
+        for (let i: number = offset; i < total; i++) {
+            dest[i] = view.getUint8(this.pos++);
+        }
     }
 
     gsmarts(): number {

--- a/src/lostcity/engine/World.ts
+++ b/src/lostcity/engine/World.ts
@@ -65,8 +65,6 @@ import {makeCrcs} from '#lostcity/server/CrcTable.js';
 import {preloadClient} from '#lostcity/server/PreloadedPacks.js';
 import {Position} from '#lostcity/entity/Position.js';
 import UpdateRebootTimer from '#lostcity/network/outgoing/model/UpdateRebootTimer.js';
-import PlayerInfo from '#lostcity/network/outgoing/model/PlayerInfo.js';
-import NpcInfo from '#lostcity/network/outgoing/model/NpcInfo.js';
 import ZoneGrid from '#lostcity/engine/zone/ZoneGrid.js';
 import ZoneMap from '#lostcity/engine/zone/ZoneMap.js';
 
@@ -582,7 +580,7 @@ class World {
                 if (this.shutdownTick < this.currentTick) {
                     // request logout on socket idle after 45 seconds (this may be 16 *ticks* in osrs!)
                     // increased timeout for compatibility with old PCs that take ages to load
-                    if (this.currentTick - player.lastResponse >= 75) {
+                    if (!Environment.LOCAL_DEV && this.currentTick - player.lastResponse >= 75) {
                         player.logoutRequested = true;
                     }
                 }
@@ -600,7 +598,7 @@ class World {
         // player logout
         let playerLogout = Date.now();
         for (const player of this.players) {
-            if (this.currentTick - player.lastResponse >= 100) {
+            if (!Environment.LOCAL_DEV && this.currentTick - player.lastResponse >= 100) {
                 // remove after 60 seconds
                 player.queue.clear();
                 player.weakQueue.clear();
@@ -724,8 +722,8 @@ class World {
 
             try {
                 player.updateMap();
-                player.write(new PlayerInfo(player));
-                player.write(new NpcInfo(player));
+                player.updatePlayers();
+                player.updateNpcs();
                 player.updateZones();
                 player.updateInvs();
                 player.updateStats();

--- a/src/lostcity/entity/NetworkPlayer.ts
+++ b/src/lostcity/entity/NetworkPlayer.ts
@@ -32,6 +32,9 @@ import CamLookAt from '#lostcity/network/outgoing/model/CamLookAt.js';
 import OutgoingMessage from '#lostcity/network/outgoing/OutgoingMessage.js';
 import ServerProtRepository from '#lostcity/network/225/outgoing/prot/ServerProtRepository.js';
 import MessageEncoder from '#lostcity/network/outgoing/codec/MessageEncoder.js';
+import Logout from '#lostcity/network/outgoing/model/Logout.js';
+import PlayerInfo from '#lostcity/network/outgoing/model/PlayerInfo.js';
+import NpcInfo from '#lostcity/network/outgoing/model/NpcInfo.js';
 
 export class NetworkPlayer extends Player {
     client: ClientSocket | null = null;
@@ -128,7 +131,8 @@ export class NetworkPlayer extends Player {
     }
 
     writeInner(message: OutgoingMessage): void {
-        if (!this.client) {
+        const client = this.client;
+        if (!client) {
             return;
         }
         const encoder: MessageEncoder<OutgoingMessage> | undefined = ServerProtRepository.getEncoder(message);
@@ -136,19 +140,17 @@ export class NetworkPlayer extends Player {
             return;
         }
         const prot: ServerProt = encoder.prot;
-        let buf: Packet;
-        if (prot.length === -1) {
-            buf = Packet.alloc(1);
-        } else if (prot.length === -2) {
-            buf = Packet.alloc(2); // maybe this can be a type 1.
-        } else {
-            buf = new Packet(new Uint8Array(1 + encoder.prot.length));
+        const buf = client.out;
+        const test = (1 + prot.length === -1 ? 1 : prot.length === -2 ? 2 : 0) + encoder.test(message);
+        if (buf.pos + test >= buf.length) {
+            client.flush();
         }
+        const pos: number = buf.pos;
         buf.p1(prot.id);
         if (prot.length === -1) {
-            buf.p1(0);
+            buf.pos += 1;
         } else if (prot.length === -2) {
-            buf.p2(0);
+            buf.pos += 2;
         }
         const start: number = buf.pos;
         encoder.encode(buf, message);
@@ -157,31 +159,15 @@ export class NetworkPlayer extends Player {
         } else if (prot.length === -2) {
             buf.psize2(buf.pos - start);
         }
-        if (this.client.encryptor) {
-            buf.data[0] = (buf.data[0] + this.client.encryptor.nextInt()) & 0xff;
+        if (client.encryptor) {
+            buf.data[pos] = (buf.data[pos] + client.encryptor.nextInt()) & 0xff;
         }
-        World.lastCycleBandwidth[1] += buf.pos;
-        this.client.write(buf);
-    }
-
-    writeImmediately(packet: Packet) {
-        if (!this.client) {
-            return;
-        }
-
-        if (this.client.encryptor) {
-            packet.data[0] = (packet.data[0] + this.client.encryptor.nextInt()) & 0xff;
-        }
-
-        this.client.write(packet);
-        this.client.flush();
+        World.lastCycleBandwidth[1] += buf.pos - pos;
     }
 
     override logout() {
-        const out = new Packet(new Uint8Array(1));
-        out.p1(ServerProt.LOGOUT.id);
-
-        this.writeImmediately(out);
+        this.writeInner(new Logout());
+        this.client?.flush();
     }
 
     override terminate() {
@@ -251,6 +237,14 @@ export class NetworkPlayer extends Player {
                 activeZones.add(ZoneMap.zoneIndex(x << 3, z << 3, this.level));
             }
         }
+    }
+
+    updatePlayers() {
+        this.write(new PlayerInfo(this.buildArea, this.level, this.x, this.z, this.originX, this.originZ, this.uid, this.mask, this.tele, this.jump, this.walkDir, this.runDir));
+    }
+
+    updateNpcs() {
+        this.write(new NpcInfo(this.buildArea, this.level, this.x, this.z, this.originX, this.originZ));
     }
 
     updateZones() {

--- a/src/lostcity/entity/Player.ts
+++ b/src/lostcity/entity/Player.ts
@@ -236,6 +236,7 @@ export default class Player extends PathingEntity {
     combatLevel: number = 3;
     headicons: number = 0;
     appearance: Uint8Array | null = null; // cached appearance
+    appearanceHashCode: bigint = 0n;
     baseLevels = new Uint8Array(21);
     lastStats: Int32Array = new Int32Array(21); // we track this so we know to flush stats only once a tick on changes
     lastLevels: Uint8Array = new Uint8Array(21); // we track this so we know to flush stats only once a tick on changes
@@ -1066,9 +1067,11 @@ export default class Player extends PathingEntity {
             }
         }
 
+        const parts: bigint[] = [];
         for (let slot = 0; slot < 12; slot++) {
             if (skippedSlots.indexOf(slot) !== -1) {
                 stream.p1(0);
+                parts[slot] = 0n;
                 continue;
             }
 
@@ -1077,11 +1080,14 @@ export default class Player extends PathingEntity {
                 const appearanceValue = this.getAppearanceInSlot(slot);
                 if (appearanceValue < 1) {
                     stream.p1(0);
+                    parts[slot] = 0n;
                 } else {
                     stream.p2(appearanceValue);
+                    parts[slot] = BigInt(appearanceValue);
                 }
             } else {
                 stream.p2(0x200 + equip.id);
+                parts[slot] = BigInt(0x200 + equip.id);
             }
         }
 
@@ -1106,6 +1112,26 @@ export default class Player extends PathingEntity {
         stream.pos = 0;
         stream.gdata(this.appearance, 0, this.appearance.length);
         stream.release();
+
+        this.appearanceHashCode = 0n;
+        for (let part: number = 0; part < 12; part++) {
+            this.appearanceHashCode <<= 0x4n;
+            if (parts[part] >= 256) {
+                this.appearanceHashCode += parts[part] - 256n;
+            }
+        }
+        if (parts[0] >= 256) {
+            this.appearanceHashCode += (parts[0] - 256n) >> 4n;
+        }
+        if (parts[1] >= 256) {
+            this.appearanceHashCode += (parts[1] - 256n) >> 8n;
+        }
+        for (let part: number = 0; part < 5; part++) {
+            this.appearanceHashCode <<= 0x3n;
+            this.appearanceHashCode += BigInt(this.colors[part]);
+        }
+        this.appearanceHashCode <<= 0x1n;
+        this.appearanceHashCode += BigInt(this.gender);
     }
 
     // ----

--- a/src/lostcity/network/225/outgoing/codec/DataLandEncoder.ts
+++ b/src/lostcity/network/225/outgoing/codec/DataLandEncoder.ts
@@ -13,4 +13,8 @@ export default class DataLandEncoder extends MessageEncoder<DataLand> {
         buf.p2(message.length);
         buf.pdata(message.data, 0, message.data.length);
     }
+
+    test(message: DataLand): number {
+        return 1 + 1 + 2 + 2 + message.data.length;
+    }
 }

--- a/src/lostcity/network/225/outgoing/codec/DataLocEncoder.ts
+++ b/src/lostcity/network/225/outgoing/codec/DataLocEncoder.ts
@@ -13,4 +13,8 @@ export default class DataLocEncoder extends MessageEncoder<DataLoc> {
         buf.p2(message.length);
         buf.pdata(message.data, 0, message.data.length);
     }
+
+    test(message: DataLoc): number {
+        return 1 + 1 + 2 + 2 + message.data.length;
+    }
 }

--- a/src/lostcity/network/225/outgoing/codec/IfSetTextEncoder.ts
+++ b/src/lostcity/network/225/outgoing/codec/IfSetTextEncoder.ts
@@ -10,4 +10,8 @@ export default class IfSetTextEncoder extends MessageEncoder<IfSetText> {
         buf.p2(message.component);
         buf.pjstr(message.text);
     }
+
+    test(message: IfSetText): number {
+        return 2 + 1 + message.text.length;
+    }
 }

--- a/src/lostcity/network/225/outgoing/codec/MessageGameEncoder.ts
+++ b/src/lostcity/network/225/outgoing/codec/MessageGameEncoder.ts
@@ -9,4 +9,8 @@ export default class MessageGameEncoder extends MessageEncoder<MessageGame> {
     encode(buf: Packet, message: MessageGame): void {
         buf.pjstr(message.msg);
     }
+
+    test(message: MessageGame): number {
+        return 1 + message.msg.length;
+    }
 }

--- a/src/lostcity/network/225/outgoing/codec/MessagePrivateEncoder.ts
+++ b/src/lostcity/network/225/outgoing/codec/MessagePrivateEncoder.ts
@@ -14,4 +14,8 @@ export default class MessagePrivateEncoder extends MessageEncoder<MessagePrivate
         buf.p1(message.staffModLevel);
         WordPack.pack(buf, WordEnc.filter(message.msg));
     }
+
+    test(message: MessagePrivate): number {
+        return 8 + 4 + 1 + 1 + message.msg.length;
+    }
 }

--- a/src/lostcity/network/225/outgoing/codec/MidiJingleEncoder.ts
+++ b/src/lostcity/network/225/outgoing/codec/MidiJingleEncoder.ts
@@ -11,4 +11,8 @@ export default class MidiJingleEncoder extends MessageEncoder<MidiJingle> {
         buf.p4(message.data.length);
         buf.pdata(message.data, 0, message.data.length);
     }
+
+    test(message: MidiJingle): number {
+        return 2 + 4 + message.data.length;
+    }
 }

--- a/src/lostcity/network/225/outgoing/codec/MidiSongEncoder.ts
+++ b/src/lostcity/network/225/outgoing/codec/MidiSongEncoder.ts
@@ -11,4 +11,8 @@ export default class MidiSongEncoder extends MessageEncoder<MidiSong> {
         buf.p4(message.crc);
         buf.p4(message.length);
     }
+
+    test(message: MidiSong): number {
+        return 1 + message.name.length + 4 + 4;
+    }
 }

--- a/src/lostcity/network/225/outgoing/codec/RebuildNormalEncoder.ts
+++ b/src/lostcity/network/225/outgoing/codec/RebuildNormalEncoder.ts
@@ -19,4 +19,8 @@ export default class RebuildNormalEncoder extends MessageEncoder<RebuildNormal> 
             buf.p4(PRELOADED_CRC.get(`l${x}_${z}`) ?? 0);
         }
     }
+
+    test(message: RebuildNormal): number {
+        return 2 + 2 + (message.mapsquares.size * (1 + 1 + 4 + 4));
+    }
 }

--- a/src/lostcity/network/225/outgoing/codec/UpdateIgnoreListEncoder.ts
+++ b/src/lostcity/network/225/outgoing/codec/UpdateIgnoreListEncoder.ts
@@ -11,4 +11,8 @@ export default class UpdateIgnoreListEncoder extends MessageEncoder<UpdateIgnore
             buf.p8(name);
         }
     }
+
+    test(message: UpdateIgnoreList): number {
+        return 8 * message.names.length;
+    }
 }

--- a/src/lostcity/network/225/outgoing/codec/UpdateInvFullEncoder.ts
+++ b/src/lostcity/network/225/outgoing/codec/UpdateInvFullEncoder.ts
@@ -34,4 +34,29 @@ export default class UpdateInvFullEncoder extends MessageEncoder<UpdateInvFull> 
             }
         }
     }
+
+    test(message: UpdateInvFull): number {
+        const {component, inv} = message;
+
+        const comType = Component.get(component);
+        const size = Math.min(inv.capacity, comType.width * comType.height);
+
+        let length: number = 0;
+        length += 3;
+        for (let slot = 0; slot < size; slot++) {
+            const obj = inv.get(slot);
+            if (obj) {
+                length += 2;
+
+                if (obj.count >= 255) {
+                    length += 5;
+                } else {
+                    length += 1;
+                }
+            } else {
+                length += 3;
+            }
+        }
+        return length;
+    }
 }

--- a/src/lostcity/network/225/outgoing/codec/UpdateInvPartialEncoder.ts
+++ b/src/lostcity/network/225/outgoing/codec/UpdateInvPartialEncoder.ts
@@ -29,4 +29,28 @@ export default class UpdateInvPartialEncoder extends MessageEncoder<UpdateInvPar
             }
         }
     }
+
+    test(message: UpdateInvPartial): number {
+        const {inv} = message;
+
+        let length: number = 0;
+        length += 2;
+        for (const slot of message.slots) {
+            const obj = inv.get(slot);
+
+            length += 1;
+            if (obj) {
+                length += 2;
+
+                if (obj.count >= 255) {
+                    length += 5;
+                } else {
+                    length += 1;
+                }
+            } else {
+                length += 3;
+            }
+        }
+        return length;
+    }
 }

--- a/src/lostcity/network/225/outgoing/codec/UpdateZonePartialEnclosedEncoder.ts
+++ b/src/lostcity/network/225/outgoing/codec/UpdateZonePartialEnclosedEncoder.ts
@@ -12,4 +12,8 @@ export default class UpdateZonePartialEnclosedEncoder extends MessageEncoder<Upd
         buf.p1((message.zoneZ << 3) - Position.zoneOrigin(message.originZ));
         buf.pdata(message.data, 0, message.data.length);
     }
+
+    test(message: UpdateZonePartialEnclosed): number {
+        return 1 + 1 + message.data.length;
+    }
 }

--- a/src/lostcity/network/outgoing/codec/MessageEncoder.ts
+++ b/src/lostcity/network/outgoing/codec/MessageEncoder.ts
@@ -5,4 +5,7 @@ import Packet from '#jagex2/io/Packet.js';
 export default abstract class MessageEncoder<T extends OutgoingMessage> {
     abstract prot: ServerProt;
     abstract encode(buf: Packet, message: T): void;
+    test(_: T): number {
+        return this.prot.length;
+    }
 }

--- a/src/lostcity/network/outgoing/model/NpcInfo.ts
+++ b/src/lostcity/network/outgoing/model/NpcInfo.ts
@@ -1,13 +1,20 @@
 import OutgoingMessage from '#lostcity/network/outgoing/OutgoingMessage.js';
 import ServerProtPriority from '#lostcity/network/outgoing/prot/ServerProtPriority.js';
-import Player from '#lostcity/entity/Player.js';
+import BuildArea from '#lostcity/entity/BuildArea.js';
 
 // this is slightly unsafe.
 export default class NpcInfo extends OutgoingMessage {
     priority = ServerProtPriority.HIGH;
 
+    accumulator: number = 0;
+
     constructor(
-        readonly player: Player
+        readonly buildArea: BuildArea,
+        readonly level: number,
+        readonly x: number,
+        readonly z: number,
+        readonly originX: number,
+        readonly originZ: number
     ) {
         super();
     }

--- a/src/lostcity/network/outgoing/model/PlayerInfo.ts
+++ b/src/lostcity/network/outgoing/model/PlayerInfo.ts
@@ -1,13 +1,26 @@
 import OutgoingMessage from '#lostcity/network/outgoing/OutgoingMessage.js';
 import ServerProtPriority from '#lostcity/network/outgoing/prot/ServerProtPriority.js';
-import Player from '#lostcity/entity/Player.js';
+import BuildArea from '#lostcity/entity/BuildArea.js';
 
 // this is slightly unsafe.
 export default class PlayerInfo extends OutgoingMessage {
     priority = ServerProtPriority.HIGH;
 
+    accumulator: number = 0;
+
     constructor(
-        readonly player: Player
+        readonly buildArea: BuildArea,
+        readonly level: number,
+        readonly x: number,
+        readonly z: number,
+        readonly originX: number,
+        readonly originZ: number,
+        readonly uid: number,
+        readonly mask: number,
+        readonly tele: boolean,
+        readonly jump: boolean,
+        readonly walkDir: number,
+        readonly runDir: number
     ) {
         super();
     }

--- a/src/lostcity/server/NullClientSocket.ts
+++ b/src/lostcity/server/NullClientSocket.ts
@@ -1,5 +1,3 @@
-import Packet from '#jagex2/io/Packet.js';
-
 import ClientSocket from './ClientSocket.js';
 
 export default class NullClientSocket extends ClientSocket {
@@ -38,55 +36,5 @@ export default class NullClientSocket extends ClientSocket {
     reset() {
         this.inOffset = 0;
         this.inCount.fill(0);
-    }
-
-    get untilNextFlush() {
-        return this.out.length - this.outOffset;
-    }
-
-    write(data: Packet) {
-        const dataArray = data.data || data;
-
-        let offset = 0;
-        let remaining = dataArray.length;
-
-        // pack as much data as we can into a single 5kb chunk, then flush and repeat
-        while (remaining > 0) {
-            const untilNextFlush = this.out.length - this.outOffset;
-
-            if (remaining > untilNextFlush) {
-                this.out.set(dataArray.slice(offset, offset + untilNextFlush), this.outOffset);
-                this.outOffset += untilNextFlush;
-                this.flush();
-                offset += untilNextFlush;
-                remaining -= untilNextFlush;
-            } else {
-                this.out.set(dataArray.slice(offset, offset + remaining), this.outOffset);
-                this.outOffset += remaining;
-                offset += remaining;
-                remaining = 0;
-            }
-        }
-    }
-
-    writeNaive(data: Uint8Array) {
-        if (this.outOffset + data.length > this.out.length) {
-            this.flush();
-        }
-
-        this.out.set(data, this.outOffset);
-        this.outOffset += data.length;
-    }
-
-    writeImmediate(data: Uint8Array) {
-        this.send(data);
-    }
-
-    flush() {
-        if (this.outOffset) {
-            // console.log('Flushing', this.out.slice(0, this.outOffset), this.outOffset);
-            this.send(this.out.slice(0, this.outOffset));
-            this.outOffset = 0;
-        }
     }
 }


### PR DESCRIPTION
- Writing packets no longer does array slicing.
- `pdata` and `gdata` no longer does array slicing.
- Cache appearances to reduce overall data out.
- Variable sized packets are now calculated real-time (except for NpcInfo and PlayerInfo).

![idk 190](https://github.com/2004Scape/Server/assets/76214316/1566a0e2-d1ab-4fe7-873f-be2d9a9eff6d)
