### PR TITLE
fix(engine): simplify and fix crypto id + set staffmodlevel without save

### DIFF
--- a/Bundle.ts
+++ b/Bundle.ts
@@ -3,34 +3,34 @@ import fs from 'fs';
 const modules: string[] = ['buffer', 'module', 'watcher', 'worker_threads', 'dotenv/config', 'bcrypt', '#lostcity/db/query.js', '#lostcity/util/PackFile.js'];
 const defines = {
     'process.platform': JSON.stringify('webworker'),
-    'process.env.WEB_PORT': '',
-    'process.env.WEB_CORS': '',
-    'process.env.NODE_ID': '',
-    'process.env.NODE_PORT': '',
-    'process.env.NODE_MEMBERS': '',
-    'process.env.NODE_XPRATE': '',
-    'process.env.NODE_PRODUCTION': '',
-    'process.env.NODE_KILLTIMER': '',
-    'process.env.NODE_ALLOW_CHEATS': '',
-    'process.env.NODE_DEBUG': '',
-    'process.env.NODE_DEBUG_PROFILE': '',
-    'process.env.NODE_STAFF': '',
-    'process.env.NODE_CLIENT_ROUTEFINDER': '',
-    'process.env.NODE_SOCKET_TIMEOUT': '',
-    'process.env.LOGIN_HOST': '',
-    'process.env.LOGIN_PORT': '',
-    'process.env.LOGIN_KEY': '',
-    'process.env.DB_HOST': '',
-    'process.env.DB_USER': '',
-    'process.env.DB_PASS': '',
-    'process.env.DB_NAME': '',
-    'process.env.BUILD_JAVA_PATH': '',
-    'process.env.BUILD_STARTUP': '',
-    'process.env.BUILD_STARTUP_UPDATE': '',
-    'process.env.BUILD_VERIFY': '',
-    'process.env.BUILD_VERIFY_FOLDER': '',
-    'process.env.BUILD_VERIFY_PACK': '',
-    'process.env.BUILD_SRC_DIR': '',
+    'process.env.WEB_PORT': 'undefined',
+    'process.env.WEB_CORS': 'undefined',
+    'process.env.NODE_ID': 'undefined',
+    'process.env.NODE_PORT': 'undefined',
+    'process.env.NODE_MEMBERS': 'undefined',
+    'process.env.NODE_XPRATE': 'undefined',
+    'process.env.NODE_PRODUCTION': 'undefined',
+    'process.env.NODE_KILLTIMER': 'undefined',
+    'process.env.NODE_ALLOW_CHEATS': 'undefined',
+    'process.env.NODE_DEBUG': 'undefined',
+    'process.env.NODE_DEBUG_PROFILE': 'undefined',
+    'process.env.NODE_STAFF': 'undefined',
+    'process.env.NODE_CLIENT_ROUTEFINDER': 'undefined',
+    'process.env.NODE_SOCKET_TIMEOUT': 'undefined',
+    'process.env.LOGIN_HOST': 'undefined',
+    'process.env.LOGIN_PORT': 'undefined',
+    'process.env.LOGIN_KEY': 'undefined',
+    'process.env.DB_HOST': 'undefined',
+    'process.env.DB_USER': 'undefined',
+    'process.env.DB_PASS': 'undefined',
+    'process.env.DB_NAME': 'undefined',
+    'process.env.BUILD_JAVA_PATH': 'undefined',
+    'process.env.BUILD_STARTUP': 'undefined',
+    'process.env.BUILD_STARTUP_UPDATE': 'undefined',
+    'process.env.BUILD_VERIFY': 'undefined',
+    'process.env.BUILD_VERIFY_FOLDER': 'undefined',
+    'process.env.BUILD_VERIFY_PACK': 'undefined',
+    'process.env.BUILD_SRC_DIR': 'undefined',
 };
 
 try {
@@ -64,6 +64,7 @@ function removeImports(bundle: string, path: string) {
     try {
         bundle = bundle.split('\n')
             .filter(line => !line.startsWith('import'))
+            .filter(line => !line.startsWith('init_crypto'))
             .join('\n');
 
         fs.writeFileSync(path, bundle);

--- a/src/lostcity/cache/config/Component.ts
+++ b/src/lostcity/cache/config/Component.ts
@@ -23,16 +23,6 @@ export default class Component {
     private static componentNames: Map<string, number> = new Map();
     private static components: Component[] = [];
 
-    static async loadAsync(dir: string): Promise<void> {
-        if (!(await fetch(`${dir}/server/interface.dat`)).ok) {
-            console.log('Warning: No interface.dat found.');
-            return;
-        }
-
-        const dat = await Packet.loadAsync(`${dir}/server/interface.dat`);
-        this.parse(dat);
-    }
-
     static load(dir: string): void {
         if (!fs.existsSync(`${dir}/server/interface.dat`)) {
             console.log('Warning: No interface.dat found.');
@@ -40,6 +30,16 @@ export default class Component {
         }
 
         const dat = Packet.load(`${dir}/server/interface.dat`);
+        this.parse(dat);
+    }
+
+    static async loadAsync(dir: string): Promise<void> {
+        if (!(await fetch(`${dir}/server/interface.dat`)).ok) {
+            console.log('Warning: No interface.dat found.');
+            return;
+        }
+
+        const dat = await Packet.loadAsync(`${dir}/server/interface.dat`);
         this.parse(dat);
     }
 

--- a/src/lostcity/entity/PlayerLoading.ts
+++ b/src/lostcity/entity/PlayerLoading.ts
@@ -42,6 +42,13 @@ export class PlayerLoading {
             ? new NetworkPlayer(safeName, name37, client)
             : new Player(safeName, name37);
 
+        if (!Environment.NODE_PRODUCTION) {
+            player.staffModLevel = 3;
+        } else if (Environment.NODE_STAFF.find(name => name === safeName) !== undefined) {
+            // player.staffModLevel = 2;
+            player.staffModLevel = 3; // todo: revert this back to `= 2` after launch
+        }
+
         if (sav.data.length < 2) {
             for (let i = 0; i < 21; i++) {
                 player.stats[i] = 0;
@@ -141,12 +148,6 @@ export class PlayerLoading {
         player.combatLevel = player.getCombatLevel();
         player.lastResponse = World.currentTick;
 
-        if (!Environment.NODE_PRODUCTION) {
-            player.staffModLevel = 3;
-        } else if (Environment.NODE_STAFF.find(name => name === safeName) !== undefined) {
-            // player.staffModLevel = 2;
-            player.staffModLevel = 3; // todo: revert this back to `= 2` after launch
-        }
         return player;
     }
 }

--- a/src/lostcity/server/ClientSocket.ts
+++ b/src/lostcity/server/ClientSocket.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'crypto';
 import { Socket } from 'net';
 import { WebSocket } from 'ws';
 
@@ -16,7 +17,7 @@ export default class ClientSocket {
     remoteAddress: string;
     totalBytesRead = 0;
     totalBytesWritten = 0;
-    uniqueId: string;
+    uniqueId = typeof self !== 'undefined' ? (self.location.host.startsWith('https') ? self.crypto.randomUUID() : '0') : randomUUID();
 
     encryptor: Isaac | null = null;
     decryptor: Isaac | null = null;
@@ -35,8 +36,7 @@ export default class ClientSocket {
 
     player: NetworkPlayer | null = null;
 
-    constructor(uniqueId: string, socket: Socket | WebSocket | null, remoteAddress: string, type = ClientSocket.TCP, state = -1) {
-        this.uniqueId = uniqueId;
+    constructor(socket: Socket | WebSocket | null, remoteAddress: string, type = ClientSocket.TCP, state = -1) {
         this.socket = socket;
         this.remoteAddress = remoteAddress;
         this.type = type;

--- a/src/lostcity/server/NullClientSocket.ts
+++ b/src/lostcity/server/NullClientSocket.ts
@@ -1,9 +1,8 @@
-import { randomUUID } from 'node:crypto';
 import ClientSocket from './ClientSocket.js';
 
 export default class NullClientSocket extends ClientSocket {
     constructor() {
-        super(randomUUID(), null, '');
+        super(null, '');
     }
 
     isTCP() {

--- a/src/lostcity/server/TcpMaintenanceServer.ts
+++ b/src/lostcity/server/TcpMaintenanceServer.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'crypto';
 import net, { Server } from 'net';
 
 import Packet from '#jagex2/io/Packet.js';
@@ -23,7 +22,7 @@ export default class TcpServer {
             const ip: string = s.remoteAddress ?? 'unknown';
             //console.log(`[Maintenance]: Connection from ${ip}`);
 
-            const socket = new ClientSocket(randomUUID(), s, ip, ClientSocket.TCP);
+            const socket = new ClientSocket(s, ip, ClientSocket.TCP);
 
             const seed = new Packet(new Uint8Array(4 + 4));
             seed.p4(Math.floor(Math.random() * 0xffffffff));

--- a/src/lostcity/server/TcpServer.ts
+++ b/src/lostcity/server/TcpServer.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'crypto';
 import net, { Server } from 'net';
 
 import Packet from '#jagex2/io/Packet.js';
@@ -25,7 +24,7 @@ export default class TcpServer {
             const ip: string = s.remoteAddress ?? 'unknown';
             //console.log(`[World]: Connection from ${ip}`);
 
-            const socket = new ClientSocket(randomUUID(), s, ip, ClientSocket.TCP);
+            const socket = new ClientSocket(s, ip, ClientSocket.TCP);
 
             const seed = new Packet(new Uint8Array(4 + 4));
             seed.p4(Math.floor(Math.random() * 0xffffffff));

--- a/src/lostcity/server/WSMaintenanceServer.ts
+++ b/src/lostcity/server/WSMaintenanceServer.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'crypto';
 import { WebSocketServer } from 'ws';
 import { IncomingMessage } from 'http';
 
@@ -38,7 +37,7 @@ export default class WSServer {
             const ip: string = getIp(req) ?? 'unknown';
             //console.log(`[WSMaintenance]: Connection from ${ip}`);
 
-            const socket = new ClientSocket(randomUUID(), ws, ip, ClientSocket.WEBSOCKET);
+            const socket = new ClientSocket(ws, ip, ClientSocket.WEBSOCKET);
 
             const seed = new Packet(new Uint8Array(4 + 4));
             seed.p4(Math.floor(Math.random() * 0xffffffff));

--- a/src/lostcity/server/WSServer.ts
+++ b/src/lostcity/server/WSServer.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'crypto';
 import { WebSocketServer, WebSocket } from 'ws';
 import { IncomingMessage } from 'http';
 
@@ -40,7 +39,7 @@ export default class WSServer {
             const ip: string = getIp(req) ?? 'unknown';
             //console.log(`[WSWorld]: Connection from ${ip}`);
 
-            const socket = new ClientSocket(randomUUID(), ws, ip, ClientSocket.WEBSOCKET);
+            const socket = new ClientSocket(ws, ip, ClientSocket.WEBSOCKET);
 
             const seed = new Packet(new Uint8Array(4 + 4));
             seed.p4(Math.floor(Math.random() * 0xffffffff));

--- a/src/lostcity/server/WorkerServer.ts
+++ b/src/lostcity/server/WorkerServer.ts
@@ -6,7 +6,7 @@ import Login from '#lostcity/engine/Login.js';
 import World from '#lostcity/engine/World.js';
 
 export default class WorkerServer {
-    socket: ClientSocket = new ClientSocket(self.location.host.startsWith('https') ? self.crypto.randomUUID() : '0', null, '127.0.0.1');
+    socket: ClientSocket = new ClientSocket(null, '127.0.0.1');
 
     constructor() {}
 


### PR DESCRIPTION
Found better ways to deal with crypto problem, either add the missing global variables to Bundle.ts defines or just filter the single init_crypto() call. Not doing this makes the worker server just error like this one that I missed: https://github.com/2004Scape/Server/commit/9a16f0f30a735e3ba25064ecde2cb76ed168d00a caused the global.crypto error too as it's used in clientcheathandler which is used by both servers.

Set staffmodlevel even without save file so people without access to filesystem can still use mod commands on webworker server.

Fix some environment variables not being set to default by setting them to undefined.

Also swapped load and loadAsync in component as I intended to keep the sync versions at the top of file.