### PR TITLE
fix(content): authentic lvl up reward messages

### DIFF
--- a/data/src/scripts/levelup/scripts/levelup_unlocks_cooking.rs2
+++ b/data/src/scripts/levelup/scripts/levelup_unlocks_cooking.rs2
@@ -4,14 +4,13 @@ switch_int(stat_base(cooking)) {
     case 5: ~objboxt(herring,"You can now cook @dbl@Herring@bla@.");
     case 6: ~objboxb(fruit_blast,"Members can now make @dbl@Fruit Blasts@bla@.");
     case 8: ~objboxb(pineapple_punch,"Members can now make @dbl@Pineapple Punches@bla@.");
-    case 10: ~doubleobjbox(mackerel,redberry_pie,"You can now cook @dbl@Redberry Pies@bla@. Members can cook|@dbl@Mackrel@bla@ and also make @dbl@Toad Crunchies");
+    case 10: ~doubleobjbox(mackerel,redberry_pie,"You can now cook @dbl@Redberry Pies@bla@. Members can cook|@dbl@Mackerel@bla@ and also make @dbl@Toad Crunchies");
     case 12: ~objboxt(spicy_crunchies,"Members can now cook @dbl@Spicy Crunchies@bla@.");
     case 14: ~objboxt(worm_crunchies,"Members can now make @dbl@Worm Crunchies@bla@.");
     case 15: ~objboxt(trout,"You can now cook @dbl@Trout@bla@.");
     case 16: ~objboxt(choc_chip_crunchies,"Members can now make @dbl@Chocolate Chip Crunchies@bla@.");
     case 18: ~doubleobjbox(cod,wizard_blizzard,"Members can now cook @dbl@Cod@bla@ and make @dbl@Wizard|@dbl@Blizzards@bla@.");
     case 20: ~doubleobjbox(pike,meat_pie,"You can now cook @dbl@Meat Pies@bla@ and @dbl@Pike@bla@. Members can|also make @dbl@Short Green Guys@bla@.");
-    case 21: ~objbox(pot_of_cream,"Members can now churn @dbl@Cream@bla@.");
     case 25: ~doubleobjbox(salmon,stew,"You can now cook @dbl@Stews@bla@ and @dbl@Salmon@bla@. Members may| also create @dbl@Fruit Battas@bla@.");
     case 26: ~objbox(toad_batta,"Members can now cook @dbl@Toad Battas@bla@.");
     case 27: ~objbox(worm_batta,"Members can now cook @dbl@Worm Battas@bla@.");

--- a/data/src/scripts/levelup/scripts/levelup_unlocks_crafting.rs2
+++ b/data/src/scripts/levelup/scripts/levelup_unlocks_crafting.rs2
@@ -40,7 +40,7 @@ switch_int(stat_base(crafting)) {
     case 68: ~objboxt(blue_dragonhide_chaps,"Members can now craft @dbl@Blue Dragonhide Chaps@bla@.");
     case 70: ~objboxt(diamond_amulet,"You can now craft @dbl@Diamond Amulets@bla@.");
     case 71: ~objbox(blue_dragonhide_body,"Members can now craft @dbl@Blue Dragonhide Armour@bla@.");
-    case 72: ~objboxt(dragonstone_necklace,"You can now craft @dbl@Dragonstone Necklaces@bla@.");
+    case 72: ~objboxt(dragonstone_necklace,"Members can now craft @dbl@Dragonstone Necklaces@bla@.");
     case 73: ~objboxt(red_dragonhide_vambraces,"Members can now craft @dbl@Red Dragonhide Vambraces@bla@.");
     case 75: ~objboxt(red_dragonhide_chaps,"Members can now craft @dbl@Red Dragonhide Chaps@bla@.");
     case 77: ~objbox(red_dragonhide_body,"Members can now craft @dbl@Red Dragonhide Armour@bla@.");

--- a/data/src/scripts/levelup/scripts/levelup_unlocks_magic.rs2
+++ b/data/src/scripts/levelup/scripts/levelup_unlocks_magic.rs2
@@ -6,8 +6,8 @@ switch_int(stat_base(magic)) {
     case 9: ~objboxt(battlestaff, "You can now cast @dbl@Earth Strike@bla@!");
     case 11: ~objboxt(battlestaff, "You can now cast @dbl@Weaken@bla@!");
     case 13: ~objboxt(battlestaff, "You can now cast @dbl@Fire Strike@bla@!");
-    case 15: ~objboxt(battlestaff, "You can now get @dbl@Bones to Peaches@bla@ from the Magic Training Arena.");
-    case 17: ~objboxt(battlestaff, "You can now cast @dbl@Air Bolt@bla@!");
+    case 15: ~objboxt(battlestaff, "You can now cast @dbl@Bones to Bananas@bla@!"); //guess
+    case 17: ~objboxt(battlestaff, "You can now cast @dbl@Wind Bolt@bla@!");
     case 19: ~objboxt(battlestaff, "You can now cast @dbl@Curse@bla@!");
     case 20: ~objboxt(battlestaff, "You can now cast @dbl@Bind@bla@!");
     case 21: ~objboxt(battlestaff, "You can now cast @dbl@Low Level Alchemy@bla@!");
@@ -20,7 +20,7 @@ switch_int(stat_base(magic)) {
     case 35: ~objboxt(battlestaff, "You can now cast @dbl@Fire Bolt@bla@!");
     case 37: ~objboxt(battlestaff, "You can now @dbl@Teleport to Falador@bla@!");
     case 39: ~objboxt(battlestaff, "You can now cast @dbl@Crumble Undead@bla@!");
-    case 41: ~objboxt(battlestaff, "You can now cast @dbl@Air Blast@bla@!");
+    case 41: ~objboxt(battlestaff, "You can now cast @dbl@Wind Blast@bla@!");
     case 43: ~objboxt(battlestaff, "You can now cast @dbl@Superheat Item@bla@!");
     case 45: ~objboxt(battlestaff, "Members can now @dbl@Teleport to Camelot@bla@!");
     case 47: ~objboxt(battlestaff, "You can now cast @dbl@Water Blast@bla@!");
@@ -31,10 +31,10 @@ switch_int(stat_base(magic)) {
     case 55: ~objboxt(battlestaff, "You can now cast @dbl@High Level Alchemy@bla@!");
     case 56: ~objboxt(battlestaff, "Members can now @dbl@Charge Water Orbs@bla@!");
     case 57: ~objboxt(battlestaff, "You can now enchant @dbl@Diamond Jewellery@bla@!");
-    case 58: ~objboxt(battlestaff, "Members can now @dbl@Teleport to Watchtower@bla@!");
+    case 58: ~objboxt(battlestaff, "Members can now @dbl@Teleport to the Watchtower@bla@!");
     case 59: ~objboxt(battlestaff, "You can now cast @dbl@Fire Blast@bla@!");
-    case 60: ~objboxt(battlestaff, "Members can now @dbl@ECharge Earth Orbs@bla@!");
-    case 62: ~objboxt(battlestaff, "Members can now cast @dbl@Air Wave@bla@!");
+    case 60: ~objboxt(battlestaff, "Members can now @dbl@Charge Earth Orbs@bla@!");
+    case 62: ~objboxt(battlestaff, "Members can now cast @dbl@Wind Wave@bla@!");
     case 63: ~objboxt(battlestaff, "Members can now @dbl@Charge Fire Orbs@bla@!");
     case 65: ~objboxt(battlestaff, "Members can now cast @dbl@Water Wave@bla@!");
     case 66: ~objboxt(battlestaff, "Members can now cast @dbl@Vulnerability@bla@ and @dbl@Charge Air|@dbl@Orbs@bla@! Members can also enter the @dbl@Wizard's Guild@bla@.");
@@ -43,7 +43,7 @@ switch_int(stat_base(magic)) {
     case 73: ~objboxt(battlestaff, "Members can now cast @dbl@Enfeeble@bla@!");
     case 75: ~objboxt(battlestaff, "Members can now cast @dbl@Fire Wave@bla@!");
     case 79: ~objboxt(battlestaff, "Members can now cast @dbl@Entangle@bla@!");
-    case 80: ~objboxt(battlestaff, "Members can now cast @dbl@Charge@bla@ and @dbl@Stun@bla@!");
+    case 80: ~objboxt(battlestaff, "Members can now cast @dbl@Stun@bla@!");
 
 
 

--- a/data/src/scripts/levelup/scripts/levelup_unlocks_prayer.rs2
+++ b/data/src/scripts/levelup/scripts/levelup_unlocks_prayer.rs2
@@ -1,18 +1,19 @@
 [label,levelup_prayer]
 //Prayer level up unlock messages
+//screenshots as early as 2006 show blue exclamation marks
 switch_int(stat_base(prayer)) {
-    case 4: ~mesbox("You can now use the Prayer @dbl@Burst of Strength@bla@!");
-    case 7: ~mesbox("You can now use the Prayer @dbl@Clarity of Thought@bla@!");
-    case 10: ~mesbox("You can now use the Prayer @dbl@Rock Skin@bla@!");
-    case 13: ~mesbox("You can now use the Prayer @dbl@Superhuman Strength@bla@!");
-    case 16: ~mesbox("You can now use the Prayer @dbl@Improved Reflexes@bla@!");
-    case 19: ~mesbox("You can now use the Prayer @dbl@Rapid Restore@bla@!");
-    case 22: ~mesbox("You can now use the Prayer @dbl@Rapid Heal@bla@!");
-    case 25: ~mesbox("You can now use the Prayer @dbl@Protect Items@bla@!");
-    case 28: ~mesbox("You can now use the Prayer @dbl@Steel Skin@bla@!");
+    case 4: ~mesbox("You can now use the Prayer @dbl@Burst of Strength!");
+    case 7: ~mesbox("You can now use the Prayer @dbl@Clarity of Thought!");
+    case 10: ~mesbox("You can now use the Prayer @dbl@Rock Skin!");
+    case 13: ~mesbox("You can now use the Prayer @dbl@Superhuman Strength!");
+    case 16: ~mesbox("You can now use the Prayer @dbl@Improved Reflexes!");
+    case 19: ~mesbox("You can now use the Prayer @dbl@Rapid Restore!");
+    case 22: ~mesbox("You can now use the Prayer @dbl@Rapid Heal!");
+    case 25: ~mesbox("You can now use the Prayer @dbl@Protect Items!");
+    case 28: ~mesbox("You can now use the Prayer @dbl@Steel Skin!");
     case 31: ~mesbox("You can now use the Prayer @dbl@Ultimate Strength@bla@|and you can enter the @dbl@Monastery");
-    case 34: ~mesbox("You can now use the Prayer @dbl@Incredible Reflexes@bla@!");
-    case 37: ~mesbox("You can now use the Prayer @dbl@Protect From Magic@bla@!");
-    case 40: ~mesbox("You can now use the Prayer @dbl@Protect From Missiles@bla@!");
-    case 43: ~mesbox("You can now use the Prayer @dbl@Protect From Melee@bla@!");
+    case 34: ~mesbox("You can now use the Prayer @dbl@Incredible Reflexes!");
+    case 37: ~mesbox("You can now use the Prayer @dbl@Protect From Magic!");
+    case 40: ~mesbox("You can now use the Prayer @dbl@Protect From Missiles!");
+    case 43: ~mesbox("You can now use the Prayer @dbl@Protect From Melee!");
 }


### PR DESCRIPTION
- (cooking): fix typo and remove churning message
- (crafting): change level 72 message to say members
- (magic): replace messages and some spell names, fix typo
- (prayer): replace messages to match old screenshots