### PR TITLE
fix(engine): changeobj not updating the obj despawn life cycle

### DIFF
--- a/src/lostcity/engine/World.ts
+++ b/src/lostcity/engine/World.ts
@@ -1361,11 +1361,11 @@ class World {
         // console.log(`[World] revealObj => name: ${ObjType.get(obj.type).name}`);
         const duration: number = obj.reveal;
         const change: number = obj.lastChange;
-        const changed: boolean = change !== -1;
         const zone: Zone = this.getZone(obj.x, obj.z, obj.level);
         zone.revealObj(obj, obj.receiverId);
         // objs next life cycle always starts from the last time they changed + the inputted duration.
-        const nextLifecycle: number = (changed ? (Obj.REVEAL - (this.currentTick - change)) : 0) + this.currentTick + duration;
+        // accounting for reveal time here.
+        const nextLifecycle: number = (change !== -1 ? (Obj.REVEAL - (this.currentTick - change)) : 0) + this.currentTick + duration;
         obj.setLifeCycle(nextLifecycle);
         this.trackZone(nextLifecycle, zone);
         this.trackZone(this.currentTick, zone);

--- a/src/lostcity/engine/World.ts
+++ b/src/lostcity/engine/World.ts
@@ -1343,8 +1343,10 @@ class World {
         const zone: Zone = this.getZone(obj.x, obj.z, obj.level);
         zone.addObj(obj, receiverId);
         if (receiverId !== -1 && objType.tradeable && (objType.members && Environment.NODE_MEMBERS || !objType.members)) {
-            obj.setLifeCycle(this.currentTick + 100);
-            this.trackZone(this.currentTick + 100, zone);
+            // objs always reveal 100 ticks after being dropped.
+            const reveal: number = this.currentTick + Obj.REVEAL;
+            obj.setLifeCycle(reveal);
+            this.trackZone(reveal, zone);
             this.trackZone(this.currentTick, zone);
             obj.receiverId = receiverId;
             obj.reveal = duration;
@@ -1358,10 +1360,14 @@ class World {
     revealObj(obj: Obj): void {
         // console.log(`[World] revealObj => name: ${ObjType.get(obj.type).name}`);
         const duration: number = obj.reveal;
+        const change: number = obj.lastChange;
+        const changed: boolean = change !== -1;
         const zone: Zone = this.getZone(obj.x, obj.z, obj.level);
         zone.revealObj(obj, obj.receiverId);
-        obj.setLifeCycle(this.currentTick + duration);
-        this.trackZone(this.currentTick + duration, zone);
+        // objs next life cycle always starts from the last time they changed + the inputted duration.
+        const nextLifecycle: number = (changed ? (Obj.REVEAL - (this.currentTick - change)) : 0) + this.currentTick + duration;
+        obj.setLifeCycle(nextLifecycle);
+        this.trackZone(nextLifecycle, zone);
         this.trackZone(this.currentTick, zone);
     }
 

--- a/src/lostcity/engine/zone/Zone.ts
+++ b/src/lostcity/engine/zone/Zone.ts
@@ -300,6 +300,7 @@ export default class Zone {
     revealObj(obj: Obj, receiverId: number): void {
         obj.receiverId = -1;
         obj.reveal = -1;
+        obj.lastChange = -1;
 
         const coord: number = Position.packZoneCoord(obj.x, obj.z);
         this.objs.sortStack(coord);
@@ -309,6 +310,7 @@ export default class Zone {
 
     changeObj(obj: Obj, receiverId: number, oldCount: number, newCount: number): void {
         obj.count = newCount;
+        obj.lastChange = World.currentTick;
 
         const coord: number = Position.packZoneCoord(obj.x, obj.z);
         this.objs.sortStack(coord);

--- a/src/lostcity/entity/Obj.ts
+++ b/src/lostcity/entity/Obj.ts
@@ -2,6 +2,11 @@ import NonPathingEntity from '#lostcity/entity/NonPathingEntity.js';
 import EntityLifeCycle from '#lostcity/entity/EntityLifeCycle.js';
 
 export default class Obj extends NonPathingEntity {
+    /**
+     * The number of ticks for an obj to reveal.
+     */
+    static readonly REVEAL: number = 100;
+
     // constructor properties
     type: number;
     count: number;
@@ -9,6 +14,7 @@ export default class Obj extends NonPathingEntity {
     // runtime
     receiverId: number = -1;
     reveal: number = -1;
+    lastChange: number = -1;
 
     constructor(level: number, x: number, z: number, lifecycle: EntityLifeCycle, type: number, count: number) {
         super(level, x, z, 1, 1, lifecycle);


### PR DESCRIPTION
- Objs always reveal 100 ticks after first being added to the zone.
- `change obj` will increase the despawn timer until the obj is revealed.

==>
Reveal = 100 ticks
Obj Duration = 200 ticks
--
Obj dropped on floor.
Change obj after 50 ticks.
Obj reveals 50 ticks later (at tick 100)
Obj despawns 250 ticks later.
--
Obj dropped on floor.
Change obj after 25 ticks.
Obj reveals 75 ticks later (at tick 100)
Obj despawns 225 ticks later.
--