### PR TITLE
fix: cleanup all dupe worker code

### DIFF
--- a/bundle.js
+++ b/bundle.js
@@ -4,7 +4,7 @@ import * as esbuild from 'esbuild';
 
 const entryPoints = ['src/lostcity/worker.ts', 'src/lostcity/server/LoginThread.ts'];
 const esbuildModules = ['node:fs/promises', 'path', 'net', 'crypto', 'fs'];
-const modules = ['buffer', 'module', 'watcher', 'worker_threads', 'dotenv/config', 'bcrypt', '#lostcity/db/query.js', '#lostcity/util/PackFile.js'];
+const modules = ['kleur', 'buffer', 'module', 'watcher', 'worker_threads', 'dotenv/config', 'bcrypt', '#lostcity/db/query.js', '#lostcity/util/PackFile.js'];
 const defines = {
     'process.platform': JSON.stringify('webworker'),
     'process.env.WEB_PORT': 'undefined',

--- a/src/lostcity/engine/Login.ts
+++ b/src/lostcity/engine/Login.ts
@@ -20,22 +20,22 @@ class Login {
     logoutRequests: Set<bigint> = new Set();
 
     constructor() {
-        const onMsg = (msg: any) => {
-            try {
-                this.onMessage(msg);
-            } catch (err) {
-                console.error('Login Thread:', err);
+        try {
+            if (typeof self === 'undefined') {
+                if (this.loginThread instanceof NodeWorker) {
+                    this.loginThread.on('message', msg => {
+                        this.onMessage(msg);
+                    });
+                }
+            } else {
+                if (this.loginThread instanceof Worker) {
+                    this.loginThread.onmessage = msg => {
+                        this.onMessage(msg.data);
+                    };
+                }
             }
-        };
-
-        if (typeof self === 'undefined') {
-            if (this.loginThread instanceof NodeWorker) {
-                this.loginThread.on('message', onMsg);
-            }
-        } else {
-            if (this.loginThread instanceof Worker) {
-                this.loginThread.onmessage = onMsg;
-            }
+        } catch (err) {
+            console.error('Login Thread:', err);
         }
     }
 
@@ -99,152 +99,77 @@ class Login {
     }
 
     private onMessage(msg: any) {
-        if (typeof self === 'undefined') {
-            switch (msg.type) {
-                case 'loginreply': {
-                    const { status, socket } = msg;
+        switch (msg.type) {
+            case 'loginreply': {
+                const { status, socket } = msg;
 
-                    const client = this.loginRequests.get(socket);
-                    if (!client) {
-                        return;
-                    }
+                const client = this.loginRequests.get(socket);
+                if (!client) {
+                    return;
+                }
 
-                    this.loginRequests.delete(socket);
+                this.loginRequests.delete(socket);
 
-                    if (status[0] !== 2) {
-                        client.writeImmediate(status);
-                        client.close();
-                        return;
-                    }
+                if (status[0] !== 2) {
+                    client.writeImmediate(status);
+                    client.close();
+                    return;
+                }
 
-                    const { info, seed, username, save } = msg;
+                const { info, seed, username, save } = msg;
 
-                    if (World.getTotalPlayers() >= 2000) {
-                        client.writeImmediate(LoginResponse.WORLD_FULL);
-                        client.close();
-                        return;
-                    }
+                if (World.getTotalPlayers() >= 2000) {
+                    client.writeImmediate(LoginResponse.WORLD_FULL);
+                    client.close();
+                    return;
+                }
 
-                    if (World.shutdownTick > -1 && World.currentTick - World.shutdownTick > 0) {
-                        client.writeImmediate(LoginResponse.SERVER_UPDATING);
-                        client.close();
-                        return;
-                    }
+                if (World.shutdownTick > -1 && World.currentTick - World.shutdownTick > 0) {
+                    client.writeImmediate(LoginResponse.SERVER_UPDATING);
+                    client.close();
+                    return;
+                }
 
-                    if (!Environment.LOGIN_KEY) {
-                        // running without a login server
-                        for (const player of World.players) {
-                            if (player.username === username) {
-                                client.writeImmediate(LoginResponse.LOGGED_IN);
-                                client.close();
-                                return;
-                            }
+                if (!Environment.LOGIN_KEY) {
+                    // running without a login server
+                    for (const player of World.players) {
+                        if (player.username === username) {
+                            client.writeImmediate(LoginResponse.LOGGED_IN);
+                            client.close();
+                            return;
                         }
                     }
-
-                    client.decryptor = new Isaac(seed);
-                    for (let i = 0; i < 4; i++) {
-                        seed[i] += 50;
-                    }
-                    client.encryptor = new Isaac(seed);
-
-                    const player = PlayerLoading.load(username, new Packet(save), client);
-                    player.lowMemory = (info & 0x1) !== 0;
-                    player.webClient = client.isWebSocket();
-
-                    World.addPlayer(player);
-                    break;
                 }
-                case 'logoutreply': {
-                    const { username } = msg;
 
-                    const player = World.getPlayerByUsername(username);
-                    if (player) {
-                        World.getZone(player.x, player.z, player.level).leave(player);
-                        World.players.remove(player.pid);
-                        player.pid = -1;
-                        player.terminate();
-
-                        this.logoutRequests.delete(player.username37);
-                    }
-                    break;
+                client.decryptor = new Isaac(seed);
+                for (let i = 0; i < 4; i++) {
+                    seed[i] += 50;
                 }
-                default:
-                    throw new Error('Unknown message type: ' + msg.type);
+                client.encryptor = new Isaac(seed);
+
+                const player = PlayerLoading.load(username, new Packet(save), client);
+                player.lowMemory = (info & 0x1) !== 0;
+                player.webClient = client.isWebSocket();
+
+                World.addPlayer(player);
+                break;
             }
-        } else {
-            switch (msg.data.type) {
-                case 'loginreply': {
-                    const { status, socket } = msg.data;
+            case 'logoutreply': {
+                const { username } = msg;
 
-                    const client = this.loginRequests.get(socket);
-                    if (!client) {
-                        return;
-                    }
+                const player = World.getPlayerByUsername(username);
+                if (player) {
+                    World.getZone(player.x, player.z, player.level).leave(player);
+                    World.players.remove(player.pid);
+                    player.pid = -1;
+                    player.terminate();
 
-                    this.loginRequests.delete(socket);
-
-                    if (status[0] !== 2) {
-                        client.writeImmediate(status);
-                        client.close();
-                        return;
-                    }
-
-                    const { info, seed, username, save } = msg.data;
-
-                    if (World.getTotalPlayers() >= 2000) {
-                        client.writeImmediate(LoginResponse.WORLD_FULL);
-                        client.close();
-                        return;
-                    }
-
-                    if (World.shutdownTick > -1 && World.currentTick - World.shutdownTick > 0) {
-                        client.writeImmediate(LoginResponse.SERVER_UPDATING);
-                        client.close();
-                        return;
-                    }
-
-                    if (!Environment.LOGIN_KEY) {
-                        // running without a login server
-                        for (const player of World.players) {
-                            if (player.username === username) {
-                                client.writeImmediate(LoginResponse.LOGGED_IN);
-                                client.close();
-                                return;
-                            }
-                        }
-                    }
-
-                    client.decryptor = new Isaac(seed);
-                    for (let i = 0; i < 4; i++) {
-                        seed[i] += 50;
-                    }
-                    client.encryptor = new Isaac(seed);
-
-                    const player = PlayerLoading.load(username, new Packet(save), client);
-                    player.lowMemory = (info & 0x1) !== 0;
-                    player.webClient = true;
-
-                    World.addPlayer(player);
-                    break;
+                    this.logoutRequests.delete(player.username37);
                 }
-                case 'logoutreply': {
-                    const { username } = msg.data;
-
-                    const player = World.getPlayerByUsername(username);
-                    if (player) {
-                        World.getZone(player.x, player.z, player.level).leave(player);
-                        World.players.remove(player.pid);
-                        player.pid = -1;
-                        player.terminate();
-
-                        this.logoutRequests.delete(player.username37);
-                    }
-                    break;
-                }
-                default:
-                    throw new Error('Unknown message type: ' + msg.data.type);
+                break;
             }
+            default:
+                throw new Error('Unknown message type: ' + msg.type);
         }
     }
 }

--- a/src/lostcity/engine/World.ts
+++ b/src/lostcity/engine/World.ts
@@ -368,36 +368,38 @@ class World {
                 this.gameMap.init(this.zoneMap);
             }
         } else {
-            console.time('Loaded in');
+            console.time('World ready');
             await this.loadAsync();
 
             if (!skipMaps) {
                 await this.gameMap.initAsync(this.zoneMap);
             }
-            console.timeEnd('Loaded in');
+            console.timeEnd('World ready');
         }
 
         Login.loginThread.postMessage({
             type: 'reset'
         });
 
-        if (typeof self === 'undefined' && !Environment.NODE_PRODUCTION) {
-            this.startDevWatcher();
+        if (typeof self === 'undefined') {
+            if (!Environment.NODE_PRODUCTION) {
+                this.startDevWatcher();
 
-            // console.time('checker');
-            // todo: this check takes me 300ms on startup! but it saves double building fresh setups
-            if (Environment.BUILD_STARTUP && (shouldBuildFileAny('data/pack/client', 'data/pack/client/lastbuild.pack') || shouldBuildFileAny('data/pack/server', 'data/pack/server/lastbuild.pack'))) {
-                this.devThread!.postMessage({
-                    type: 'pack'
-                });
+                // console.time('checker');
+                // todo: this check takes me 300ms on startup! but it saves double building fresh setups
+                if (Environment.BUILD_STARTUP && (shouldBuildFileAny('data/pack/client', 'data/pack/client/lastbuild.pack') || shouldBuildFileAny('data/pack/server', 'data/pack/server/lastbuild.pack'))) {
+                    this.devThread!.postMessage({
+                        type: 'pack'
+                    });
+                }
+                // console.timeEnd('checker');
             }
-            // console.timeEnd('checker');
-        }
 
-        if (Environment.WEB_PORT === 80) {
-            console.log(kleur.green().bold('World ready') + kleur.white().bold(': http://localhost'));
-        } else {
-            console.log(kleur.green().bold('World ready') + kleur.white().bold(': http://localhost:' + Environment.WEB_PORT));
+            if (Environment.WEB_PORT === 80) {
+                console.log(kleur.green().bold('World ready') + kleur.white().bold(': http://localhost'));
+            } else {
+                console.log(kleur.green().bold('World ready') + kleur.white().bold(': http://localhost:' + Environment.WEB_PORT));
+            }
         }
 
         if (startCycle) {

--- a/src/lostcity/server/CrcTable.ts
+++ b/src/lostcity/server/CrcTable.ts
@@ -76,9 +76,4 @@ if (typeof self === 'undefined') {
     if (fs.existsSync('data/pack/client/')) {
         makeCrcs();
     }
-// } else {
-    // fetching directory works on local http servers but not github pages, also not needed rn
-    // if ((await fetch('data/pack/client/crc')).ok) {
-    //     await makeCrcsAsync();
-    // }
 }

--- a/src/lostcity/server/LoginThread.ts
+++ b/src/lostcity/server/LoginThread.ts
@@ -11,400 +11,223 @@ import {LoginClient, LoginResponse} from '#lostcity/server/LoginServer.js';
 
 import Environment from '#lostcity/util/Environment.js';
 
-let priv;
-
 if (typeof self === 'undefined') {
     if (!parentPort) throw new Error('This file must be run as a worker thread.');
-    priv = forge.pki.privateKeyFromPem(fs.readFileSync('data/config/private.pem', 'ascii'));
-} else {
-    priv = forge.pki.privateKeyFromPem(await (await fetch('data/config/private.pem')).text());
-}
 
-if (typeof self === 'undefined' && parentPort) {
+    const priv = forge.pki.privateKeyFromPem(fs.readFileSync('data/config/private.pem', 'ascii'));
+
     parentPort.on('message', async msg => {
         try {
             if (!parentPort) throw new Error('This file must be run as a worker thread.');
-
-            switch (msg.type) {
-                case 'reset': {
-                    if (!Environment.LOGIN_KEY) {
-                        return;
-                    }
-
-                    const login = new LoginClient();
-                    await login.reset();
-                    break;
-                }
-                case 'heartbeat': {
-                    if (!Environment.LOGIN_KEY) {
-                        return;
-                    }
-
-                    const login = new LoginClient();
-                    await login.heartbeat(msg.players);
-                    break;
-                }
-                case 'loginreq': {
-                    const { opcode, data, socket } = msg;
-
-                    const stream = new Packet(data);
-
-                    const revision = stream.g1();
-                    if (revision !== 225) {
-                        parentPort.postMessage({
-                            type: 'loginreply',
-                            status: LoginResponse.SERVER_UPDATED,
-                            socket
-                        });
-                        return;
-                    }
-
-                    const info = stream.g1();
-
-                    const crcs = new Uint8Array(9 * 4);
-                    stream.gdata(crcs, 0, crcs.length);
-
-                    stream.rsadec(priv);
-
-                    if (stream.g1() !== 10) {
-                        parentPort.postMessage({
-                            type: 'loginreply',
-                            status: LoginResponse.LOGIN_REJECTED,
-                            socket
-                        });
-                        return;
-                    }
-
-                    const seed = [];
-                    for (let i = 0; i < 4; i++) {
-                        seed[i] = stream.g4();
-                    }
-
-                    const uid = stream.g4();
-                    const username = stream.gjstr();
-                    const password = stream.gjstr();
-
-                    if (username.length < 1 || username.length > 12) {
-                        parentPort.postMessage({
-                            type: 'loginreply',
-                            status: LoginResponse.INVALID_USER_OR_PASS,
-                            socket
-                        });
-                        return;
-                    }
-
-                    if (Environment.LOGIN_KEY) {
-                        if (password.length < 5 || password.length > 20) {
-                            parentPort.postMessage({
-                                type: 'loginreply',
-                                status: LoginResponse.INVALID_USER_OR_PASS,
-                                socket
-                            });
-                            return;
-                        }
-
-                        const login = new LoginClient();
-                        const request = await login.load(toBase37(toSafeName(username)), password, uid);
-
-                        if (request.reply === 1 && request.data) {
-                            parentPort.postMessage({
-                                type: 'loginreply',
-                                status: LoginResponse.SUCCESSFUL,
-                                socket,
-                                info,
-                                seed,
-                                username: toSafeName(username),
-                                save: request.data.data
-                            });
-                        } else if ((request.reply === 2 || request.reply === 3) && opcode === 16) {
-                            // new connection + already logged in
-                            parentPort.postMessage({
-                                type: 'loginreply',
-                                status: LoginResponse.LOGGED_IN,
-                                socket
-                            });
-                            return;
-                        } else if (request.reply === 3 && opcode === 18) {
-                            // reconnection + already logged into another world (???)
-                            parentPort.postMessage({
-                                type: 'loginreply',
-                                status: LoginResponse.LOGGED_IN,
-                                socket
-                            });
-                            return;
-                        } else if (request.reply === 4) {
-                            parentPort.postMessage({
-                                type: 'loginreply',
-                                status: LoginResponse.SUCCESSFUL,
-                                socket,
-                                info,
-                                seed,
-                                username: toSafeName(username),
-                                save: new Uint8Array()
-                            });
-                        } else if (request.reply === 5) {
-                            // invalid credentials (bad user or bad pass)
-                            parentPort.postMessage({
-                                type: 'loginreply',
-                                status: LoginResponse.INVALID_USER_OR_PASS,
-                                socket
-                            });
-                            return;
-                        } else if (request.reply === -1) {
-                            // login server connection error
-                            parentPort.postMessage({
-                                type: 'loginreply',
-                                status: LoginResponse.LOGIN_SERVER_OFFLINE,
-                                socket
-                            });
-                            return;
-                        } else {
-                            parentPort.postMessage({
-                                type: 'loginreply',
-                                status: LoginResponse.LOGIN_REJECTED,
-                                socket
-                            });
-                            return;
-                        }
-                    } else {
-                        let save = new Uint8Array();
-                        const safeName = toSafeName(username);
-                        if (fs.existsSync(`data/players/${safeName}.sav`)) {
-                            save = await fsp.readFile(`data/players/${safeName}.sav`);
-                        }
-
-                        parentPort.postMessage({
-                            type: 'loginreply',
-                            status: LoginResponse.SUCCESSFUL,
-                            socket,
-                            info,
-                            seed,
-                            username: safeName,
-                            save
-                        });
-                    }
-                    break;
-                }
-                case 'logout': {
-                    const { username, save } = msg;
-
-                    if (Environment.LOGIN_KEY) {
-                        const login = new LoginClient();
-                        const reply = await login.save(toBase37(username), save);
-
-                        if (reply === 0) {
-                            parentPort.postMessage({
-                                type: 'logoutreply',
-                                username
-                            });
-                        }
-                    } else {
-                        parentPort.postMessage({
-                            type: 'logoutreply',
-                            username
-                        });
-                    }
-                    break;
-                }
-                default:
-                    console.error('Unknown message type: ' + msg.type);
-                    break;
-            }
+            await handleRequests(parentPort, msg, priv);
         } catch (err) {
             console.error(err);
         }
     });
 } else {
+    const priv = forge.pki.privateKeyFromPem(await (await fetch('data/config/private.pem')).text());
+
     self.onmessage = async msg => {
         try {
-            switch (msg.data.type) {
-                case 'reset': {
-                    // if (!Environment.LOGIN_KEY) {
-                    //     return;
-                    // }
-
-                    // const login = new LoginClient();
-                    // await login.reset();
-                    break;
-                }
-                case 'heartbeat': {
-                    // if (!Environment.LOGIN_KEY) {
-                    //     return;
-                    // }
-
-                    // const login = new LoginClient();
-                    // await login.heartbeat(msg.players);
-                    break;
-                }
-                case 'loginreq': {
-                    const { opcode, data, socket } = msg.data;
-
-                    const stream = new Packet(data);
-
-                    const revision = stream.g1();
-                    if (revision !== 225) {
-                        self.postMessage({
-                            type: 'loginreply',
-                            status: LoginResponse.SERVER_UPDATED,
-                            socket
-                        });
-                        return;
-                    }
-
-                    const info = stream.g1();
-
-                    const crcs = new Uint8Array(9 * 4);
-                    stream.gdata(crcs, 0, crcs.length);
-
-                    stream.rsadec(priv);
-
-                    if (stream.g1() !== 10) {
-                        self.postMessage({
-                            type: 'loginreply',
-                            status: LoginResponse.LOGIN_REJECTED,
-                            socket
-                        });
-                        return;
-                    }
-
-                    const seed = [];
-                    for (let i = 0; i < 4; i++) {
-                        seed[i] = stream.g4();
-                    }
-
-                    const uid = stream.g4();
-                    const username = stream.gjstr();
-                    const password = stream.gjstr();
-
-                    if (username.length < 1 || username.length > 12) {
-                        self.postMessage({
-                            type: 'loginreply',
-                            status: LoginResponse.INVALID_USER_OR_PASS,
-                            socket
-                        });
-                        return;
-                    }
-
-                    if (Environment.LOGIN_KEY) {
-                        if (password.length < 5 || password.length > 20) {
-                            self.postMessage({
-                                type: 'loginreply',
-                                status: LoginResponse.INVALID_USER_OR_PASS,
-                                socket
-                            });
-                            return;
-                        }
-
-                        const login = new LoginClient();
-                        const request = await login.load(toBase37(toSafeName(username)), password, uid);
-
-                        if (request.reply === 1 && request.data) {
-                            self.postMessage({
-                                type: 'loginreply',
-                                status: LoginResponse.SUCCESSFUL,
-                                socket,
-                                info,
-                                seed,
-                                username: toSafeName(username),
-                                save: request.data.data
-                            });
-                        } else if ((request.reply === 2 || request.reply === 3) && opcode === 16) {
-                            // new connection + already logged in
-                            self.postMessage({
-                                type: 'loginreply',
-                                status: LoginResponse.LOGGED_IN,
-                                socket
-                            });
-                            return;
-                        } else if (request.reply === 3 && opcode === 18) {
-                            // reconnection + already logged into another world (???)
-                            self.postMessage({
-                                type: 'loginreply',
-                                status: LoginResponse.LOGGED_IN,
-                                socket
-                            });
-                            return;
-                        } else if (request.reply === 4) {
-                            self.postMessage({
-                                type: 'loginreply',
-                                status: LoginResponse.SUCCESSFUL,
-                                socket,
-                                info,
-                                seed,
-                                username: toSafeName(username),
-                                save: new Uint8Array()
-                            });
-                        } else if (request.reply === 5) {
-                            // invalid credentials (bad user or bad pass)
-                            self.postMessage({
-                                type: 'loginreply',
-                                status: LoginResponse.INVALID_USER_OR_PASS,
-                                socket
-                            });
-                            return;
-                        } else if (request.reply === -1) {
-                            // login server connection error
-                            self.postMessage({
-                                type: 'loginreply',
-                                status: LoginResponse.LOGIN_SERVER_OFFLINE,
-                                socket
-                            });
-                            return;
-                        } else {
-                            self.postMessage({
-                                type: 'loginreply',
-                                status: LoginResponse.LOGIN_REJECTED,
-                                socket
-                            });
-                            return;
-                        }
-                    } else {
-                        let save = new Uint8Array();
-                        const safeName = toSafeName(username);
-                        const saveFile = await fetch(`data/players/${safeName}.sav`);
-                        if (saveFile.ok) {
-                            save = new Uint8Array(await saveFile.arrayBuffer());
-                        }
-
-                        self.postMessage({
-                            type: 'loginreply',
-                            status: LoginResponse.SUCCESSFUL,
-                            socket,
-                            info,
-                            seed,
-                            username: safeName,
-                            save
-                        });
-                    }
-                    break;
-                }
-                case 'logout': {
-                    const { username, save } = msg.data;
-
-                    if (Environment.LOGIN_KEY) {
-                        const login = new LoginClient();
-                        const reply = await login.save(toBase37(username), save);
-
-                        if (reply === 0) {
-                            self.postMessage({
-                                type: 'logoutreply',
-                                username
-                            });
-                        }
-                    } else {
-                        self.postMessage({
-                            type: 'logoutreply',
-                            username
-                        });
-                    }
-                    break;
-                }
-                default:
-                    console.error('Unknown message type: ' + msg.data.type);
-                    break;
-            }
+            await handleRequests(self, msg.data, priv);
         } catch (err) {
             console.error(err);
         }
     };
+}
+
+async function handleRequests(parentPort: any, msg: any, priv: forge.pki.rsa.PrivateKey) {
+    switch (msg.type) {
+        case 'reset': {
+            if (!Environment.LOGIN_KEY) {
+                return;
+            }
+
+            const login = new LoginClient();
+            await login.reset();
+            break;
+        }
+        case 'heartbeat': {
+            if (!Environment.LOGIN_KEY) {
+                return;
+            }
+
+            const login = new LoginClient();
+            await login.heartbeat(msg.players);
+            break;
+        }
+        case 'loginreq': {
+            const { opcode, data, socket } = msg;
+
+            const stream = new Packet(data);
+
+            const revision = stream.g1();
+            if (revision !== 225) {
+                parentPort.postMessage({
+                    type: 'loginreply',
+                    status: LoginResponse.SERVER_UPDATED,
+                    socket
+                });
+                return;
+            }
+
+            const info = stream.g1();
+
+            const crcs = new Uint8Array(9 * 4);
+            stream.gdata(crcs, 0, crcs.length);
+
+            stream.rsadec(priv);
+
+            if (stream.g1() !== 10) {
+                parentPort.postMessage({
+                    type: 'loginreply',
+                    status: LoginResponse.LOGIN_REJECTED,
+                    socket
+                });
+                return;
+            }
+
+            const seed = [];
+            for (let i = 0; i < 4; i++) {
+                seed[i] = stream.g4();
+            }
+
+            const uid = stream.g4();
+            const username = stream.gjstr();
+            const password = stream.gjstr();
+
+            if (username.length < 1 || username.length > 12) {
+                parentPort.postMessage({
+                    type: 'loginreply',
+                    status: LoginResponse.INVALID_USER_OR_PASS,
+                    socket
+                });
+                return;
+            }
+
+            if (Environment.LOGIN_KEY) {
+                if (password.length < 5 || password.length > 20) {
+                    parentPort.postMessage({
+                        type: 'loginreply',
+                        status: LoginResponse.INVALID_USER_OR_PASS,
+                        socket
+                    });
+                    return;
+                }
+
+                const login = new LoginClient();
+                const request = await login.load(toBase37(toSafeName(username)), password, uid);
+
+                if (request.reply === 1 && request.data) {
+                    parentPort.postMessage({
+                        type: 'loginreply',
+                        status: LoginResponse.SUCCESSFUL,
+                        socket,
+                        info,
+                        seed,
+                        username: toSafeName(username),
+                        save: request.data.data
+                    });
+                } else if ((request.reply === 2 || request.reply === 3) && opcode === 16) {
+                    // new connection + already logged in
+                    parentPort.postMessage({
+                        type: 'loginreply',
+                        status: LoginResponse.LOGGED_IN,
+                        socket
+                    });
+                    return;
+                } else if (request.reply === 3 && opcode === 18) {
+                    // reconnection + already logged into another world (???)
+                    parentPort.postMessage({
+                        type: 'loginreply',
+                        status: LoginResponse.LOGGED_IN,
+                        socket
+                    });
+                    return;
+                } else if (request.reply === 4) {
+                    parentPort.postMessage({
+                        type: 'loginreply',
+                        status: LoginResponse.SUCCESSFUL,
+                        socket,
+                        info,
+                        seed,
+                        username: toSafeName(username),
+                        save: new Uint8Array()
+                    });
+                } else if (request.reply === 5) {
+                    // invalid credentials (bad user or bad pass)
+                    parentPort.postMessage({
+                        type: 'loginreply',
+                        status: LoginResponse.INVALID_USER_OR_PASS,
+                        socket
+                    });
+                    return;
+                } else if (request.reply === -1) {
+                    // login server connection error
+                    parentPort.postMessage({
+                        type: 'loginreply',
+                        status: LoginResponse.LOGIN_SERVER_OFFLINE,
+                        socket
+                    });
+                    return;
+                } else {
+                    parentPort.postMessage({
+                        type: 'loginreply',
+                        status: LoginResponse.LOGIN_REJECTED,
+                        socket
+                    });
+                    return;
+                }
+            } else {
+                let save = new Uint8Array();
+                const safeName = toSafeName(username);
+
+                if (typeof self === 'undefined') {
+                    if (fs.existsSync(`data/players/${safeName}.sav`)) {
+                        save = await fsp.readFile(`data/players/${safeName}.sav`);
+                    }
+                } else {
+                    const saveFile = await fetch(`data/players/${safeName}.sav`);
+                    if (saveFile.ok) {
+                        save = new Uint8Array(await saveFile.arrayBuffer());
+                    }
+                }
+
+                parentPort.postMessage({
+                    type: 'loginreply',
+                    status: LoginResponse.SUCCESSFUL,
+                    socket,
+                    info,
+                    seed,
+                    username: safeName,
+                    save
+                });
+            }
+            break;
+        }
+        case 'logout': {
+            const { username, save } = msg;
+
+            if (Environment.LOGIN_KEY) {
+                const login = new LoginClient();
+                const reply = await login.save(toBase37(username), save);
+
+                if (reply === 0) {
+                    parentPort.postMessage({
+                        type: 'logoutreply',
+                        username
+                    });
+                }
+            } else {
+                parentPort.postMessage({
+                    type: 'logoutreply',
+                    username
+                });
+            }
+            break;
+        }
+        default:
+            console.error('Unknown message type: ' + msg.type);
+            break;
+    }
 }


### PR DESCRIPTION
The worker implementation is now just reduced to some async functions and typeof self checks that are needed 😄 

Note: sometimes it can send `loginThread.postMessage` before login thread has set onmessage in which case it will get stuck on login forever. It only seems to happen on bun bundles though, esbuild bundles load loginthread faster.

Not really a problem anyway as u can just await the gamemaps to load first which will fix the timing, but I might let the worker start on client load instead of login as well.