### PR TITLE
fix(content): Change ikov move trigger to use mapzone, mourner and ogre fixes

### DIFF
--- a/data/src/scripts/_unpack/all.npc
+++ b/data/src/scripts/_unpack/all.npc
@@ -8312,7 +8312,7 @@ walkanim=dog_walk
 readyanim=dog_ready
 vislevel=1
 model1=model_2936_npc
-timer=1
+timer=40
 param=death_anim,dog_death
 
 [npc_822]

--- a/data/src/scripts/areas/area_ardougne_east/scripts/brother_omad.rs2
+++ b/data/src/scripts/areas/area_ardougne_east/scripts/brother_omad.rs2
@@ -33,7 +33,7 @@ switch_int (~p_choice2("Can I help at all?", 1, "I'm sorry to hear that! I hope 
 ~chatnpc("<p,neutral>Please do. We won't be able to help you as we are peaceful men but we would be grateful for your help!");
 ~chatplayer("<p,neutral>Where are they?");
 %drunkmonk_progress = ^drunkmonk_spoken_to_omad;
-softtimer(blanket_ladder, 1);
+settimer(blanket_ladder, 1);
 ~send_quest_progress(questlist:drunkmonk, %drunkmonk_progress, ^drunkmonk_complete);
 ~chatnpc("<p,neutral>They hide in a secret cave in the forest. It's hidden under a ring of stones. Please, bring back the blanket!");
 

--- a/data/src/scripts/areas/area_ardougne_west/configs/mourner.npc
+++ b/data/src/scripts/areas/area_ardougne_west/configs/mourner.npc
@@ -27,7 +27,17 @@ head1=model_51_obj_wear
 param=attack_anim,human_staff_pound
 param=defend_anim,human_staff_def
 param=attack_sound,staff_hit
-// TODO
+// stats based off: https://oldschool.runescape.wiki/w/Mourner?oldid=9768605#Lv_11, 70t respawn on rs3
+respawnrate=70
+hitpoints=19
+attack=8
+strength=8
+defence=8
+param=attackbonus,6
+param=strengthbonus,2
+param=stabdefence,6
+param=slashdefence,6
+param=crushdefence,9
 
 [npc_348]
 name=Mourner
@@ -52,7 +62,15 @@ model4=model_273_obj_wear
 model5=model_185_obj_wear
 model6=model_323_obj_wear
 head1=model_51_obj_wear
-// TODO
+// stats based off: https://oldschool.runescape.wiki/w/Mourner?oldid=9768605#Lv_24, 70t respawn on rs3
+respawnrate=70
+hitpoints=25
+attack=20
+strength=20
+defence=20
+param=stabdefence,3
+param=slashdefence,2
+param=crushdefence,4
 
 [npc_357]
 name=Mourner
@@ -79,7 +97,17 @@ model7=model_555_npc
 head1=model_51_obj_wear
 param=attack_anim,human_staff_spike
 param=attack_sound,staff_stab
-// TODO
+// stats based off: https://oldschool.runescape.wiki/w/Mourner?oldid=9768605#Lv_18, 70t respawn on rs3
+respawnrate=70
+hitpoints=13
+attack=17
+strength=17
+defence=17
+param=attackbonus,5
+param=strengthbonus,5
+param=stabdefence,5
+param=slashdefence,5
+param=crushdefence,7
 
 [npc_369]
 name=Mourner
@@ -106,17 +134,15 @@ model4=model_273_obj_wear
 model5=model_323_obj_wear
 model6=model_499_npc
 head1=model_51_obj_wear
-// stats based off: https://oldschool.runescape.wiki/w/Mourner?oldid=8089161#Lv_18, 70t respawn on rs3
+// stats based off: https://oldschool.runescape.wiki/w/Mourner?oldid=9753180#Lv_24_(Vial), 70t respawn on rs3
 respawnrate=70
-hitpoints=13
-attack=17
-strength=17
-defence=17
-param=attackbonus,5
-param=strengthbonus,5
-param=stabdefence,5
-param=slashdefence,5
-param=crushdefence,7
+hitpoints=25
+attack=20
+strength=20
+defence=20
+param=stabdefence,2
+param=slashdefence,1
+param=crushdefence,3
 
 [npc_370]
 name=Mourner
@@ -149,8 +175,6 @@ hitpoints=19
 attack=10
 strength=10
 defence=10
-param=attackbonus,5
-param=strengthbonus,6
 param=stabdefence,3
 param=slashdefence,2
 param=crushdefence,4
@@ -186,8 +210,6 @@ hitpoints=13
 attack=10
 strength=10
 defence=10
-param=attackbonus,5
-param=strengthbonus,6
 param=stabdefence,3
 param=slashdefence,2
 param=crushdefence,4

--- a/data/src/scripts/areas/area_gnome/scripts/gnomes.rs2
+++ b/data/src/scripts/areas/area_gnome/scripts/gnomes.rs2
@@ -1,5 +1,6 @@
 [opnpc1,gnome_green] @talk_to_gnome;
 [opnpc1,gnome_brown] @talk_to_gnome;
+[opnpc1,gnome_black] @talk_to_gnome;
 [opnpc1,gnome_woman_white] @talk_to_gnome_woman;
 [opnpc1,gnome_woman_black] @talk_to_gnome_woman;
 

--- a/data/src/scripts/general/scripts/quests.rs2
+++ b/data/src/scripts/general/scripts/quests.rs2
@@ -239,5 +239,5 @@ if(%phoenixgang_progress > 0 & %blackarmgang_progress ! ^blackarmgang_complete) 
 if_settab(questlist, ^tab_quest_journal);
 
 if (%drunkmonk_progress >= ^drunkmonk_spoken_to_omad) {
-    softtimer(blanket_ladder, 1);
+    settimer(blanket_ladder, 1);
 }

--- a/data/src/scripts/music/scripts/move.rs2
+++ b/data/src/scripts/music/scripts/move.rs2
@@ -468,7 +468,7 @@ settimer(move_ikovtrigger, 1);
 
 [mapzone,0_50_49] ~move_musictrigger(coord);
 
-[mapzone,0_50_50] mes("testing"); ~move_musictrigger(coord);
+[mapzone,0_50_50] ~move_musictrigger(coord);
 
 [mapzone,0_50_51] ~move_musictrigger(coord);
 

--- a/data/src/scripts/music/scripts/move.rs2
+++ b/data/src/scripts/music/scripts/move.rs2
@@ -166,7 +166,9 @@ if (%music_mapsquare ! $mapsquare) {
 
 [mapzone,0_41_152] ~move_musictrigger(coord);
 
-[mapzone,0_41_153] ~move_musictrigger(coord);
+[mapzone,0_41_153]
+~move_musictrigger(coord);
+settimer(move_ikovtrigger, 1);
 
 [mapzone,0_41_154] ~move_musictrigger(coord);
 
@@ -466,7 +468,7 @@ if (%music_mapsquare ! $mapsquare) {
 
 [mapzone,0_50_49] ~move_musictrigger(coord);
 
-[mapzone,0_50_50] ~move_musictrigger(coord);
+[mapzone,0_50_50] mes("testing"); ~move_musictrigger(coord);
 
 [mapzone,0_50_51] ~move_musictrigger(coord);
 

--- a/data/src/scripts/quests/quest_drunkmonk/scripts/quest_drunkmonk.rs2
+++ b/data/src/scripts/quests/quest_drunkmonk/scripts/quest_drunkmonk.rs2
@@ -1,4 +1,4 @@
-[softtimer,blanket_ladder] // This might be some form of move trigger instead?
+[timer,blanket_ladder]
 if(distance(^blanket_ladder_coord, coord) <= 2 & ~drunkmonk_ladder_active = false) {
     mes("A ladder mysteriously appears.");
     loc_add(^blanket_ladder_coord, loc_1765, 1, centrepiece_straight, 200);

--- a/data/src/scripts/quests/quest_ikov/scripts/ikov_dungeon.rs2
+++ b/data/src/scripts/quests/quest_ikov/scripts/ikov_dungeon.rs2
@@ -33,28 +33,25 @@ if($entering = false | %ikov_lever = 1) {
 }
 ~mesbox("The door won't open!");
 
-[proc,move_ikovtrigger](coord $coord)
+[mapzoneexit,0_41_153] cleartimer(move_ikovtrigger);
+
+[timer,move_ikovtrigger]
 if(inzone(^ikovbridge_zone_lower, ^ikovbridge_zone_upper, coord) = true) {
-    if (coordx(coord) = coordx(movecoord(^ikovbridge_zone_lower, 1, 0, 0))) {
-        if(coordx(last_coord) <= coordx(^ikovbridge_zone_lower)) {
-            p_teleport(movecoord(coord, -1, 0, 0));
-        } else {
-            p_teleport(movecoord(coord, 1, 0, 0));
-        }
-    }
-    p_stopaction;
     queue(ikov_movebridge, 0);
 }
 
 [queue,ikov_movebridge]
-if(coordx(coord) <= coordx(movecoord(^ikovbridge_zone_lower, 1, 0, 0))) {
-    ~forcemove(movecoord(coord, 1, 0, 0));
+if(inzone(^ikovbridge_zone_lower, ^ikovbridge_zone_upper, coord) = false) {
+    return;
+}
+if(coordx(last_coord) <= coordx(movecoord(^ikovbridge_zone_lower, 1, 0, 0))) {
+    ~forcemove(movecoord(^ikovbridge_zone_lower, 1, 0, abs(calc(coordz(^ikovbridge_zone_lower) - coordz(coord)))));
     if(weight >= 0) {
         @ikov_bridgefail;
     }
     ~forcemove(movecoord(coord, 2, 0, 0));
 } else {
-    ~forcemove(movecoord(coord, -1, 0, 0));
+    ~forcemove(movecoord(^ikovbridge_zone_lower, 1, 0, abs(calc(coordz(^ikovbridge_zone_lower) - coordz(coord)))));
     if(weight >= 0) {
         @ikov_bridgefail;
     }

--- a/data/src/scripts/quests/quest_murder/scripts/sinclair_guard_dog.rs2
+++ b/data/src/scripts/quests/quest_murder/scripts/sinclair_guard_dog.rs2
@@ -1,4 +1,3 @@
 [ai_timer,sinclair_guard_dog]
-if(random(40) = 0) { // approximation
-    npc_say("BARK");
-}
+npc_say("BARK");
+npc_settimer(~random_range(1, 40));

--- a/data/src/scripts/skill_combat/scripts/npc/npc_combat.rs2
+++ b/data/src/scripts/skill_combat/scripts/npc/npc_combat.rs2
@@ -134,6 +134,11 @@ if(npc_type = fire_warrior_of_lesarkus & (inv_total(worn, ice_arrow) = 0 | %dama
     return (false);
 }
 
+if(npc_type = npc_374 & %damagetype <= ^crush_style & npc_range(coord) <= 1) {
+    mes("These ogres are for ranged combat only.");
+    return (false);
+}
+
 if (string_length(nc_op($npc, 2)) > 0) {
     return (true);
 }

--- a/data/src/scripts/skill_combat/scripts/player/player_melee.rs2
+++ b/data/src/scripts/skill_combat/scripts/player/player_melee.rs2
@@ -7,6 +7,10 @@ p_stopaction;
 // TODO this is for flinching players (pvp etc)
 //if (autoretaliateenabled && action_clock < gameClock()) action_clock = gameClock() + (weaponSpeed / 2)
 
+if (~npc_is_attackable(npc_type) = false) {
+    return;
+}
+
 if (%action_delay > map_clock | getwalktrigger() = stunned) {
     p_opnpc(2); // it is guaranteed here that we are already within op distance
     return;
@@ -19,10 +23,6 @@ if(npc_stat(hitpoints) = 0 & (npc_type = sir_mordred | npc_type = black_knight_t
 if (npc_stat(hitpoints) = 0) {
     p_stopaction;
     return; // this means the npc is not avail to fight i.e dead
-}
-
-if (~npc_is_attackable(npc_type) = false) {
-    return;
 }
 
 ~player_combat_stat; // update combat varps before swinging

--- a/src/lostcity/engine/script/handlers/PlayerOps.ts
+++ b/src/lostcity/engine/script/handlers/PlayerOps.ts
@@ -1001,7 +1001,7 @@ const PlayerOps: CommandHandlers = {
     }),
 
     [ScriptOpcode.LAST_COORD]: checkedHandler(ActivePlayer, state => {
-        state.pushInt(Position.packCoord(state.activePlayer.level, state.activePlayer.lastX, state.activePlayer.lastZ));
+        state.pushInt(Position.packCoord(state.activePlayer.level, state.activePlayer.lastStepX, state.activePlayer.lastStepZ));
     }),
 };
 


### PR DESCRIPTION
change ikov move trigger to use a timer that starts/stops on mapzone enter/exit, not 1:1 (no p_teleport to prevent moving to middle of bridge at the start) so might need to be adjusted later
* more mourner stats
* prevent attacking combat camp ogres with melee
* change last_coord to use laststep values instead (since lastX/Z will update before timer runs)
* change drunkmonk ladder to operate on reg timer instead of softtimer
