### PR TITLE
fix(content): remove resetting attack styles on weapon switch

### DIFF
--- a/data/src/scripts/skill_combat/scripts/player/weapon_category.rs2
+++ b/data/src/scripts/skill_combat/scripts/player/weapon_category.rs2
@@ -102,7 +102,6 @@ if ($previous = null | $obj = null | oc_category($previous) ! oc_category($obj))
     // osrs keeps track of selected per category
     %attackstyle_magic = 0;
     %autocast_spell = null;
-    %attackstyle = 0;
 }
 if (~inzone_coord_pair_table(gnomeball_zones, coord) = true) {
     if_settab(gnomeball, 0);
@@ -159,7 +158,6 @@ if ($previous = null | $obj = null | oc_category($previous) ! oc_category($obj))
     // osrs keeps track of selected per category
     .%attackstyle_magic = 0;
     .%autocast_spell = null;
-    .%attackstyle = 0;
 }
 if (~.inzone_coord_pair_table(gnomeball_zones, .coord) = true) {
     .if_settab(gnomeball, 0);


### PR DESCRIPTION
Video from 2005:
https://youtu.be/LSpyUVXa4LE?t=225

I believe early osrs worked this way. Osrs later made a change to remember attack styles per weapon.