### PR TITLE
fix(content): Sheep Herder quest fixes

### DIFF
--- a/data/src/scripts/quests/quest_sheepherder/scripts/npcs/councillor_halgrive.rs2
+++ b/data/src/scripts/quests/quest_sheepherder/scripts/npcs/councillor_halgrive.rs2
@@ -17,8 +17,8 @@ switch_int(%sheepherder_progress) {
 
 [label,halgrive_whats_wrong]
 ~chatplayer("<p,quiz>What's wrong?");
-~chatnpc("<p,confused>You may or may not be aware,|but a plague has spread across West Ardougne.|Now, so far, our efforts to contain it have|been largely successly, for the most part.");
-~chatnpc("<p,conufsed>However, four sheep recently escaped from| a farm near the city. When they were found,|We noticed that they were strangely discolored,|so we asked the mourners to examine them.");
+~chatnpc("<p,confused>You may or may not be aware,|but a plague has spread across West Ardougne.|Now, so far, our efforts to contain it have|been largely successfully, for the most part.");
+~chatnpc("<p,confused>However, four sheep recently escaped from| a farm near the city. When they were found,|we noticed that they were strangely discolored,|so we asked the mourners to examine them.");
 ~chatnpc("<p,sad>They believe that the sheep have|become infected with the plague.");
 ~chatnpc("<p,confused>As the councillor response for public health and safety here in East Ardougne, I am looking for someone to herd these sheep into a safe enclosure, kill them quickly and cleanly and then dispose of the remains hygienically in a special incinerator.");
 ~chatnpc("<p,neutral>Unfortunately nobody wants to risk catching the plague, and I am unable to find someone willing to undertake this mission for me.");

--- a/data/src/scripts/quests/quest_sheepherder/scripts/npcs/diseased_sheep.rs2
+++ b/data/src/scripts/quests/quest_sheepherder/scripts/npcs/diseased_sheep.rs2
@@ -22,13 +22,39 @@
 
 [label,prod_sheep](npc $npc)
 p_arrivedelay;
-if (~inzone_coord_pair_table(sheepherder_in_pen, npc_coord) = true) {
-    ~mesbox("The sheep is already in the enclosure.|You don't need to prod it.");
+
+if (%sheepherder_progress = ^sheepherder_not_started) {
+    mes("The sheep looks extremely ill and you haven't any reason to interfere with it.");
     return;
 }
 
-if (($npc = green_sheep & inv_total(inv, green_sheep_bones)> 0)) {
-    ~mesbox("You've already got bones from a sheep like this.|You don't need to fetch another one now.");
+if (%sheepherder_progress = ^sheepherder_complete) {
+    ~mesbox("There's no need for you to do that.|You've already completed the Sheep Herder quest.");
+    return;
+}
+
+if (%sheepherder_progress > ^sheepherder_not_started & %sheepherder_progress < ^sheepherder_complete) {
+    // not wearing a protective suit
+    if (inv_total(worn, plague_jacket) < 1 | inv_total(worn, plague_trousers)  < 1) {
+        ~chatplayer("<p,neutral>The sheep looks extremely unwell.|I don't want to touch it without a full protective suit.");
+        return;
+    }
+
+    // not having a prod but having a protective suit
+    def_obj $rhand = inv_getobj(worn, ^wearpos_rhand);
+    if ($rhand = null) {
+        ~chatplayer("<p,angry>I'm not prodding a sickly-looking sheep with my hands!");
+         ~chatplayer("<p,neutral>I'll need to wield an appropriate tool.");
+        return;
+    } else if ($rhand ! cattle_prod) {
+        ~chatplayer("<p,neutral>I don't want to attack the sheep.|I need to make it move!");
+         ~chatplayer("<p,neutral>I'll need to wield an appropriate tool.");
+        return;
+    }
+}
+
+if (~inzone_coord_pair_table(sheepherder_in_pen, npc_coord) = true) {
+    ~mesbox("The sheep is already in the enclosure.|You don't need to prod it.");
     return;
 }
 
@@ -36,6 +62,12 @@ db_find(sheep_table:sheep_type, $npc);
 def_dbrow $data = db_findnext;
 if ($data = null) {
     ~displaymessage(^dm_default);
+    return;
+}
+
+def_namedobj $npc_bones = db_getfield($data, sheep_table:sheep_bones, 0);
+if ((npc_category = diseased_sheep & inv_total(inv, $npc_bones) > 0)) {
+    ~mesbox("You've already got bones from a sheep like this.|You don't need to fetch another one now.");
     return;
 }
 

--- a/data/src/scripts/skill_combat/scripts/npc/npc_combat.rs2
+++ b/data/src/scripts/skill_combat/scripts/npc/npc_combat.rs2
@@ -188,23 +188,6 @@ if (npc_category = kolodion & enum(int, npc, mage_arena_bosses, %magearena_progr
     return(false);
 }
 
-if (npc_category = diseased_sheep) {
-    if (%sheepherder_progress = ^sheepherder_complete) {
-        ~mesbox("There's no need for you to do that.|You've already completed the Sheep Herder quest.");
-        return(false);
-    }
-
-    if (%sheepherder_progress > ^sheepherder_not_started & %sheepherder_progress < ^sheepherder_complete) {
-        ~chatplayer("<p,neutral>I don't want to attack the sheep.|I need to make it move!");
-        return(false);
-    }
-
-    if (%sheepherder_progress = ^sheepherder_not_started) {
-        ~mesbox("The sheep looks extremely ill and you|haven't any reason to interfere with it.");
-        return(false);
-    }
-}
-
 if (npc_hasop(2) = true) {
     return (true);
 }


### PR DESCRIPTION
1. Fixed typos in Councillor Halgrive's dialogue
2. Removed the combat checks for dialogue so now it uses the default messaging.
3. Relocated the combat checks to Diseased Sheep so prodding is prevented under the correct circumstances
4. Fixed checking if the inventory had bones from sheep you've already prodded.