### PR TITLE
feat(engine): multiple webworker connections support

### DIFF
--- a/bundle.js
+++ b/bundle.js
@@ -2,9 +2,10 @@ import fs from 'fs';
 import {basename} from 'path';
 import * as esbuild from 'esbuild';
 
-const entryPoints = ['src/lostcity/worker.ts', 'src/lostcity/server/LoginThread.ts'];
-const esbuildModules = ['node:fs/promises', 'path', 'net', 'crypto', 'fs'];
-const modules = ['kleur', 'buffer', 'module', 'watcher', 'worker_threads', 'dotenv/config', 'bcrypt', '#lostcity/db/query.js', '#lostcity/util/PackFile.js'];
+const dir = '../Client2/public/';
+const entrypoints = ['src/lostcity/worker.ts', 'src/lostcity/server/LoginThread.ts'];
+const esbuildIgnores = ['node:fs/promises', 'path', 'net', 'crypto', 'fs'];
+const ignores = ['kleur', 'buffer', 'module', 'watcher', 'worker_threads', 'dotenv/config', 'bcrypt', '#lostcity/db/query.js', '#lostcity/util/PackFile.js'];
 const defines = {
     'process.platform': JSON.stringify('webworker'),
     'process.env.WEB_PORT': 'undefined',
@@ -39,6 +40,9 @@ const defines = {
 
 try {
     preloadDirs();
+    if (!fs.existsSync(dir)) {
+        fs.mkdirSync(dir, { recursive: true });
+    }
     process.argv0 === 'bun' ? await bun() : await esb();
 } catch (e) {
     console.error(e);
@@ -50,30 +54,30 @@ async function esb() {
         format: 'esm',
         write: false,
         outdir: 'placeholder', // unused but required by esbuild
-        entryPoints: entryPoints,
-        external: modules.concat(esbuildModules),
+        entryPoints: entrypoints,
+        external: ignores.concat(esbuildIgnores),
         define: defines,
         // minify: true,
         // sourcemap: 'linked',
     }).catch((e) => { throw new Error(e); });
 
     for (let index = 0; index < bundle.outputFiles.length; index++) {
-        removeImports(bundle.outputFiles[index].text, entryPoints[index]);
+        removeImports(bundle.outputFiles[index].text, entrypoints[index]);
     }
 }
 
 async function bun() {
     // eslint-disable-next-line no-undef
     const bundle = await Bun.build({
-        entrypoints: entryPoints,
-        external: modules,
+        entrypoints: entrypoints,
+        external: ignores,
         define: defines,
         // minify: true,
         // sourcemap: 'linked',
     }).catch((e) => { throw new Error(e); });
 
     for (let index = 0; index < bundle.outputs.length; index++) {
-        removeImports(await bundle.outputs[index].text(), entryPoints[index]);
+        removeImports(await bundle.outputs[index].text(), entrypoints[index]);
     }
 }
 
@@ -94,7 +98,7 @@ function preloadDirs() {
 
 function removeImports(output, file) {
     // turn into plugin for minify/sourcemaps
-    const path = '../Client2/src/public/' + basename(file).replace('.ts', '.js');
+    const path = dir + basename(file).replace('.ts', '.js');
 
     output = output.split('\n')
         .filter(line => !line.startsWith('import'))

--- a/src/jagex2/io/Packet.ts
+++ b/src/jagex2/io/Packet.ts
@@ -186,7 +186,7 @@ export default class Packet extends Hashable {
         } else {
             const blob = new Blob([this.data.subarray(start, start + length)], { type: 'application/octet-stream' });
             const url = URL.createObjectURL(blob);
-            self.postMessage( { type: 'save', value: url, path: filePath });
+            self.postMessage({ type: 'save', value: url, path: filePath });
         }
     }
 

--- a/src/lostcity/engine/GameMap.ts
+++ b/src/lostcity/engine/GameMap.ts
@@ -77,7 +77,7 @@ export default class GameMap {
             this.decodeLands(lands, landData, mapsquareX, mapsquareZ);
             this.decodeLocs(lands, locData, mapsquareX, mapsquareZ, zoneMap);
         });
-        // await Promise.all(maps); // this bottlenecks login time
+        await Promise.all(maps);
         console.timeEnd('Loading game map');
     }
 

--- a/src/lostcity/server/WorkerServer.ts
+++ b/src/lostcity/server/WorkerServer.ts
@@ -47,7 +47,6 @@ export default class WorkerServer {
                         if (socket.player) {
                             socket.player.client = null;
                         }
-                        socket.close();
                         this.sockets.delete(e.data.id);
                     }
                     break;

--- a/src/lostcity/worker.ts
+++ b/src/lostcity/worker.ts
@@ -5,3 +5,4 @@ await World.start();
 
 const workerServer = new WorkerServer();
 workerServer.start();
+self.postMessage({ type: 'ready' });


### PR DESCRIPTION
These changes are for webrtc which is all client sided, and it works by having webrtc send and receive worker messages.

1. move uniqueId generation for workerserver to client, which means randomUUID has to be in the constructor
2. allow starting server on client load by sending `connection` message from client on login
3. map for connections, close logged off clientsockets, simplify ClientSocket
4. change bundles output dir to /public instead of /src/public to be ignored by terser in client2
5. fixed server hanging on load if you try to login before it's ready.
6. copy wasm files while bundling to avoid adding them to client, also copy packs+pem automatically too
7. Fixed issue where connected peers never logout if they X out of tab, sends close message on client unload.

More info and links here https://github.com/2004Scape/Client2/pull/21