### PR TITLE
fix(content): player able to logout immediately after npc dies during combat

### DIFF
--- a/data/src/scripts/skill_combat/scripts/npc/npc_death.rs2
+++ b/data/src/scripts/skill_combat/scripts/npc/npc_death.rs2
@@ -10,7 +10,6 @@ if (finduid(%npc_aggressive_player) = true) {
 }
 if (npc_findhero = true){
     %aggressive_npc = null;
-    %lastcombat = null;
 }
 npc_anim(npc_param(death_anim), 0);
 npc_delay(2);

--- a/data/src/scripts/skill_combat/scripts/player/player_combat.rs2
+++ b/data/src/scripts/skill_combat/scripts/player/player_combat.rs2
@@ -102,7 +102,7 @@ if (map_multi(npc_coord) = true) {
 }
 // player has been attacked in the last 8 ticks, and not by the current npc
 // or player has been attacked in the last 8 ticks, and %aggressive_npc is null (for pvp)
-if (add(%lastcombat, 8) > map_clock & (%aggressive_npc ! npc_uid | %aggressive_npc = null)) {
+if (add(%lastcombat, 8) > map_clock & (%aggressive_npc ! npc_uid & %aggressive_npc ! null)) {
     mes("I'm already under attack.");
     return(false);
 }


### PR DESCRIPTION
- Npc death will still allow the player to instantly attack another npc, after the npc's death anim