### PR TITLE
fix(content): fix staging and incorrect dialogue during runemysteries

### DIFF
--- a/data/src/scripts/areas/area_lumbridge/scripts/duke_horacio.rs2
+++ b/data/src/scripts/areas/area_lumbridge/scripts/duke_horacio.rs2
@@ -11,12 +11,12 @@ if (%dragon_shield = ^quest_dragon_knows_about_shield & inv_total(inv, dragonfir
 @duke_horacio_money;
 
 [proc,duke_handle_rune_mysteries]()(label)
-if (%runemysteries_progress = 0) return(duke_rune_mysteries_start);
+if (%runemysteries_progress = ^runemysteries_not_started) return(duke_rune_mysteries_start);
 else if (%runemysteries_progress = ^runemysteries_complete) return(duke_rune_mysteries_complete);
 else return (duke_rune_mysteries_in_progress);
 
 [label,duke_horacio_money]
-~chatplayer("<p,neutral>Where can I find money?");
+~chatplayer("<p,quiz>Where can I find money?");
 ~chatnpc("<p,neutral>I've heard that the blacksmiths are prosperous amongst the peasantry. Maybe you could try your hand at that?");
 
 [label,duke_rune_mysteries_start]
@@ -26,33 +26,26 @@ else return (duke_rune_mysteries_in_progress);
 ~chatnpc("<p,neutral>the Wizards' Tower for me? It's just south-west of here and should not take you very long at all. I would be awfully grateful.");
 def_int $option = ~p_choice2("Sure, no problem.", 1, "Not right now.", 2);
 if ($option = 1) {
-    ~chatplayer("<p,neutral>Sure, no problem.");
-    %runemysteries_progress = 1;
-    ~send_quest_progress(questlist:runemysteries, %runemysteries_progress, 5);
-    ~chatnpc("<p,neutral>Thank you very much, stranger. I am sure the head wizard will reward you for such an interesting find.");
-    if(inv_freespace(inv) = 0) {
-        ~mesbox("The Duke tries to hand you the talisman, but you don't have enough room to take it.");
-    } else {
-        // https://youtu.be/khWXGF8spNs?t=40
-        ~mesbox("The Duke hands you an @blu@air talisman.");
-        inv_add(inv, air_talisman, 1);
-    }
+    ~chatplayer("<p,happy>Sure, no problem.");
+    %runemysteries_progress = ^runemysteries_started;
+    ~send_quest_progress(questlist:runemysteries, %runemysteries_progress, ^runemysteries_complete);
+    ~chatnpc("<p,happy>Thank you very much, stranger. I am sure the head wizard will reward you for such an interesting find.");
+    // https://youtu.be/khWXGF8spNs?t=40, inv space check prob added later during OSRS (chisel dialogue doesn't have anything related)
+    ~mesbox("The Duke hands you an @blu@air talisman.");
+    inv_add(inv, air_talisman, 1);
 } else if($option = 2) {
     ~chatplayer("<p,neutral>Not right now.");
-    ~chatnpc("<p,neutral>As you wish. Hopefully I can find someone else to help.");
+    ~chatnpc("<p,sad>As you wish, stranger, although I have this strange feeling that it is important. Unfortunately, I cannot leave my castle unattended.");
 }
 
 [label,duke_rune_mysteries_in_progress]
 if(~obj_gettotal(air_talisman) = 0) {
     ~chatnpc("<p,neutral>Did you speak to the head wizard for me yet, adventurer?");
     ~chatplayer("<p,neutral>No, I lost that talisman that you gave me.");
-    if(inv_freespace(inv) = 0) {
-        ~objbox(air_talisman, "The Duke tries to hand you a talisman, but you don't have enough room to take it.");
-    } else {
-        ~chatnpc("<p,neutral>Ah, that would explain it. One of my servants found this outside, and it seemed too much of a coincidence that more than one strange.");
-        inv_add(inv, air_talisman, 1);
-        ~chatnpc("<p,neutral>object would appear on my land in such a short period of time. Please take this to the head wizard at the Wizards' Tower, south-west of here, and don't lose it this time.");
-    }
+    ~chatnpc("<p,neutral>Ah, that would explain it. One of my servants found this outside, and it seemed too much of a coincidence that more than one strange.");
+    ~chatnpc("<p,neutral>object would appear on my land in such a short period of time. Please take this to the head wizard at the Wizards' Tower, south-west of here, and don't lose it this time.");
+    ~mesbox("The Duke hands you an @blu@air talisman.");
+    inv_add(inv, air_talisman, 1);
 } else {
     ~chatnpc("<p,neutral>The only task remotely approaching a quest is the delivery of that talisman I gave you to the head wizard of the Wizards' Tower,");
     ~chatnpc("<p,neutral>south-west of here. I suggest you deliver it to him as soon as possible. I have the oddest feeling that it is important...");
@@ -60,8 +53,7 @@ if(~obj_gettotal(air_talisman) = 0) {
 
 [label,duke_rune_mysteries_complete]
 ~chatplayer("<p,neutral>Have you any quests for me?");
-//~chatnpc("<p,neutral>The only job I had was the delivery of that talisman, so I'm afraid not.");
-~chatnpc("<p,neutral>All is well for me."); // rsc
+~chatnpc("<p,neutral>No, all is well for me."); // chisel
 
 // dragon slayer
 [label,duke_horacio_shield]

--- a/data/src/scripts/areas/area_varrock/scripts/aubury.rs2
+++ b/data/src/scripts/areas/area_varrock/scripts/aubury.rs2
@@ -1,55 +1,54 @@
 [opnpc1,aubury]
-if(%runemysteries_progress = 3) {
+if(%runemysteries_progress = ^runemysteries_given_package) {
     ~chatnpc("<p,neutral>My gratitude to you adventurer for bringing me these research notes. I notice that you brought the head wizard a special talisman that was the key to our finally unlocking the puzzle.");
     ~chatnpc("<p,neutral>Combined with the information I had already already collated regarding the Rune Essence, I think we have finally unlocked the power to");
     ~chatnpc("<p,neutral>...no. I am getting ahead of myself. Please take this summary of my research back to the head wizard at the Wizards' Tower. I trust his judgement on whether to let you in on our little secret or not.");
-    ~mesbox("Aubury gives you his research notes.");
-    if (inv_freespace(inv) = 0) {
-        ~objbox(notes, "Aubury tries to hand you the Research Notes, but you don't have enough room to take them.");
-        return;
-    }
-    %runemysteries_progress = 4;
+    %runemysteries_progress = ^runemysteries_received_notes;
     inv_add(inv, notes, 1);
-    return;
-}
-if(%runemysteries_progress = 4) {
+    ~mesbox("Aubury gives you his research notes.");
+} else if(%runemysteries_progress = ^runemysteries_received_notes) {
     ~chatnpc("<p,neutral>I suggest you take those research notes of mine back to the head wizard at the Wizards' Tower.");
     if(~obj_gettotal(notes) = 0) {
         ~chatplayer("<p,neutral>I can't... I lost them...");
         ~chatplayer("<p,neutral>Well, luckily I have duplicates. It's a good thing they are written in code, I would not want the wrong kind of person to get access to the information contained within.");
-        if (inv_freespace(inv) = 0) {
-            ~objbox(notes, "Aubury tries to hand you the Research Notes, but you don't have enough room to take them.");
-            return;
-        }
         inv_add(inv, notes, 1);
     } else {
        ~chatplayer("<p,neutral>Ok then, I will do that.");
+       ~chatnpc("<p,neutral>Unless you were talking to me because you wished to buy some runes?");
+       @multi2("Yes please!", aubury_shop, "Oh, it's a rune shop. No thank you, then.", aubury_no);
     }
     return;
+} else {
+    ~chatnpc("<p,happy>Do you want to buy some runes?");
+    if (%runemysteries_progress <= ^runemysteries_given_talisman) {
+        @multi2("Yes please!", aubury_shop, "Oh, it's a rune shop. No thank you, then.", aubury_no);
+    } else if (%runemysteries_progress = ^runemysteries_received_package & inv_total(inv, research_package) > 0) {
+        @multi3("Yes please!", aubury_shop, "Oh, it's a rune shop. No thank you, then.", aubury_no, "I have been sent here with a package for you.", aubury_package);
+    } else {
+        @multi3("Yes please!", aubury_shop, "Oh, it's a rune shop. No thank you, then.", aubury_no, "Can you teleport me to the Rune Essence?", aubury_ess);
+    }
 }
 
-~chatnpc("<p,happy>Do you want to buy some runes?");
-def_int $choice;
-if (%runemysteries_progress <= 1) {
-    $choice = ~p_choice2("Yes please!", 1, "Oh, it's a rune shop. No thank you, then.", 2);
-} else if (%runemysteries_progress = 2 & inv_total(inv, research_package) > 0) {
-    $choice = ~p_choice3("Yes please!", 1, "Oh, it's a rune shop. No thank you, then.", 2, "I have been sent here with a package for you.", 4);
-} else {
-    $choice = ~p_choice3("Yes please!", 1, "Oh, it's a rune shop. No thank you, then.", 2, "Can you teleport me to the Rune Essence?", 3);
+[label,aubury_shop] ~openshop_activenpc;
+
+[label,aubury_no]
+~chatplayer("<p,happy>Oh, it's a rune shop. No thank you, then.");
+~chatnpc("<p,happy>Well, if you find someone who does want runes, please send them my way.");
+
+[label,aubury_ess]
+~chatplayer("<p,quiz>Can you teleport me to the Rune Essence?");
+@teleport_to_essence_mine(^essence_mine_to_aubury);
+
+[label,aubury_package]
+~chatplayer("<p,neutral>I have been sent here with a package for you. It's from the head wizard at the Wizards' Tower.");
+~chatnpc("<p,shock>Really? But... surely he can't have..? Please, let me have it, it must be extremely important for him to have sent a stranger.");
+if(inv_total(inv, research_package) = 0) {
+    ~chatplayer("<p,confused>Uh... yeah... about that... I kind of don't have it with me...");
+    ~chatnpc("<p,confused>What kind of person tells me they have a delivery for me, but not with them? Honestly.");
+    ~chatnpc("<p,neutral>Come back when you do.");
+    return;
 }
-if ($choice = 1) {
-    ~openshop_activenpc;
-} else if ($choice = 2) {
-    ~chatplayer("<p,happy>Oh, it's a rune shop. No thank you, then.");
-    ~chatnpc("<p,happy>Well, if you find someone who does want runes, please send them my way.");
-} else if ($choice = 3) {
-    ~chatplayer("<p,quiz>Can you teleport me to the Rune Essence?");
-    @teleport_to_essence_mine(^essence_mine_to_aubury);
-} else {
-    ~chatplayer("<p,neutral>I have been sent here with a package for you. It's from the head wizard at the Wizards' Tower.");
-    ~chatnpc("<p,neutral>Really? But... surely he can't have..? Please, let me have it, it must be extremely important for him to have sent a stranger.");
-    inv_del(inv, research_package, 1);
-    %runemysteries_progress = 3;
-    ~mesbox("You hand Aubury the research package.");
-    ~chatnpc("<p,neutral>This... is incredible. Please, give me a few moments to quickly look over this, and then talk to me again.");
-}
+~mesbox("You hand Aubury the research package.");
+inv_del(inv, research_package, 1);
+%runemysteries_progress = ^runemysteries_given_package;
+~chatnpc("<p,neutral>This... is incredible. Please, give me a few moments to quickly look over this, and then talk to me again.");

--- a/data/src/scripts/areas/area_wizard_tower/scripts/sedridor.rs2
+++ b/data/src/scripts/areas/area_wizard_tower/scripts/sedridor.rs2
@@ -1,36 +1,34 @@
 [opnpc1,sedridor]
 ~chatnpc("<p,neutral>Welcome adventurer, to the world renowned|Wizards' Tower. How may I help you?");
 // we don't support teleporting until the quest is complete
-if(%runemysteries_progress = 0) {
-    def_int $option = ~p_choice2("Nothing thanks, I'm just looking around.", 1, "What are you doing down here?", 2);
-    if ($option = 1) {
-        @sedridor_nothing;
-    }
-    if ($option = 2) {
-        @sedridor_2;
-    }
-} else if(%runemysteries_progress = 1) {
+if(%runemysteries_progress = ^runemysteries_not_started) {
+    @multi2("Nothing thanks, I'm just looking around.", @sedridor_nothing, "What are you doing down here?", @sedridor_2);
+} else if(%runemysteries_progress = ^runemysteries_started) {
     @rune_mysteries;
-} else if(%runemysteries_progress = 2) {
+} else if(%runemysteries_progress = ^runemysteries_given_talisman) {
+    @sedridor_incredible;
+} else if(%runemysteries_progress = ^runemysteries_received_package) {
     if(~obj_gettotal(research_package) = 0) {
-        ~chatplayer("<p,neutral>...I lost the package you gave me.");
-        ~chatnpc("<p,neutral>You WHAT?");
+        ~chatplayer("<p,sad>...I lost the package you gave me.");
+        ~chatnpc("<p,shock>You WHAT?");
         ~chatnpc("<p,neutral>Tch, that was really very careless of you. Luckily as head wizard I have great powers, and will be able to teleport it back here without too much effort.");
+        // TODO: wiki mentions an animation and graphic "that looks like a teleport" here, try to figure out what it's supposed to look like (removed in the 2021-2022 rework)
         ~chatnpc("<p,neutral>Ok, I have retrieved it. Luckily it doesn't appear to have been damaged. Now please take it to Aubury, and try not to lose it again.");
-        if (inv_freespace(inv) = 0) {
-            ~objbox(research_package, "Sedridor tries to hand you the Research Package, but you don't have enough room to take them.");
-            return;
-        }
         inv_add(inv, research_package, 1);
     } else {
-        ~chatnpc("<p,neutral>How goes your quest? Have you delivered the research notes to my friend Aubury yet?");
+        ~chatnpc("<p,neutral>Ah, <displayname()>. How goes your quest? Have you delivered the research notes to my friend Aubury yet?");
         ~chatplayer("<p,neutral>Not yet...");
         ~chatnpc("<p,neutral>Well, please do so as soon as possible. Remember: to get to Varrock, head due North, through Draynor Village, around Draynor Manor, and then head East when");
         ~chatnpc("<p,neutral>you get to the Barbarian village. The man you seek is named Aubury, and he owns the rune shop there. It is vital he receives this package.");
     }
-} else if (%runemysteries_progress = 4) {
-    
-    ~chatnpc("<p,neutral>Ah, <displayname()>. How goes our quest? Have you delivered the research notes to my friend Aubury yet?");
+} else if(%runemysteries_progress = ^runemysteries_given_package) {
+    ~chatnpc("<p,neutral>Ah, <displayname()>. How goes your quest? Have you delivered the research notes to my friend Aubury yet?");
+    ~chatplayer("<p,neutral>Yes, I have.");
+    ~chatnpc("<p,quiz>And did he give you anything in return?");
+    ~chatplayer("<p,confused>No... he told me to go back after he'd had a quick look at the research you sent him.");
+    ~chatnpc("<p,confused>I think perhaps you should go and speak to him again then, adventurer.");
+} else if(%runemysteries_progress = ^runemysteries_received_notes) {
+    ~chatnpc("<p,neutral>Ah, <displayname()>. How goes your quest? Have you delivered the research notes to my friend Aubury yet?");
     ~chatplayer("<p,neutral>Yes, I have. He gave me some research notes to pass on to you.");
     ~chatnpc("<p,neutral>May I have his notes then?");
     if(~obj_gettotal(notes) = 0) {
@@ -66,11 +64,9 @@ if(%runemysteries_progress = 0) {
     ~chatplayer("<p,neutral>So only you and Aubury know the teleport|spell to the Rune Essence?");
     ~chatnpc("<p,neutral>No... there are others... whom I will tell of your|authorisation to visit that place. When you speak|to them, they will know you, and grant you|access to that place when asked.");
     ~chatnpc("<p,neutral>Use the Air Talisman to locate the air temple,|and use any further talismans you find to locate|the other missing elemental temples.|Now... my research notes please?");
-
+    ~mesbox("You hand the head wizard the research notes.|He hands you back the Air Talisman.");
     inv_del(inv, notes, 1);
     inv_add(inv, air_talisman, 1);
-    ~mesbox("You hand the head wizard the research notes.|He hands you back the Air Talisman.");
-
     queue(rune_mysteries_complete, 0);
 
 } else if(%runemysteries_progress = ^runemysteries_complete) {
@@ -84,6 +80,10 @@ if(%runemysteries_progress = 0) {
         @teleport_to_essence_mine(^essence_mine_to_sedridor);
     }
 }
+
+[opnpcu,sedridor]
+if(last_useitem = notes & %runemysteries_progress = ^runemysteries_received_notes) @aubury_package;
+~displaymessage(^dm_default);
 
 [label,rune_mysteries]
 def_int $option = ~p_choice3("Nothing thanks, I'm just looking around.", 1, "What are you doing down here?", 2, "I'm looking for the head wizard.", 3);
@@ -101,9 +101,9 @@ if ($option = 1) {
         @seridor_3;
     } else if ($option = 2) {
         ~chatplayer("<p,neutral>No, I'll only give it to the head wizard.");
-        ~chatnpc("<p,neutral>Hmmm. Well, I admire your caution adventurer, perhaps I can prove myself? I will use my mental powers to discover...");
+        ~chatnpc("<p,quiz>Hmmm. Well, I admire your caution adventurer, perhaps I can prove myself? I will use my mental powers to discover...");
         ~chatnpc("<p,neutral>Your name is... <displayname()>!");
-        ~chatplayer("<p,neutral>You're right!");
+        ~chatplayer("<p,shock>You're right!");
         ~chatnpc("<p,neutral>Well I am head wizard you know! You don't get to my position without learning a few tricks along the way!");
         ~chatnpc("<p,neutral>So now I have proved myself to you why don't you hand over that talisman, hmm?");
         @seridor_3;
@@ -132,15 +132,19 @@ if ($option = 1) {
 }
 
 [label,seridor_3]
-~chatplayer("<p,neutral>Ok here you are.");
+~chatplayer("<p,neutral>Ok, here you are.");
 if (inv_total(inv, air_talisman) = 0) {
     // from chisel, confirm mesanims
-    ~chatplayer("<p,sad>...except I don't have it with me...");
+    ~chatplayer("<p,confused>...except I don't have it with me...");
     ~chatnpc("<p,confused>Hmmm? You are a very odd person. Come back again when you have found it.");
     return;
 }
 inv_del(inv, air_talisman, 1);
+%runemysteries_progress = ^runemysteries_given_talisman;
 ~mesbox("You hand the Talisman to the wizard.");
+@sedridor_incredible;
+
+[label,sedridor_incredible]
 ~chatnpc("<p,shock>Wow! This is... incredible!");
 ~chatnpc("<p,shock>Th-this talisman you brought me...! It is the last piece|of the puzzle, I think! Finally! The legacy of our|ancestors... it will return to us once more!");
 ~chatnpc("<p,neutral>I need time to study this, <displayname()>. Can you please do me this task while I study this talisman you have brought me? In the mighty town of Varrock, which");
@@ -153,15 +157,12 @@ def_int $option = ~p_choice2("Yes, certainly.", 1, "No, I'm busy.", 2);
 if ($option = 1) {
     ~chatplayer("<p,neutral>Yes, certainly.");
     ~chatnpc("<p,neutral>Take this package, and head directly North|from here, through Draynor village, until you reach|the Barbarian Village. Then head East from there|until you reach Varrock.");
-    ~chatnpc("<p,neutral>Once in Varrock, take this package to the owner of the rune shop. His name is Aubury. You may find it|helpful to ask one of Varrock's citizens for directions.");
+    ~chatnpc("<p,neutral>Once in Varrock, take this package to the owner of the rune shop. His name is Aubury. You may find it helpful to ask one of Varrock's citizens for directions,");
     ~chatnpc("<p,neutral>as Varrock can be a confusing place for the first time visitor. He will give you a special item - bring it back to me, and I shall show you the mystery of the runes...");
-    if (inv_freespace(inv) = 0) {
-        ~mesbox("The head wizard tries to hand you the Research Package, but you don't have enough room to take it.");
-        return;
-    }
-    inv_add(inv, research_package, 1);
-    %runemysteries_progress = 2;
+    // inv check seems to be added with OSRS rework
     ~mesbox("The head wizard gives you a package.");
+    inv_add(inv, research_package, 1);
+    %runemysteries_progress = ^runemysteries_received_package;
     ~chatnpc("<p,neutral>Best of luck with your quest, <displayname()>.");
 } else if ($option = 2) {
     ~chatplayer("<p,neutral>No, I'm busy.");

--- a/data/src/scripts/general/configs/quest.constant
+++ b/data/src/scripts/general/configs/quest.constant
@@ -1,4 +1,4 @@
-^runemysteries_complete = 5
+^runemysteries_complete = 6
 ^doric_complete = 2
 ^cook_complete = 2
 ^romeojuliet_complete = 100

--- a/data/src/scripts/quests/quest_runemysteries/configs/quest_runemysteries.constant
+++ b/data/src/scripts/quests/quest_runemysteries/configs/quest_runemysteries.constant
@@ -1,0 +1,6 @@
+^runemysteries_not_started = 0
+^runemysteries_started = 1
+^runemysteries_given_talisman = 2
+^runemysteries_received_package = 3
+^runemysteries_given_package = 4
+^runemysteries_received_notes = 5


### PR DESCRIPTION
- fix quest stages during rune mysteries (6 instead of 5)
- fix some mistakes with and add some missing dialogue to the quest