### PR TITLE
fix(content): Removed magic bonuses from blue skirt

### DIFF
--- a/data/src/scripts/_unpack/all.obj
+++ b/data/src/scripts/_unpack/all.obj
@@ -504,8 +504,6 @@ manwear=model_265_obj_wear,0
 womanwear=model_428_idk,0
 weight=2lb
 tradeable=yes
-param=magicattack,2
-param=magicdefence,2
 
 [pink_skirt]
 cost=2


### PR DESCRIPTION
As far as I can tell the blue skirt has never offered any bonuses.
The best evidence I've found so far is a runehq link from 2005 which specifically mentions: "No stat effects; this is just to match the rest of your clothing."
 - https://web.archive.org/web/20051130235246/http://runehq.com/RHQItemView.php?id=1149

There are also no bonuses for the blue skirt in runescape classic, or even OSRS today. So I'm fairly confident that it's never had any.