### PR TITLE
fix(content): use correct bury bone queue for tutorial

### DIFF
--- a/data/src/scripts/tutorial/scripts/skills/tut_bury_bone.rs2
+++ b/data/src/scripts/tutorial/scripts/skills/tut_bury_bone.rs2
@@ -1,5 +1,5 @@
 [label,tut_bury_bones](int $slot)
-if (getqueue(finish_bury) > 0) {
+if (getqueue(tut_finish_bury) > 0) {
     return;
 }
 
@@ -10,7 +10,7 @@ def_obj $last_item = inv_getobj(inv, $slot);
 inv_delslot(inv, $slot);
 // this is strong queue in later revs
 p_stopaction;
-queue(finish_bury, 1, $last_item);
+queue(tut_finish_bury, 1, $last_item);
 
 [queue,tut_finish_bury](obj $last_item)
 if_close;


### PR DESCRIPTION
- Minor fix to use proper queue inside tutorial for burying bones, previously was able to level prayer past 3 during tutorial.