### PR TITLE
fix(engine): Async webworker loading and other fixes

### DIFF
--- a/bundle.js
+++ b/bundle.js
@@ -61,7 +61,7 @@ async function esb() {
     }
 }
 
-async function bun(entryPoints) {
+async function bun() {
     // eslint-disable-next-line no-undef
     const bundle = await Bun.build({
         entrypoints: entryPoints,

--- a/bundle.js
+++ b/bundle.js
@@ -53,8 +53,8 @@ async function esb() {
         entryPoints: entryPoints,
         external: modules.concat(esbuildModules),
         define: defines,
-        // sourcemap: 'inline',
         // minify: true,
+        // sourcemap: 'linked',
     }).catch((e) => { throw new Error(e); });
 
     for (let index = 0; index < bundle.outputFiles.length; index++) {
@@ -68,8 +68,8 @@ async function bun() {
         entrypoints: entryPoints,
         external: modules,
         define: defines,
-        // sourcemap: 'inline',
         // minify: true,
+        // sourcemap: 'linked',
     }).catch((e) => { throw new Error(e); });
 
     for (let index = 0; index < bundle.outputs.length; index++) {
@@ -93,6 +93,7 @@ function preloadDirs() {
 }
 
 function removeImports(output, file) {
+    // turn into plugin for minify/sourcemaps
     const path = '../Client2/src/public/' + basename(file).replace('.ts', '.js');
 
     output = output.split('\n')

--- a/bundle.js
+++ b/bundle.js
@@ -38,12 +38,12 @@ const defines = {
 
 try {
     preloadDirs();
-    process.argv0 === 'bun' ? await bun(entryPoints) : await esb(entryPoints);
+    process.argv0 === 'bun' ? await bun() : await esb();
 } catch (e) {
     console.error(e);
 }
 
-async function esb(entryPoints) {
+async function esb() {
     const bundle = await esbuild.build({
         bundle: true,
         format: 'esm',
@@ -101,5 +101,5 @@ function removeImports(output, file) {
 
     fs.writeFileSync(path, output);
 
-    console.log(`${file} size: ${(fs.statSync(path).size / (1024 * 1024)).toFixed(2)} MB`);
+    console.log(`${path} size: ${(fs.statSync(path).size / (1024 * 1024)).toFixed(2)} MB`);
 }

--- a/bundle.js
+++ b/bundle.js
@@ -1,4 +1,5 @@
 import fs from 'fs';
+import {basename} from 'path';
 import * as esbuild from 'esbuild';
 
 const entryPoints = ['src/lostcity/worker.ts', 'src/lostcity/server/LoginThread.ts'];
@@ -92,7 +93,7 @@ function preloadDirs() {
 }
 
 function removeImports(output, file) {
-    const path = '../Client2/src/public/' + file.split('/').pop().replace('.ts', '.js');
+    const path = '../Client2/src/public/' + basename(file).replace('.ts', '.js');
 
     output = output.split('\n')
         .filter(line => !line.startsWith('import'))

--- a/data/src/scripts/areas/area_karamja/scripts/trufitus.rs2
+++ b/data/src/scripts/areas/area_karamja/scripts/trufitus.rs2
@@ -120,7 +120,7 @@ if(%junglepotion_progress = ^junglepotion_not_started) {
 ~chatnpc("<p,happy>I can only guide you so far as the herbs are not easy to find. With some luck, you will find each herb in turn and bring to me. I will give you details of where to find the next herb.");
 ~chatnpc("<p,happy>In return for this great favour I will give you training in Herblore.");
 def_int $option5 = ~p_choice2("Hmmm, sounds difficult, I don't know if I am ready for the challenge.", 1, "It sounds like just the challenge for me.", 2);
-if($option5 = 1) {
+if($option5 = 2) {
     if (%druid_progress = ^druid_complete & stat(herblore) >= 3) { // does the quest start before or after this dialogue?
         %junglepotion_progress = ^junglepotion_get_snake_weed;
         ~send_quest_progress(questlist:junglepotion, %junglepotion_progress, ^junglepotion_complete);
@@ -132,7 +132,7 @@ if($option5 = 1) {
     } else {
         ~mesbox("You do not meet all of the requirements to start|the Jungle Potion quest."); // TODO: what happens originally?
     }
-} else if($option5 = 2) {
+} else if($option5 = 1) {
     ~chatplayer("<p,neutral>Hmmm, sounds difficult, I don't know if I am ready for the challenge.");
     ~chatnpc("<p,neutral>Very well then Bwana, maybe you will return to me invigorated and ready to take up the challenge one day?");
 }

--- a/data/src/scripts/areas/area_karamja/scripts/trufitus.rs2
+++ b/data/src/scripts/areas/area_karamja/scripts/trufitus.rs2
@@ -119,12 +119,12 @@ if(%junglepotion_progress = ^junglepotion_not_started) {
 ~chatnpc("<p,happy>I need to make a special brew! A potion that helps me to commune with the gods. For this potion, I need very special herbs, that are only found in the deep jungle.");
 ~chatnpc("<p,happy>I can only guide you so far as the herbs are not easy to find. With some luck, you will find each herb in turn and bring to me. I will give you details of where to find the next herb.");
 ~chatnpc("<p,happy>In return for this great favour I will give you training in Herblore.");
-def_int $option5 = ~p_choice2_header("Yes.", 1, "No.", 2, "Start the Jungle Potion quest?");
+def_int $option5 = ~p_choice2("Hmmm, sounds difficult, I don't know if I am ready for the challenge.", 1, "It sounds like just the challenge for me.", 2);
 if($option5 = 1) {
-    if (%druid_progress = ^druid_complete & stat(herblore) >= 3) { // TODO: is this right place to put it?
+    if (%druid_progress = ^druid_complete & stat(herblore) >= 3) { // does the quest start before or after this dialogue?
         %junglepotion_progress = ^junglepotion_get_snake_weed;
         ~send_quest_progress(questlist:junglepotion, %junglepotion_progress, ^junglepotion_complete);
-        ~chatplayer("<p,confused>It sounds like just the challenge for me. And it would make a nice break from killing things!");
+        ~chatplayer("<p,happy>It sounds like just the challenge for me. And it would make a nice break from killing things!");
         ~chatnpc("<p,happy>That is excellent Bwana! The first herb that you need to gather is called");
         ~chatnpc("<p,happy>Snake Weed.");
         ~chatnpc("<p,neutral>It grows near the vines in an area to the south west where");
@@ -133,7 +133,7 @@ if($option5 = 1) {
         ~mesbox("You do not meet all of the requirements to start|the Jungle Potion quest."); // TODO: what happens originally?
     }
 } else if($option5 = 2) {
-    ~chatplayer("<p,confused>Hmmm, sounds difficult, I don't know if I am ready for the challenge.");
+    ~chatplayer("<p,neutral>Hmmm, sounds difficult, I don't know if I am ready for the challenge.");
     ~chatnpc("<p,neutral>Very well then Bwana, maybe you will return to me invigorated and ready to take up the challenge one day?");
 }
 

--- a/src/lostcity/cache/config/CategoryType.ts
+++ b/src/lostcity/cache/config/CategoryType.ts
@@ -20,12 +20,13 @@ export default class CategoryType extends ConfigType {
     }
 
     static async loadAsync(dir: string) {
-        if (!(await fetch(`${dir}/server/category.dat`)).ok) {
+        const file = await fetch(`${dir}/server/category.dat`);
+        if (!file.ok) {
             console.log('Warning: No category.dat found.');
             return;
         }
 
-        const dat = await Packet.loadAsync(`${dir}/server/category.dat`);
+        const dat = new Packet(new Uint8Array(await file.arrayBuffer()));
         this.parse(dat);
     }
 

--- a/src/lostcity/cache/config/Component.ts
+++ b/src/lostcity/cache/config/Component.ts
@@ -34,12 +34,13 @@ export default class Component {
     }
 
     static async loadAsync(dir: string): Promise<void> {
-        if (!(await fetch(`${dir}/server/interface.dat`)).ok) {
+        const file = await fetch(`${dir}/server/interface.dat`);
+        if (!file.ok) {
             console.log('Warning: No interface.dat found.');
             return;
         }
 
-        const dat = await Packet.loadAsync(`${dir}/server/interface.dat`);
+        const dat = new Packet(new Uint8Array(await file.arrayBuffer()));
         this.parse(dat);
     }
 

--- a/src/lostcity/cache/config/DbRowType.ts
+++ b/src/lostcity/cache/config/DbRowType.ts
@@ -20,11 +20,13 @@ export default class DbRowType extends ConfigType {
     }
 
     static async loadAsync(dir: string) {
-        if (!(await fetch(`${dir}/server/dbrow.dat`)).ok) {
+        const file = await fetch(`${dir}/server/dbrow.dat`);
+        if (!file.ok) {
             console.log('Warning: No dbrow.dat found.');
             return;
         }
-        const dat = await Packet.loadAsync(`${dir}/server/dbrow.dat`);
+
+        const dat = new Packet(new Uint8Array(await file.arrayBuffer()));
         this.parse(dat);
     }
 

--- a/src/lostcity/cache/config/DbTableType.ts
+++ b/src/lostcity/cache/config/DbTableType.ts
@@ -19,11 +19,13 @@ export default class DbTableType extends ConfigType {
     }
 
     static async loadAsync(dir: string) {
-        if (!(await fetch(`${dir}/server/dbtable.dat`)).ok) {
+        const file = await fetch(`${dir}/server/dbtable.dat`);
+        if (!file.ok) {
             console.log('Warning: No dbtable.dat found.');
             return;
         }
-        const dat = await Packet.loadAsync(`${dir}/server/dbtable.dat`);
+
+        const dat = new Packet(new Uint8Array(await file.arrayBuffer()));
         this.parse(dat);
     }
 

--- a/src/lostcity/cache/config/EnumType.ts
+++ b/src/lostcity/cache/config/EnumType.ts
@@ -20,12 +20,13 @@ export default class EnumType extends ConfigType {
     }
 
     static async loadAsync(dir: string) {
-        if (!(await fetch(`${dir}/server/enum.dat`)).ok) {
+        const file = await fetch(`${dir}/server/enum.dat`);
+        if (!file.ok) {
             console.log('Warning: No enum.dat found.');
             return;
         }
 
-        const dat = await Packet.loadAsync(`${dir}/server/enum.dat`);
+        const dat = new Packet(new Uint8Array(await file.arrayBuffer()));
         this.parse(dat);
     }
 

--- a/src/lostcity/cache/config/FloType.ts
+++ b/src/lostcity/cache/config/FloType.ts
@@ -21,13 +21,14 @@ export default class FloType extends ConfigType {
     }
 
     static async loadAsync(dir: string) {
-        if (!(await fetch(`${dir}/server/flo.dat`)).ok) {
+        const file = await fetch(`${dir}/server/flo.dat`);
+        if (!file.ok) {
             console.log('Warning: No flo.dat found.');
             return;
         }
-        const server = await Packet.loadAsync(`${dir}/server/flo.dat`);
-        const jag = await Jagfile.loadAsync(`${dir}/client/config`);
-        this.parse(server, jag);
+
+        const [server, jag] = await Promise.all([file.arrayBuffer(), Jagfile.loadAsync(`${dir}/client/config`)]);
+        this.parse(new Packet(new Uint8Array(server)), jag);
     }
 
     static parse(server: Packet, jag: Jagfile) {

--- a/src/lostcity/cache/config/HuntType.ts
+++ b/src/lostcity/cache/config/HuntType.ts
@@ -25,11 +25,13 @@ export default class HuntType extends ConfigType {
     }
 
     static async loadAsync(dir: string) {
-        if (!(await fetch(`${dir}/server/hunt.dat`)).ok) {
+        const file = await fetch(`${dir}/server/hunt.dat`);
+        if (!file.ok) {
             console.log('Warning: No hunt.dat found.');
             return;
         }
-        const dat = await Packet.loadAsync(`${dir}/server/hunt.dat`);
+
+        const dat = new Packet(new Uint8Array(await file.arrayBuffer()));
         this.parse(dat);
     }
 

--- a/src/lostcity/cache/config/IdkType.ts
+++ b/src/lostcity/cache/config/IdkType.ts
@@ -21,14 +21,14 @@ export default class IdkType extends ConfigType {
     }
 
     static async loadAsync(dir: string) {
-        if (!(await fetch(`${dir}/server/idk.dat`)).ok) {
+        const file = await fetch(`${dir}/server/idk.dat`);
+        if (!file.ok) {
             console.log('Warning: No idk.dat found.');
             return;
         }
 
-        const server = await Packet.loadAsync(`${dir}/server/idk.dat`);
-        const jag = await Jagfile.loadAsync(`${dir}/client/config`);
-        this.parse(server, jag);
+        const [server, jag] = await Promise.all([file.arrayBuffer(), Jagfile.loadAsync(`${dir}/client/config`)]);
+        this.parse(new Packet(new Uint8Array(server)), jag);
     }
 
     static parse(server: Packet, jag: Jagfile) {

--- a/src/lostcity/cache/config/InvType.ts
+++ b/src/lostcity/cache/config/InvType.ts
@@ -27,11 +27,13 @@ export default class InvType extends ConfigType {
     }
 
     static async loadAsync(dir: string) {
-        if (!(await fetch(`${dir}/server/inv.dat`)).ok) {
+        const file = await fetch(`${dir}/server/inv.dat`);
+        if (!file.ok) {
             console.log('Warning: No inv.dat found.');
             return;
         }
-        const dat = await Packet.loadAsync(`${dir}/server/inv.dat`);
+
+        const dat = new Packet(new Uint8Array(await file.arrayBuffer()));
         this.parse(dat);
     }
 

--- a/src/lostcity/cache/config/LocType.ts
+++ b/src/lostcity/cache/config/LocType.ts
@@ -23,13 +23,14 @@ export default class LocType extends ConfigType {
     }
 
     static async loadAsync(dir: string) {
-        if (!(await fetch(`${dir}/server/loc.dat`)).ok) {
+        const file = await fetch(`${dir}/server/loc.dat`);
+        if (!file.ok) {
             console.log('Warning: No loc.dat found.');
             return;
         }
-        const server = await Packet.loadAsync(`${dir}/server/loc.dat`);
-        const jag = await Jagfile.loadAsync(`${dir}/client/config`);
-        this.parse(server, jag);
+
+        const [server, jag] = await Promise.all([file.arrayBuffer(), Jagfile.loadAsync(`${dir}/client/config`)]);
+        this.parse(new Packet(new Uint8Array(server)), jag);
     }
 
     static parse(server: Packet, jag: Jagfile) {

--- a/src/lostcity/cache/config/MesanimType.ts
+++ b/src/lostcity/cache/config/MesanimType.ts
@@ -18,11 +18,13 @@ export default class MesanimType extends ConfigType {
     }
 
     static async loadAsync(dir: string) {
-        if (!(await fetch(`${dir}/server/mesanim.dat`)).ok) {
+        const file = await fetch(`${dir}/server/mesanim.dat`);
+        if (!file.ok) {
             console.log('Warning: No mesanim.dat found.');
             return;
         }
-        const dat = await Packet.loadAsync(`${dir}/server/mesanim.dat`);
+
+        const dat = new Packet(new Uint8Array(await file.arrayBuffer()));
         this.parse(dat);
     }
 

--- a/src/lostcity/cache/config/NpcType.ts
+++ b/src/lostcity/cache/config/NpcType.ts
@@ -27,13 +27,14 @@ export default class NpcType extends ConfigType {
     }
 
     static async loadAsync(dir: string) {
-        if (!(await fetch(`${dir}/server/npc.dat`)).ok) {
+        const file = await fetch(`${dir}/server/npc.dat`);
+        if (!file.ok) {
             console.log('Warning: No npc.dat found.');
             return;
         }
-        const server = await Packet.loadAsync(`${dir}/server/npc.dat`);
-        const jag = await Jagfile.loadAsync(`${dir}/client/config`);
-        this.parse(server, jag);
+
+        const [server, jag] = await Promise.all([file.arrayBuffer(), Jagfile.loadAsync(`${dir}/client/config`)]);
+        this.parse(new Packet(new Uint8Array(server)), jag);
     }
 
     static parse(server: Packet, jag: Jagfile) {

--- a/src/lostcity/cache/config/ObjType.ts
+++ b/src/lostcity/cache/config/ObjType.ts
@@ -24,13 +24,14 @@ export default class ObjType extends ConfigType {
     }
 
     static async loadAsync(dir: string) {
-        if (!(await fetch(`${dir}/server/obj.dat`)).ok) {
+        const file = await fetch(`${dir}/server/obj.dat`);
+        if (!file.ok) {
             console.log('Warning: No obj.dat found.');
             return;
         }
-        const server = await Packet.loadAsync(`${dir}/server/obj.dat`);
-        const jag = await Jagfile.loadAsync(`${dir}/client/config`);
-        this.parse(server, jag);
+
+        const [server, jag] = await Promise.all([file.arrayBuffer(), Jagfile.loadAsync(`${dir}/client/config`)]);
+        this.parse(new Packet(new Uint8Array(server)), jag);
     }
 
     static parse(server: Packet, jag: Jagfile) {

--- a/src/lostcity/cache/config/ParamType.ts
+++ b/src/lostcity/cache/config/ParamType.ts
@@ -20,11 +20,13 @@ export default class ParamType extends ConfigType {
     }
 
     static async loadAsync(dir: string) {
-        if (!(await fetch(`${dir}/server/param.dat`)).ok) {
+        const file = await fetch(`${dir}/server/param.dat`);
+        if (!file.ok) {
             console.log('Warning: No param.dat found.');
+            return;
         }
 
-        const dat = await Packet.loadAsync(`${dir}/server/param.dat`);
+        const dat = new Packet(new Uint8Array(await file.arrayBuffer()));
         this.parse(dat);
     }
 

--- a/src/lostcity/cache/config/SeqFrame.ts
+++ b/src/lostcity/cache/config/SeqFrame.ts
@@ -17,12 +17,13 @@ export default class SeqFrame {
     }
 
     static async loadAsync(dir: string) {
-        if (!(await fetch(`${dir}/server/frame_del.dat`)).ok) {
+        const file = await fetch(`${dir}/server/frame_del.dat`);
+        if (!file.ok) {
             console.log('Warning: No frame_del.dat found.');
             return;
         }
 
-        const dat = await Packet.loadAsync(`${dir}/server/frame_del.dat`);
+        const dat = new Packet(new Uint8Array(await file.arrayBuffer()));
         this.parse(dat);
     }
 

--- a/src/lostcity/cache/config/SeqType.ts
+++ b/src/lostcity/cache/config/SeqType.ts
@@ -22,14 +22,14 @@ export default class SeqType extends ConfigType {
     }
 
     static async loadAsync(dir: string) {
-        if (!(await fetch(`${dir}/server/seq.dat`)).ok) {
+        const file = await fetch(`${dir}/server/seq.dat`);
+        if (!file.ok) {
             console.log('Warning: No seq.dat found.');
             return;
         }
 
-        const server = await Packet.loadAsync(`${dir}/server/seq.dat`);
-        const jag = await Jagfile.loadAsync(`${dir}/client/config`);
-        this.parse(server, jag);
+        const [server, jag] = await Promise.all([file.arrayBuffer(), Jagfile.loadAsync(`${dir}/client/config`)]);
+        this.parse(new Packet(new Uint8Array(server)), jag);
     }
 
     static parse(server: Packet, jag: Jagfile) {

--- a/src/lostcity/cache/config/SpotanimType.ts
+++ b/src/lostcity/cache/config/SpotanimType.ts
@@ -21,14 +21,14 @@ export default class SpotanimType extends ConfigType {
     }
 
     static async loadAsync(dir: string) {
-        if (!(await fetch(`${dir}/server/spotanim.dat`)).ok) {
+        const file = await fetch(`${dir}/server/spotanim.dat`);
+        if (!file.ok) {
             console.log('Warning: No spotanim.dat found.');
             return;
         }
 
-        const server = await Packet.loadAsync(`${dir}/server/spotanim.dat`);
-        const jag = await Jagfile.loadAsync(`${dir}/client/config`);
-        this.parse(server, jag);
+        const [server, jag] = await Promise.all([file.arrayBuffer(), Jagfile.loadAsync(`${dir}/client/config`)]);
+        this.parse(new Packet(new Uint8Array(server)), jag);
     }
 
     static parse(server: Packet, jag: Jagfile) {

--- a/src/lostcity/cache/config/StructType.ts
+++ b/src/lostcity/cache/config/StructType.ts
@@ -20,12 +20,13 @@ export default class StructType extends ConfigType implements ParamHolder {
     }
 
     static async loadAsync(dir: string) {
-        if (!(await fetch(`${dir}/server/struct.dat`)).ok) {
+        const file = await fetch(`${dir}/server/struct.dat`);
+        if (!file.ok) {
             console.log('Warning: No struct.dat found.');
             return;
         }
 
-        const dat = await Packet.loadAsync(`${dir}/server/struct.dat`);
+        const dat = new Packet(new Uint8Array(await file.arrayBuffer()));
         this.parse(dat);
     }
 

--- a/src/lostcity/cache/config/VarNpcType.ts
+++ b/src/lostcity/cache/config/VarNpcType.ts
@@ -21,12 +21,13 @@ export default class VarNpcType extends ConfigType {
     }
 
     static async loadAsync(dir: string) {
-        if (!(await fetch(`${dir}/server/varn.dat`)).ok) {
+        const file = await fetch(`${dir}/server/varn.dat`);
+        if (!file.ok) {
             console.log('Warning: No varn.dat found.');
             return;
         }
 
-        const dat = await Packet.loadAsync(`${dir}/server/varn.dat`);
+        const dat = new Packet(new Uint8Array(await file.arrayBuffer()));
         this.parse(dat);
     }
 

--- a/src/lostcity/cache/config/VarPlayerType.ts
+++ b/src/lostcity/cache/config/VarPlayerType.ts
@@ -30,14 +30,14 @@ export default class VarPlayerType extends ConfigType {
     }
 
     static async loadAsync(dir: string) {
-        if (!(await fetch(`${dir}/server/varp.dat`)).ok) {
+        const file = await fetch(`${dir}/server/varp.dat`);
+        if (!file.ok) {
             console.log('Warning: No varp.dat found.');
             return;
         }
 
-        const server = await Packet.loadAsync(`${dir}/server/varp.dat`);
-        const jag = await Jagfile.loadAsync(`${dir}/client/config`);
-        this.parse(server, jag);
+        const [server, jag] = await Promise.all([file.arrayBuffer(), Jagfile.loadAsync(`${dir}/client/config`)]);
+        this.parse(new Packet(new Uint8Array(server)), jag);
     }
 
     static parse(server: Packet, jag: Jagfile) {

--- a/src/lostcity/cache/config/VarSharedType.ts
+++ b/src/lostcity/cache/config/VarSharedType.ts
@@ -19,12 +19,13 @@ export default class VarSharedType extends ConfigType {
     }
 
     static async loadAsync(dir: string) {
-        if (!(await fetch(`${dir}/server/vars.dat`)).ok) {
+        const file = await fetch(`${dir}/server/vars.dat`);
+        if (!file.ok) {
             console.log('Warning: No vars.dat found.');
             return;
         }
 
-        const dat = await Packet.loadAsync(`${dir}/server/vars.dat`);
+        const dat = new Packet(new Uint8Array(await file.arrayBuffer()));
         this.parse(dat);
     }
 

--- a/src/lostcity/cache/wordenc/WordEnc.ts
+++ b/src/lostcity/cache/wordenc/WordEnc.ts
@@ -46,12 +46,13 @@ export default class WordEnc {
     }
 
     static async loadAsync(dir: string): Promise<void> {
-        if (!(await fetch(`${dir}/client/wordenc`)).ok) {
-            console.log('Warning: No wordenc found.');
+        const file = await fetch(`${dir}/client/wordenc`);
+        if (!file.ok) {
+            console.log('Warning: No wordenc.dat found.');
             return;
         }
 
-        const wordenc = await Jagfile.loadAsync(`${dir}/client/wordenc`);
+        const wordenc = new Jagfile(new Packet(new Uint8Array(await file.arrayBuffer())));
         this.readAll(wordenc);
     }
 

--- a/src/lostcity/cache/wordenc/WordEnc.ts
+++ b/src/lostcity/cache/wordenc/WordEnc.ts
@@ -54,7 +54,7 @@ export default class WordEnc {
         const wordenc = await Jagfile.loadAsync(`${dir}/client/wordenc`);
         this.readAll(wordenc);
     }
-        
+
     static readAll(wordenc: Jagfile): void {
         const fragmentsenc = wordenc.read('fragmentsenc.txt');
         if (!fragmentsenc) {

--- a/src/lostcity/engine/GameMap.ts
+++ b/src/lostcity/engine/GameMap.ts
@@ -59,20 +59,25 @@ export default class GameMap {
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-ignore
         const { serverMaps } = await import('#lostcity/server/PreloadedDirs.js');
-        const maps: string[] = serverMaps;
-        for (let index: number = 0; index < maps.length; index++) {
-            console.log('init ', maps[index]);
-            const [mx, mz] = maps[index].substring(1).split('_').map(Number);
+        const maps = serverMaps.map(async (map: string) => {
+            const [mx, mz] = map.substring(1).split('_').map(Number);
             const mapsquareX: number = mx << 6;
             const mapsquareZ: number = mz << 6;
 
-            this.decodeNpcs(await Packet.loadAsync(`${path}n${mx}_${mz}`), mapsquareX, mapsquareZ);
-            this.decodeObjs(await Packet.loadAsync(`${path}o${mx}_${mz}`), mapsquareX, mapsquareZ, zoneMap);
+            const [npcData, objData, landData, locData] = await Promise.all([
+                await Packet.loadAsync(`${path}n${mx}_${mz}`),
+                await Packet.loadAsync(`${path}o${mx}_${mz}`),
+                await Packet.loadAsync(`${path}m${mx}_${mz}`),
+                await Packet.loadAsync(`${path}l${mx}_${mz}`)]);
+
+            this.decodeNpcs(npcData, mapsquareX, mapsquareZ);
+            this.decodeObjs(objData, mapsquareX, mapsquareZ, zoneMap);
             // collision
             const lands: Int8Array = new Int8Array(GameMap.MAPSQUARE); // 4 * 64 * 64 size is guaranteed for lands
-            this.decodeLands(lands, await Packet.loadAsync(`${path}m${mx}_${mz}`), mapsquareX, mapsquareZ);
-            this.decodeLocs(lands, await Packet.loadAsync(`${path}l${mx}_${mz}`), mapsquareX, mapsquareZ, zoneMap);
-        }
+            this.decodeLands(lands, landData, mapsquareX, mapsquareZ);
+            this.decodeLocs(lands, locData, mapsquareX, mapsquareZ, zoneMap);
+        });
+        await Promise.all(maps);
         console.timeEnd('Loading game map');
     }
 

--- a/src/lostcity/engine/GameMap.ts
+++ b/src/lostcity/engine/GameMap.ts
@@ -77,7 +77,7 @@ export default class GameMap {
             this.decodeLands(lands, landData, mapsquareX, mapsquareZ);
             this.decodeLocs(lands, locData, mapsquareX, mapsquareZ, zoneMap);
         });
-        await Promise.all(maps);
+        // await Promise.all(maps); // this bottlenecks login time
         console.timeEnd('Loading game map');
     }
 

--- a/src/lostcity/engine/Login.ts
+++ b/src/lostcity/engine/Login.ts
@@ -57,6 +57,7 @@ class Login {
             const revision = data.g1();
             if (revision !== 225) {
                 socket.writeImmediate(LoginResponse.SERVER_UPDATED);
+                socket.close();
                 return;
             }
 
@@ -66,6 +67,7 @@ class Login {
             data.gdata(crcs, 0, crcs.length);
             if (!Packet.checkcrc(crcs, 0, crcs.length, CrcBuffer32)) {
                 socket.writeImmediate(LoginResponse.SERVER_UPDATED);
+                socket.close();
                 return;
             }
 

--- a/src/lostcity/engine/World.ts
+++ b/src/lostcity/engine/World.ts
@@ -300,20 +300,20 @@ class World {
             await ParamType.loadAsync('data/pack');
         }
 
-        if (this.shouldReload('obj', true)) {
-            await ObjType.loadAsync('data/pack');
-            transmitted = true;
-        }
+        // if (this.shouldReload('obj', true)) {
+        //     await ObjType.loadAsync('data/pack');
+        //     transmitted = true;
+        // }
 
-        if (this.shouldReload('loc', true)) {
-            await LocType.loadAsync('data/pack');
-            transmitted = true;
-        }
+        // if (this.shouldReload('loc', true)) {
+        //     await LocType.loadAsync('data/pack');
+        //     transmitted = true;
+        // }
 
-        if (this.shouldReload('npc', true)) {
-            await NpcType.loadAsync('data/pack');
-            transmitted = true;
-        }
+        // if (this.shouldReload('npc', true)) {
+        //     await NpcType.loadAsync('data/pack');
+        //     transmitted = true;
+        // }
 
         if (this.shouldReload('idk', true)) {
             await IdkType.loadAsync('data/pack');
@@ -419,6 +419,7 @@ class World {
         // await makeCrcsAsync();
 
         // todo: detect and reload static data (like maps)
+
         await preloadClientAsync();
     }
 
@@ -441,14 +442,16 @@ class World {
                 this.gameMap.init(this.zoneMap);
             }
         } else {
-            await FontType.loadAsync('data/pack');
-            await WordEnc.loadAsync('data/pack');
+            // need to load these prior to gamemap
+            await Promise.all([await ObjType.loadAsync('data/pack'), await LocType.loadAsync('data/pack'), await NpcType.loadAsync('data/pack')]);
 
-            await this.reloadAsync();
-
+            console.time('out of');
             if (!skipMaps) {
-                await this.gameMap.initAsync(this.zoneMap);
+                await Promise.all([await FontType.loadAsync('data/pack'), await WordEnc.loadAsync('data/pack'), await this.reloadAsync(), await this.gameMap.initAsync(this.zoneMap)]);
+            } else {
+                await Promise.all([await FontType.loadAsync('data/pack'), await WordEnc.loadAsync('data/pack'), await this.reloadAsync()]);
             }
+            console.timeEnd('out of');
         }
 
         Login.loginThread.postMessage({

--- a/src/lostcity/engine/script/Script.ts
+++ b/src/lostcity/engine/script/Script.ts
@@ -134,7 +134,13 @@ export default class Script {
     }
 
     get fileName() {
-        return path.basename(this.info.sourceFilePath);
+        if (typeof self === 'undefined') {
+            return path.basename(this.info.sourceFilePath);
+        } else {
+            return this.info.sourceFilePath;
+            // TODOS change after checking this
+            // return this.info.sourceFilePath.split('/').pop();
+        }
     }
 
     lineNumber(pc: number) {

--- a/src/lostcity/engine/script/Script.ts
+++ b/src/lostcity/engine/script/Script.ts
@@ -137,9 +137,7 @@ export default class Script {
         if (typeof self === 'undefined') {
             return path.basename(this.info.sourceFilePath);
         } else {
-            return this.info.sourceFilePath;
-            // TODOS change after checking this
-            // return this.info.sourceFilePath.split('/').pop();
+            return this.info.sourceFilePath.split('/').pop()?.split('\\').pop();
         }
     }
 

--- a/src/lostcity/engine/script/ScriptProvider.ts
+++ b/src/lostcity/engine/script/ScriptProvider.ts
@@ -40,8 +40,7 @@ export default class ScriptProvider {
     }
 
     static async loadAsync(dir: string): Promise<number> {
-        const dat = await Packet.loadAsync(`${dir}/server/script.dat`);
-        const idx = await Packet.loadAsync(`${dir}/server/script.idx`);
+        const [dat, idx] = await Promise.all([Packet.loadAsync(`${dir}/server/script.dat`), Packet.loadAsync(`${dir}/server/script.idx`)]);
         return this.parse(dat, idx);
     }
 

--- a/src/lostcity/engine/script/ScriptRunner.ts
+++ b/src/lostcity/engine/script/ScriptRunner.ts
@@ -1,5 +1,3 @@
-import path from 'path';
-
 import Script from '#lostcity/engine/script/Script.js';
 import ScriptOpcode from '#lostcity/engine/script/ScriptOpcode.js';
 import ScriptPointer from '#lostcity/engine/script/ScriptPointer.js';
@@ -178,7 +176,7 @@ export default class ScriptRunner {
 
             if (state.self instanceof Player) {
                 state.self.wrappedMessageGame(`script error: ${err.message}`);
-                state.self.wrappedMessageGame(`file: ${path.basename(state.script.info.sourceFilePath)}`);
+                state.self.wrappedMessageGame(`file: ${state.script.fileName}`);
                 state.self.wrappedMessageGame('');
 
                 state.self.wrappedMessageGame('stack backtrace:');
@@ -202,7 +200,7 @@ export default class ScriptRunner {
             }
 
             console.error(`script error: ${err.message}`);
-            console.error(`file: ${path.basename(state.script.info.sourceFilePath)}`);
+            console.error(`file: ${state.script.fileName}`);
             console.error('');
 
             console.error('stack backtrace:');

--- a/src/lostcity/server/ClientSocket.ts
+++ b/src/lostcity/server/ClientSocket.ts
@@ -17,7 +17,7 @@ export default class ClientSocket {
     remoteAddress: string;
     totalBytesRead = 0;
     totalBytesWritten = 0;
-    uniqueId = typeof self === 'undefined' ? randomUUID() : (self.location.protocol === 'https:' ? self.crypto.randomUUID() : '0');
+    uniqueId = typeof self === 'undefined' ? randomUUID() : (self.isSecureContext ? self.crypto.randomUUID() : '0');
 
     encryptor: Isaac | null = null;
     decryptor: Isaac | null = null;

--- a/src/lostcity/server/CrcTable.ts
+++ b/src/lostcity/server/CrcTable.ts
@@ -42,8 +42,7 @@ async function makeCrcAsync(path: string) {
 
     const packet = new Packet(new Uint8Array(await file.arrayBuffer()));
     const crc = Packet.getcrc(packet.data, 0, packet.data.length);
-    CrcTable.push(crc);
-    CrcBuffer.p4(crc);
+    return crc;
 }
 
 export async function makeCrcsAsync() {
@@ -51,14 +50,24 @@ export async function makeCrcsAsync() {
 
     CrcBuffer.pos = 0;
     CrcBuffer.p4(0);
-    await makeCrcAsync('data/pack/client/title');
-    await makeCrcAsync('data/pack/client/config');
-    await makeCrcAsync('data/pack/client/interface');
-    await makeCrcAsync('data/pack/client/media');
-    await makeCrcAsync('data/pack/client/models');
-    await makeCrcAsync('data/pack/client/textures');
-    await makeCrcAsync('data/pack/client/wordenc');
-    await makeCrcAsync('data/pack/client/sounds');
+
+    const [title, config, iface, media, models, textures, wordenc, sounds] = await Promise.all([
+        makeCrcAsync('data/pack/client/title'),
+        makeCrcAsync('data/pack/client/config'),
+        makeCrcAsync('data/pack/client/interface'),
+        makeCrcAsync('data/pack/client/media'),
+        makeCrcAsync('data/pack/client/models'),
+        makeCrcAsync('data/pack/client/textures'),
+        makeCrcAsync('data/pack/client/wordenc'),
+        makeCrcAsync('data/pack/client/sounds')
+    ]);
+
+    for (const crc of [title, config, iface, media, models, textures, wordenc, sounds]) {
+        if (crc) {
+            CrcTable.push(crc);
+            CrcBuffer.p4(crc);
+        }
+    }
 
     CrcBuffer32 = Packet.getcrc(CrcBuffer.data, 0, CrcBuffer.data.length);
 }

--- a/src/lostcity/server/CrcTable.ts
+++ b/src/lostcity/server/CrcTable.ts
@@ -67,7 +67,8 @@ if (typeof self === 'undefined') {
         makeCrcs();
     }
 } else {
-    if ((await fetch('data/pack/client')).ok) {
+    // fetching directory works on local http servers but not github pages
+    if ((await fetch('data/pack/client/crc')).ok) {
         await makeCrcsAsync();
     }
 }

--- a/src/lostcity/server/CrcTable.ts
+++ b/src/lostcity/server/CrcTable.ts
@@ -66,9 +66,9 @@ if (typeof self === 'undefined') {
     if (fs.existsSync('data/pack/client/')) {
         makeCrcs();
     }
-} else {
-    // fetching directory works on local http servers but not github pages
-    if ((await fetch('data/pack/client/crc')).ok) {
-        await makeCrcsAsync();
-    }
+// } else {
+    // fetching directory works on local http servers but not github pages, also not needed rn
+    // if ((await fetch('data/pack/client/crc')).ok) {
+    //     await makeCrcsAsync();
+    // }
 }

--- a/src/lostcity/server/CrcTable.ts
+++ b/src/lostcity/server/CrcTable.ts
@@ -35,11 +35,12 @@ export function makeCrcs() {
 }
 
 async function makeCrcAsync(path: string) {
-    if (!(await fetch(path)).ok) {
+    const file = await fetch(path);
+    if (!file.ok) {
         return;
     }
 
-    const packet = await Packet.loadAsync(path);
+    const packet = new Packet(new Uint8Array(await file.arrayBuffer()));
     const crc = Packet.getcrc(packet.data, 0, packet.data.length);
     CrcTable.push(crc);
     CrcBuffer.p4(crc);

--- a/src/lostcity/server/LoginThread.ts
+++ b/src/lostcity/server/LoginThread.ts
@@ -361,10 +361,9 @@ if (typeof self === 'undefined' && parentPort) {
                     } else {
                         let save = new Uint8Array();
                         const safeName = toSafeName(username);
-                        // TODO(config): Github pages adds /Client2 to pathname, and can't use pathname as worker adds its own file to it.
-                        const url = new URL(`data/players/${safeName}.sav`, self.location.origin);
-                        if ((await fetch(url)).ok) {
-                            save = new Uint8Array(await (await fetch(url)).arrayBuffer());
+                        const saveFile = await fetch(`data/players/${safeName}.sav`);
+                        if (saveFile.ok) {
+                            save = new Uint8Array(await saveFile.arrayBuffer());
                         }
 
                         self.postMessage({

--- a/src/lostcity/server/LoginThread.ts
+++ b/src/lostcity/server/LoginThread.ts
@@ -361,6 +361,7 @@ if (typeof self === 'undefined' && parentPort) {
                     } else {
                         let save = new Uint8Array();
                         const safeName = toSafeName(username);
+                        // TODO(config): Github pages adds /Client2 to pathname, and can't use pathname as worker adds its own file to it.
                         const url = new URL(`data/players/${safeName}.sav`, self.location.origin);
                         if ((await fetch(url)).ok) {
                             save = new Uint8Array(await (await fetch(url)).arrayBuffer());

--- a/src/lostcity/server/PreloadedPacks.ts
+++ b/src/lostcity/server/PreloadedPacks.ts
@@ -48,8 +48,6 @@ export async function preloadClientAsync() {
     //console.log('Preloading client data');
     //console.time('Preloaded client data');
 
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
     const fetchAll = async (type: string, name: string) => {
         let data = new Uint8Array(await (await fetch(`data/pack/client/${type}/${name}`)).arrayBuffer());
         if (type === 'jingles') {
@@ -62,11 +60,13 @@ export async function preloadClientAsync() {
         PRELOADED_CRC.set(name, crc);
     };
 
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
     const { jingles, maps, songs } = await import('./PreloadedDirs.js');
     const allPacks = [
-        ...maps.map(name => fetchAll('maps', name)),
-        ...songs.map(name => fetchAll('songs', name)),
-        ...jingles.map(name => fetchAll('jingles', name))
+        ...maps.map((name: string) => fetchAll('maps', name)),
+        ...songs.map((name: string) => fetchAll('songs', name)),
+        ...jingles.map((name: string) => fetchAll('jingles', name))
     ];
     await Promise.all(allPacks);
     //console.timeEnd('Preloaded client data');

--- a/src/lostcity/server/PreloadedPacks.ts
+++ b/src/lostcity/server/PreloadedPacks.ts
@@ -46,7 +46,7 @@ export function preloadClient() {
 
 export async function preloadClientAsync() {
     //console.log('Preloading client data');
-    console.time('Preloaded client data');
+    //console.time('Preloaded client data');
 
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
@@ -69,5 +69,5 @@ export async function preloadClientAsync() {
         ...jingles.map(name => fetchAll('jingles', name))
     ];
     await Promise.all(allPacks);
-    console.timeEnd('Preloaded client data');
+    //console.timeEnd('Preloaded client data');
 }

--- a/src/lostcity/server/PreloadedPacks.ts
+++ b/src/lostcity/server/PreloadedPacks.ts
@@ -46,46 +46,28 @@ export function preloadClient() {
 
 export async function preloadClientAsync() {
     //console.log('Preloading client data');
-    //console.time('Preloaded client data');
+    console.time('Preloaded client data');
 
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
+    const fetchAll = async (type: string, name: string) => {
+        let data = new Uint8Array(await (await fetch(`data/pack/client/${type}/${name}`)).arrayBuffer());
+        if (type === 'jingles') {
+            // Strip off bzip header.
+            data = data.subarray(4);
+        }
+        const crc = Packet.getcrc(data, 0, data.length);
+
+        PRELOADED.set(name, data);
+        PRELOADED_CRC.set(name, crc);
+    };
+
     const { jingles, maps, songs } = await import('./PreloadedDirs.js');
-    const allMaps = maps;
-    for (let i = 0; i < allMaps.length; i++) {
-        const name = allMaps[i];
-        console.log(name);
-
-        const map = new Uint8Array(await (await fetch(`data/pack/client/maps/${name}`)).arrayBuffer());
-        const crc = Packet.getcrc(map, 0, map.length);
-
-        PRELOADED.set(name, map);
-        PRELOADED_CRC.set(name, crc);
-    }
-
-    const allSongs = songs;
-    for (let i = 0; i < allSongs.length; i++) {
-        const name = allSongs[i];
-        console.log(name);
-
-        const song = new Uint8Array(await (await fetch(`data/pack/client/songs/${name}`)).arrayBuffer());
-        const crc = Packet.getcrc(song, 0, song.length);
-
-        PRELOADED.set(name, song);
-        PRELOADED_CRC.set(name, crc);
-    }
-
-    const allJingles = jingles;
-    for (let i = 0; i < allJingles.length; i++) {
-        const name = allJingles[i];
-        console.log(name);
-
-        // Strip off bzip header.
-        const jingle = new Uint8Array(await (await fetch(`data/pack/client/jingles/${name}`)).arrayBuffer()).subarray(4);
-        const crc = Packet.getcrc(jingle, 0, jingle.length);
-
-        PRELOADED.set(name, jingle);
-        PRELOADED_CRC.set(name, crc);
-    }
-    //console.timeEnd('Preloaded client data');
+    const allPacks = [
+        ...maps.map(name => fetchAll('maps', name)),
+        ...songs.map(name => fetchAll('songs', name)),
+        ...jingles.map(name => fetchAll('jingles', name))
+    ];
+    await Promise.all(allPacks);
+    console.timeEnd('Preloaded client data');
 }

--- a/src/lostcity/server/WorkerServer.ts
+++ b/src/lostcity/server/WorkerServer.ts
@@ -6,7 +6,7 @@ import Login from '#lostcity/engine/Login.js';
 import World from '#lostcity/engine/World.js';
 
 export default class WorkerServer {
-    socket: ClientSocket = new ClientSocket(null, 'localhost');
+    socket: ClientSocket = new ClientSocket(null, '127.0.0.1');
 
     constructor() {}
 

--- a/src/lostcity/server/WorkerServer.ts
+++ b/src/lostcity/server/WorkerServer.ts
@@ -6,7 +6,7 @@ import Login from '#lostcity/engine/Login.js';
 import World from '#lostcity/engine/World.js';
 
 export default class WorkerServer {
-    socket: ClientSocket = new ClientSocket(null, '127.0.0.1');
+    socket: ClientSocket = new ClientSocket(null, 'localhost');
 
     constructor() {}
 

--- a/src/lostcity/server/WorkerServer.ts
+++ b/src/lostcity/server/WorkerServer.ts
@@ -16,10 +16,22 @@ export default class WorkerServer {
         seed.p4(Math.floor(Math.random() * 0xffffffff));
         this.socket.send(seed.data);
 
+        // TODO: figure this out
+        self.onerror = async (e: Event) => {
+            console.log(e);
+            self.close();
+            // this.socket.close();
+        };
+
+        self.onmessageerror = async (e: MessageEvent) => {
+            console.log(e);
+            self.close();
+            // this.socket.close();
+        };
+
         self.onmessage = async (e: MessageEvent) => {
             const packet = new Packet(new Uint8Array(e.data));
             switch (e.data.type) {
-                // TODO: are these needed later?
                 // case 'close':
                 //     if (this.socket.player) {
                 //         this.socket.player.client = null;


### PR DESCRIPTION
I lied, got one more batch of low hanging fruit:

1. massively speed up load time in browser by using promise.all for everything (4 min -> 1-3 sec) awaiting gamemaps is commented out for now as it adds another 1-2 sec and there's no need to wait. Can be reduced to 500 ms by generating the preloaded packs too but not very important.
2. add socket.close when sending loginresponses as workers didn't close which increased ram usage rapidly if invalid logins happen, but it also applies to websocket server as I noticed that the client would show a bunch of pending instances in network tab forever until you exit server.
3. fix esbuild error due to no basename implementation (bun has some polyfills for node) when scriptrunner errors happen.
4. check for secure context in worker the intended way, always works now
5. Jungle potion fix reported by @thesuddensilent 
6. Fix saves loading on github

You can see load time in console here, it's faster after first login due to fetch caching I believe:

https://lesleyrs.github.io/Client2/?world=999&detail=high&method=0
