### PR TITLE
fix(engine): do not allow repathing if player has no target or cant access

### DIFF
--- a/src/lostcity/entity/Player.ts
+++ b/src/lostcity/entity/Player.ts
@@ -823,7 +823,7 @@ export default class Player extends PathingEntity {
 
     processInteraction() {
         if (this.target === null || !this.canAccess()) {
-            this.updateMovement();
+            this.updateMovement(false);
             return;
         }
 


### PR DESCRIPTION
![idk 199](https://github.com/user-attachments/assets/cb123296-1cf1-43d2-8fb3-019acbfec960)
