### PR TITLE
feat: quest_chompybird part 4

### DIFF
--- a/data/src/scripts/general/configs/quest.constant
+++ b/data/src/scripts/general/configs/quest.constant
@@ -84,3 +84,4 @@
 ^mcannon_questpoints = 1
 ^cog_questpoints = 1
 ^grandtree_questpoints = 5
+^chompybird_questpoints = 2

--- a/data/src/scripts/quests/quest_chompybird/configs/quest_chompybird.constant
+++ b/data/src/scripts/quests/quest_chompybird/configs/quest_chompybird.constant
@@ -15,4 +15,14 @@
 
 // varbit locations - TBC exact
 ^chompybird_varbit_made_arrows = 0
+
+// 0 = potato, 1 = onion
 ^chompybird_varbit_rantz_flavour = 1
+
+// 0 = not set, 1 = equa leaves, 2 = cabbage
+^chompybird_varbit_bugs_flavour_start = 2
+^chompybird_varbit_bugs_flavour_end = 3
+
+// 0 = not set, 1 = tomato, 2 = doogle leaves
+^chompybird_varbit_fycie_flavour_start = 4
+^chompybird_varbit_fycie_flavour_end = 5

--- a/data/src/scripts/quests/quest_chompybird/configs/quest_chompybird.constant
+++ b/data/src/scripts/quests/quest_chompybird/configs/quest_chompybird.constant
@@ -15,3 +15,4 @@
 
 // varbit locations - TBC exact
 ^chompybird_varbit_made_arrows = 0
+^chompybird_varbit_rantz_flavour = 1

--- a/data/src/scripts/quests/quest_chompybird/scripts/bloated_toad.rs2
+++ b/data/src/scripts/quests/quest_chompybird/scripts/bloated_toad.rs2
@@ -71,55 +71,42 @@ if (p_finduid(uid) = true) {
     }
 }
 
-// the code below is a bit of a mess, its meant to handle the
-// "each toad only spawns 1 chompy" situation while still exploding them after 4 attempts
-// so there are a parallel set of queues
-
-// first attempt, has not spawned a chompy yet
+/**
+ * Handle a Bloated Toad rolling to spawn a Chompy Bird
+ *
+ * last_int is used for state tracking:
+ *  - how many times the toad has been rolled
+ *  - whether the toad has spawned a Chompy Bird
+ */
 [ai_queue4,bloated_toad]
-if (random(5) = 1) {
-    npc_queue(8, 0, 25);
-    ~spawn_chompy_bird(npc_coord);
+def_boolean $chompy_already_spawned = false;
+if (last_int >= 10) {
+    $chompy_already_spawned = true;
+}
+
+def_boolean $toad_should_explode = false;
+if (last_int = 3 | last_int = 13) {
+    $toad_should_explode = true;
+}
+
+def_int $next_state = calc(last_int + 1);
+
+def_boolean $should_spawn_chompy = false;
+if ($chompy_already_spawned = false & random(5) = 1) {
+    $should_spawn_chompy = true;
+
+    $next_state = calc($next_state + 10);
+}
+
+if ($toad_should_explode = true) {
+    ~toad_explode();
 } else {
-    npc_queue(5, 0, 25);
+    npc_queue(4, $next_state, 25);
 }
 
-// second attempt, has not spawned a chompy yet
-[ai_queue5,bloated_toad]
-if (random(5) = 1) {
-    npc_queue(9, 0, 25);
-    ~spawn_chompy_bird(npc_coord);
-} else {
-    npc_queue(6, 0, 25);
-}
-
-// third attempt, has not spawned a chompy yet
-[ai_queue6,bloated_toad]
-if (random(5) = 1) {
-    npc_queue(10, 0, 25);
-    ~spawn_chompy_bird(npc_coord);
-} else {
-    npc_queue(7, 0, 25);
-}
-
-// fourth attempt, has not spawned a chompy yet
-[ai_queue7,bloated_toad]
-~toad_explode();
-if (random(5) = 1) {
+if ($should_spawn_chompy = true) {
     ~spawn_chompy_bird(npc_coord);
 }
-
-// second attempt, HAS already spawned a chompy
-[ai_queue8,bloated_toad]
-npc_queue(9, 0, 25);
-
-// third attempt, HAS already spawned a chompy
-[ai_queue9,bloated_toad]
-npc_queue(10, 0, 25);
-
-// fourth attempt, HAS already spawned a chompy
-[ai_queue10,bloated_toad]
-~toad_explode();
 
 [proc,toad_explode]()
 // TODO in OSRS this isn't sent with a height

--- a/data/src/scripts/quests/quest_chompybird/scripts/bugs.rs2
+++ b/data/src/scripts/quests/quest_chompybird/scripts/bugs.rs2
@@ -1,5 +1,7 @@
 [opnpc1,chompybird_bugs]
 switch_int(%chompybird_progress) {
+    case ^chompybird_not_started:
+        ~chatnpc("<p,neutral>You's better talk to Dad, him chasey sneaky da chompy.");
     case ^chompybird_started:
         // TODO is this the right check? source: https://oldschool.runescape.wiki/w/Transcript:Big_Chompy_Bird_Hunting#Talking_to_Bugs_without_a_chisel_and_knife
         if (inv_total(inv, chisel) > 0 & inv_total(inv, knife) > 0) {

--- a/data/src/scripts/quests/quest_chompybird/scripts/bugs.rs2
+++ b/data/src/scripts/quests/quest_chompybird/scripts/bugs.rs2
@@ -47,6 +47,21 @@ switch_int(%chompybird_progress) {
     case ^chompybird_shown_toad:
         ~chatnpc("<p,neutral>You's better talk to Dad, he might have something for you to do.");
 
+    case ^chompybird_told_to_cook_chompy:
+        def_int $flavour = getbit_range(%chompybird_kills, ^chompybird_varbit_bugs_flavour_start, ^chompybird_varbit_bugs_flavour_end);
+
+        if ($flavour = 0) {
+            $flavour = calc(random(1) + 1);
+            setbit_range_toint(%chompybird_kills, $flavour, ^chompybird_varbit_bugs_flavour_start, ^chompybird_varbit_bugs_flavour_end);
+        }
+
+        def_string $chompy_flavour = "equa leaves";
+        if ($flavour = 2) {
+            $chompy_flavour = "cabbage";
+        }
+
+        ~chatnpc("<p,neutal>Dad say's you's making da chompy for us! Slurp! Me's|has to have <$chompy_flavour> wiv mine! Chompy is our|favourite yummms!");
+
     case default:
         // TODO TBC other states
         return;

--- a/data/src/scripts/quests/quest_chompybird/scripts/bugs.rs2
+++ b/data/src/scripts/quests/quest_chompybird/scripts/bugs.rs2
@@ -62,6 +62,10 @@ switch_int(%chompybird_progress) {
 
         ~chatnpc("<p,neutal>Dad say's you's making da chompy for us! Slurp! Me's|has to have <$chompy_flavour> wiv mine! Chompy is our|favourite yummms!");
 
+    case ^chompybird_chompy_cooked:
+        // TODO mesanim TBC
+        ~chatnpc("<p,neutral>Have you talked to Dad, he might have something for you to do.");
+
     case default:
         // TODO TBC other states
         return;

--- a/data/src/scripts/quests/quest_chompybird/scripts/chompy_bird.rs2
+++ b/data/src/scripts/quests/quest_chompybird/scripts/chompy_bird.rs2
@@ -32,3 +32,12 @@ if (.npc_find(npc_coord, bloated_toad, 1, 1) = true) {
         }
     }
 }
+
+[opnpc4,chompy_bird_corpse]
+mes("You start plucking the chompy bird.");
+anim(human_pickupfloor, 0);
+p_delay(1);
+obj_add(npc_coord, raw_chompy, 1, ^lootdrop_duration);
+obj_add(npc_coord, bones, 1, ^lootdrop_duration);
+inv_add(inv, feather, calc(random(20) + 10));
+npc_del;

--- a/data/src/scripts/quests/quest_chompybird/scripts/fycie.rs2
+++ b/data/src/scripts/quests/quest_chompybird/scripts/fycie.rs2
@@ -1,5 +1,7 @@
 [opnpc1,chompybird_fycie]
 switch_int(%chompybird_progress) {
+    case ^chompybird_not_started:
+        ~chatnpc("<p,neutral>You's better talk to Dad, We not talk to wierdly|'umans.");
     case ^chompybird_started:
         // TODO is this the right check? source: https://oldschool.runescape.wiki/w/Transcript:Big_Chompy_Bird_Hunting#Talking_to_Fycie_after_buying_her_feathers
         if (inv_total(inv, feather) >= 25) {

--- a/data/src/scripts/quests/quest_chompybird/scripts/fycie.rs2
+++ b/data/src/scripts/quests/quest_chompybird/scripts/fycie.rs2
@@ -44,6 +44,21 @@ switch_int(%chompybird_progress) {
 
     case ^chompybird_shown_toad:
         ~chatnpc("<p,neutral>You's better talk to Dad, him chasey sneaky chompy.");
+
+    case ^chompybird_told_to_cook_chompy:
+        def_int $flavour = getbit_range(%chompybird_kills, ^chompybird_varbit_fycie_flavour_start, ^chompybird_varbit_fycie_flavour_end);
+
+        if ($flavour = 0) {
+            $flavour = calc(random(1) + 1);
+            setbit_range_toint(%chompybird_kills, $flavour, ^chompybird_varbit_fycie_flavour_start, ^chompybird_varbit_fycie_flavour_end);
+        }
+
+        def_string $chompy_flavour = "tomato";
+        if ($flavour = 2) {
+            $chompy_flavour = "doogle leaves";
+        }
+
+        ~chatnpc("<p,neutal>Dad say's you's roastling da chompy for us! Slurp!|Me's wants <$chompy_flavour> wiv mine! Yummy, can't wait|to eats it.");
         
     case default:
         // TODO TBC other states

--- a/data/src/scripts/quests/quest_chompybird/scripts/fycie.rs2
+++ b/data/src/scripts/quests/quest_chompybird/scripts/fycie.rs2
@@ -60,6 +60,10 @@ switch_int(%chompybird_progress) {
 
         ~chatnpc("<p,neutal>Dad say's you's roastling da chompy for us! Slurp!|Me's wants <$chompy_flavour> wiv mine! Yummy, can't wait|to eats it.");
         
+    case ^chompybird_chompy_cooked:
+        // TODO mesanim TBC
+        ~chatnpc("<p,neutral>Go talk to Dad, him chasey sneaky chompy.");
+
     case default:
         // TODO TBC other states
         return;

--- a/data/src/scripts/quests/quest_chompybird/scripts/quest_chompybird.rs2
+++ b/data/src/scripts/quests/quest_chompybird/scripts/quest_chompybird.rs2
@@ -35,3 +35,13 @@ p_delay(1);
 mes("You collect some gas from the swamp.");
 inv_del(inv, ogre_bellows_0, 1);
 inv_add(inv, ogre_bellows_3, 1);
+
+
+[queue,quest_chompybird_complete]
+%chompybird_progress = ^chompybird_complete;
+stat_advance(fletching, 262);
+stat_advance(cooking, 1470);
+stat_advance(ranged, 735);
+// TODO is ogre bow given separately here?
+// TODO confirm completion dialog
+~send_quest_complete(questlist:chompybird, ogre_bow, 250, ^chompybird_questpoints, "You have completed Big Chompy Bird Hunting!");

--- a/data/src/scripts/quests/quest_chompybird/scripts/quest_chompybird.rs2
+++ b/data/src/scripts/quests/quest_chompybird/scripts/quest_chompybird.rs2
@@ -16,15 +16,22 @@ p_teleport(0_41_46_6_53);
 [label,use_bellows_on_swamp_bubbles]
 switch_obj(last_useitem) {
     case ogre_bellows_0:
-        // TODO TBC anim and sound
-        anim(human_firecooking, 0);
-        sound_synth(ogre_bellows_suck, 0, 0);
-        p_delay(1);
-
-        mes("You collect some gas from the swamp.");
-        inv_del(inv, ogre_bellows_0, 1);
-        inv_add(inv, ogre_bellows_3, 1);
+        ~ogre_bellows_suck(ogre_bellows_0);
+    case ogre_bellows_1:
+        ~ogre_bellows_suck(ogre_bellows_1);
+    case ogre_bellows_2:
+        ~ogre_bellows_suck(ogre_bellows_2);
     case default:
         // TODO can you fill bellows (2) and (1)?
         mes("Nothing interesting happens.");
 }
+
+[proc,ogre_bellows_suck](obj $bellows)
+// TODO TBC anim and sound
+anim(human_firecooking, 0);
+sound_synth(ogre_bellows_suck, 0, 0);
+p_delay(1);
+
+mes("You collect some gas from the swamp.");
+inv_del(inv, ogre_bellows_0, 1);
+inv_add(inv, ogre_bellows_3, 1);

--- a/data/src/scripts/quests/quest_chompybird/scripts/rantz.rs2
+++ b/data/src/scripts/quests/quest_chompybird/scripts/rantz.rs2
@@ -84,17 +84,72 @@ switch_int(%chompybird_progress) {
         ~chatnpc("<p,neutral>Hey You! Got da chompy yet?");
         ~chatplayer("<p,neutral>Not yet!");
         ~chatnpc("<p,angry>Well hurry up and get some, we is hungry!");
+    case ^chompybird_player_killed_chompy:
+        if (inv_total(inv, raw_chompy) = 0) {
+            mes("[debug] TODO currently unimplemented");
+        } else {
+            // TODO mesanim TBC
+            ~chatnpc("<p,default>Hey You! Got da chompy yet?");
+            ~chatplayer("<p,neutral>Yep, here's your chompy Bird!");
+            @rantz_show_chompy;
+        }
+    case ^chompybird_told_to_cook_chompy:
+        @rantz_tell_chompy_flavour;
 
     // TODO dialog to buy ogre bow back from Rantz
 }
 
+[label,rantz_show_chompy]
+~objbox(raw_chompy,"You show Rantz the freshly plucked chompy carcass.");
+
+~chatnpc("<p,angry>Dat's a great chompy, you musta got a lucky shot wiv|da stabbie chucker.");
+%chompybird_progress = ^chompybird_told_to_cook_chompy;
+if (random(1) = 0) {
+    setbit(%chompybird_kills, ^chompybird_varbit_rantz_flavour);
+} else {
+    clearbit(%chompybird_kills, ^chompybird_varbit_rantz_flavour);
+}
+
+@rantz_tell_chompy_flavour;
+
+[label,rantz_tell_chompy_flavour]
+~chatnpc("<p,angry>Okay's now you's needs to cook da chompy! Slurp!|You's can cook it's over der!|@blu@~ Rantz points to a nearby spit roast. ~");
+
+def_string $chompy_flavour = "Potato";
+if (testbit(%chompybird_kills, ^chompybird_varbit_rantz_flavour) = true) {
+    // full stop (sic) in OSRS
+    $chompy_flavour = "Onion.";
+}
+
+~chatnpc("<p,angry>But's we's particular about our chompy yumms. Me's|wants <$chompy_flavour> wiv mine! Fycie and Bugs want|something wiv der's as well, go and ask 'em wat dey|want.");
+~chatplayer("<p,angry>What! Now I've got the chompy bird, you expect me to|cook it as well?");
+~chatnpc("<p,angry>Yep, da spit's over der! Last time Rantz did yummies,|got very bad, did bad things to food... and belly.");
+~chatplayer("<p,angry>HUH!");
+
 [opnpcu,chompybird_rantz]
 switch_obj(last_useitem) {
     case raw_chompy:
-        // TODO mesanim TBC
-        ~chatnpc("<p,neutral>Erk! Da's a yukky chompy, I's wants a yummie chompy!");
-        
-        @return_to_rantz;
+        if (%chompybird_progress < ^chompybird_player_killed_chompy) {
+            // TODO mesanim TBC
+            ~chatnpc("<p,neutral>Erk! Da's a yukky chompy, I's wants a yummie chompy!");
+            @return_to_rantz;
+            return;
+        }
+
+        if (%chompybird_progress = ^chompybird_player_killed_chompy) {
+            @rantz_show_chompy;
+            return;
+        }
+
+        if (%chompybird_progress = ^chompybird_told_to_cook_chompy) {
+            
+            ~objbox(raw_chompy,"You show Rantz the freshly plucked chompy carcass.");
+            @rantz_tell_chompy_flavour;
+            return;
+        }
+
+        // TODO TBC
+        mes("Nothing interesting happens.");
 
     case ogre_arrow:
         if (%chompybird_progress = ^chompybird_not_started) {

--- a/data/src/scripts/quests/quest_chompybird/scripts/rantz.rs2
+++ b/data/src/scripts/quests/quest_chompybird/scripts/rantz.rs2
@@ -39,6 +39,53 @@ switch_int(%chompybird_progress) {
         }
     case ^chompybird_shown_toad:
         @where_to_put_toadies;
+    case ^chompybird_dropped_toad:
+        // TODO mesanim TBC
+        ~chatplayer("<p,neutral>There you go, I've placed the bait.");
+        ~chatnpc("<p,neutral>Goodz, me now waits for da chompy! It shouldn't be long now. Sneaky... sneaky...");
+        ~chatplayer("<p,neutral>Yes, I know... stick da chompy!");
+        ~chatnpc("<p,neutral>Hey, you's creature, is da fatsy toady still dere? Go get more fatsy toadies if dey all gone!");
+        ~chatplayer("<p,neutral>What? I have to get more bait if there's none there? Does this Chompy Bird even exist I wonder?");
+    case ^chompybird_chompy_ate_toad:
+        mes("[debug] currently unimplemented");
+    case ^chompybird_rantz_tried_to_shoot_chompy:
+        ~chatplayer("<p,neutral>Hey there, you keep missing the chompy bird.");
+        ~chatnpc("<p,angry>I knows, I keeps missing... because your stabbers are|worserer at flying than a dead dog.");
+
+        switch_int(~p_choice2("Oh, keep trying then... you might hit one through pure luck.", 1, "Come on, let me have a go...", 2)) {
+            case 1:
+                ~chatplayer("<p,angry>Oh, keep trying then... you might hit one through pure luck.");
+                ~chatnpc("<p,angry>Grrrr... You lookin' like a chompy!");
+            case 2:
+                ~chatplayer("<p,angry>Come on, let me have a go...");
+                ~chatnpc("<p,angry>No, is Rantz stabby thrower... you too weedy...");
+
+                switch_int(~p_choice2("I'm actually quite strong... please let me try.", 1, "Oh suit yourself, you'll just have to go hungry.", 2)) {
+                    case 1:
+                        ~chatplayer("<p,sad>I'm actually quite strong... please let me try.");
+                        ~chatnpc("<p,angry>Oh, ok...I lend you other stabby thrower... but creature|don't better cry when it hurts itself.");
+        
+                        if (inv_freespace(inv) = 0) {
+                            // TODO confirm dialog
+                            ~chatnpc("<p,angry>[dev message: player inventory full]");
+                            return;
+                        }
+
+                        inv_add(inv, ogre_bow, 1);
+                        %chompybird_progress = ^chompybird_rantz_gave_player_bow;
+                        ~objbox(ogre_bow,"Rantz hands over an ogre bow. It's huge! You can|barely drawn back the string!");
+                    case 2:
+                        ~chatplayer("<p,angry>Oh suit yourself, you'll just have to go hungry.");
+                        ~chatnpc("<p,angry>Or I eat you instead!");
+                }
+        }
+    case ^chompybird_rantz_gave_player_bow:
+        // TODO mesanim TBC
+        ~chatnpc("<p,neutral>Hey You! Got da chompy yet?");
+        ~chatplayer("<p,neutral>Not yet!");
+        ~chatnpc("<p,angry>Well hurry up and get some, we is hungry!");
+
+    // TODO dialog to buy ogre bow back from Rantz
 }
 
 [opnpcu,chompybird_rantz]
@@ -90,6 +137,10 @@ switch_obj(last_useitem) {
         }
 
         @show_toad;
+
+    case ogre_bow:
+        // TODO confirm mesanim
+        ~chatnpc("<p,neutral>Yeah, it's a goodly stabbie chucker, but you's is too weedy to use it like Rantz.");
 
     case default:
         // TODO TBC

--- a/data/src/scripts/quests/quest_chompybird/scripts/rantz.rs2
+++ b/data/src/scripts/quests/quest_chompybird/scripts/rantz.rs2
@@ -142,7 +142,6 @@ switch_obj(last_useitem) {
         }
 
         if (%chompybird_progress = ^chompybird_told_to_cook_chompy) {
-            
             ~objbox(raw_chompy,"You show Rantz the freshly plucked chompy carcass.");
             @rantz_tell_chompy_flavour;
             return;

--- a/data/src/scripts/quests/quest_chompybird/scripts/rantz.rs2
+++ b/data/src/scripts/quests/quest_chompybird/scripts/rantz.rs2
@@ -157,7 +157,7 @@ switch_obj(last_useitem) {
         mes("Nothing interesting happens.");
 
     case seasoned_chompy:
-        if (%chompybird_progress = chompybird_chompy_cooked)
+        if (%chompybird_progress = ^chompybird_chompy_cooked)
         {
             @hand_chompy_to_rantz;
             return;

--- a/data/src/scripts/quests/quest_chompybird/scripts/rantz.rs2
+++ b/data/src/scripts/quests/quest_chompybird/scripts/rantz.rs2
@@ -95,6 +95,12 @@ switch_int(%chompybird_progress) {
         }
     case ^chompybird_told_to_cook_chompy:
         @rantz_tell_chompy_flavour;
+    case ^chompybird_chompy_cooked:
+        // TODO what if the player no longer has the seasoned chompy? Does it still auto-hand in?
+        @hand_chompy_to_rantz;
+    case ^chompybird_complete:
+        // TODO message tbc
+        ~chatnpc("<p,default>Tank's very much for da chompy...|Fycie an Bugs like very much da chompy yumms!");
 
     // TODO dialog to buy ogre bow back from Rantz
 }
@@ -148,6 +154,16 @@ switch_obj(last_useitem) {
         }
 
         // TODO TBC
+        mes("Nothing interesting happens.");
+
+    case seasoned_chompy:
+        if (%chompybird_progress = chompybird_chompy_cooked)
+        {
+            @hand_chompy_to_rantz;
+            return;
+        }
+
+        // TODO tbc other states
         mes("Nothing interesting happens.");
 
     case ogre_arrow:
@@ -303,3 +319,15 @@ if (p_finduid(uid) = true) {
 %chompybird_progress = ^chompybird_shown_toad;
 
 @where_to_put_toadies;
+
+[label,hand_chompy_to_rantz]
+// TODO mesanim and line breaks TBC
+~chatnpc("<p,neutral>Hey creature, did you's get da cooked chompy yet?|I smelled something cooking and it mades me 'ungry.|Hand over da chompy if ya know what's good for ya.");
+~chatplayer("<p,neutral>Yes, here you go, here's your cooked chompy bird.");
+inv_del(inv, seasoned_chompy, 1);
+queue(quest_chompybird_complete, 0);
+~objbox(seasoned_chompy, "You hand over the cooked chompy bird to Rantz.");
+
+~chatnpc("<p,neutral>Hey hey! We got da delicious chompy bird - yay!|This looks really tasty as well!");
+~chatnpc("<p,neutral>Tank's very much for da chompy...|Fycie an Bugs like very much da chompy yumms!|@dbl@~ The family of ogres sit down together and enjoy your well cooked chompy bird. ~");
+~chatplayer("<p,neutral>It's my pleasure!");

--- a/data/src/scripts/quests/quest_chompybird/scripts/raw_chompy.rs2
+++ b/data/src/scripts/quests/quest_chompybird/scripts/raw_chompy.rs2
@@ -35,8 +35,16 @@ if (%chompybird_progress = ^chompybird_told_to_cook_chompy)
 
 if (%chompybird_progress = ^chompybird_chompy_cooked)
 {
-    // TODO auto hand in to Rantz
-    ~displaymessage(^dm_default);
+    // TODO what if the player no longer has the original chompy? Does it still auto-hand in?
+    if (npc_find(loc_coord, chompybird_rantz, 16, 0) = true)
+    {
+        @hand_chompy_to_rantz;
+    }
+    else
+    {
+        mes("eep cabbage , could not find Rantz - please tell a dev");
+    }
+
     return;
 }
 

--- a/data/src/scripts/quests/quest_chompybird/scripts/raw_chompy.rs2
+++ b/data/src/scripts/quests/quest_chompybird/scripts/raw_chompy.rs2
@@ -114,6 +114,8 @@ if ($has_rantz_ingredient = false | $has_bugs_ingredient = false | $has_fycie_in
 // TODO in OSRS this takes some time, and the spit is animated
 %chompybird_progress = ^chompybird_chompy_cooked;
 mes("You carefully place the chompy bird on the spit-roast.");
+inv_del(inv, raw_chompy, 1);
 mes("You add the other ingredients and cook the food.");
 mes("Eventually the chompy is cooked.");
+inv_add(inv, seasoned_chompy, 1);
 ~objbox(seasoned_chompy, "You use the <$rantz_ingredient_name>, <$bugs_ingredient_name> and the <$fycie_ingredient_name>|with the chompy bird to make a seasoned chompy.");

--- a/data/src/scripts/quests/quest_chompybird/scripts/raw_chompy.rs2
+++ b/data/src/scripts/quests/quest_chompybird/scripts/raw_chompy.rs2
@@ -1,0 +1,12 @@
+[opheldu,raw_chompy]
+switch_obj (last_useitem)
+{
+    case cabbage, tomato, potato, equa_leaves, doogle_leaves:
+        @quest_chompybird_add_ingredients_to_chompy_message;
+    case default : ~displaymessage(^dm_default);
+};
+
+
+[label,quest_chompybird_add_ingredients_to_chompy_message]
+// message taken from OSRS
+~mesbox("You can only add ingredients when you're cooking a chompy bird. Ensure you have the seasonings you want to use in your inventory when cooking the chompy bird and you will use them automatically when cooking.");

--- a/data/src/scripts/quests/quest_chompybird/scripts/raw_chompy.rs2
+++ b/data/src/scripts/quests/quest_chompybird/scripts/raw_chompy.rs2
@@ -10,3 +10,109 @@ switch_obj (last_useitem)
 [label,quest_chompybird_add_ingredients_to_chompy_message]
 // message taken from OSRS
 ~mesbox("You can only add ingredients when you're cooking a chompy bird. Ensure you have the seasonings you want to use in your inventory when cooking the chompy bird and you will use them automatically when cooking.");
+
+[oplocu,loc_3375]
+// TODO what else can be cooked here?
+if (last_useitem ! raw_chompy)
+{
+    ~displaymessage(^dm_default);
+    return;
+}
+
+// TODO allow cooking after quest
+if (%chompybird_progress ! ^chompybird_told_to_cook_chompy)
+{
+    // TODO this has a few different messages in different quest states on OSRS
+    ~displaymessage(^dm_default);
+    return;
+}
+
+def_int $bugs_ingredient = getbit_range(%chompybird_kills, ^chompybird_varbit_bugs_flavour_start, ^chompybird_varbit_bugs_flavour_end);
+def_int $fycie_ingredient = getbit_range(%chompybird_kills, ^chompybird_varbit_fycie_flavour_start, ^chompybird_varbit_fycie_flavour_end);
+
+if ($bugs_ingredient = 0 | $fycie_ingredient = 0)
+{
+    // TODO confirm behaviour
+    mes("You should ask Bugs and Fycie for their favourite ingredients first!");
+    return;
+}
+
+def_int $rantz_ingredient = getbit_range(%chompybird_kills, ^chompybird_varbit_rantz_flavour, ^chompybird_varbit_rantz_flavour);
+
+def_boolean $has_rantz_ingredient = false;
+
+def_string $rantz_ingredient_name;
+def_string $bugs_ingredient_name;
+def_string $fycie_ingredient_name;
+
+if ($rantz_ingredient = 0)
+{
+    if (inv_total(inv, potato) > 0)
+    {
+        $has_rantz_ingredient = true;
+    }
+
+    $rantz_ingredient_name = "potato";
+}
+else if ($rantz_ingredient = 1)
+{
+    if (inv_total(inv, onion) > 0)
+    {
+        $has_rantz_ingredient = true;
+    }
+    
+    $rantz_ingredient_name = "onion";
+}
+
+def_boolean $has_bugs_ingredient = false;
+
+if ($bugs_ingredient = 1)
+{
+    if (inv_total(inv, equa_leaves) > 0)
+    {
+        $has_bugs_ingredient = true;
+    }
+
+    $bugs_ingredient_name = "equa leaves";
+}
+else if ($bugs_ingredient = 2)
+{
+    if (inv_total(inv, cabbage) > 0)
+    {
+        $has_bugs_ingredient = true;
+    }
+
+    $bugs_ingredient_name = "cabbage";
+}
+
+def_boolean $has_fycie_ingredient = false;
+
+if ($fycie_ingredient = 1)
+{
+    if (inv_total(inv, tomato) > 0)
+    {
+        $has_fycie_ingredient = true;
+    }
+
+    $fycie_ingredient_name = "tomato";
+}
+else if ($fycie_ingredient = 2)
+{
+    if (inv_total(inv, doogle_leaves) > 0)
+    {
+        $has_fycie_ingredient = true;
+    }
+
+    $fycie_ingredient_name = "doogle leaves";
+}
+
+if ($has_rantz_ingredient = false | $has_bugs_ingredient = false | $has_fycie_ingredient = false) {
+    ~mesbox("You don't have all the ingredients yet to cook the chompy bird for the ogre family.|Remember what the Ogre family wanted? Rantz wanted <$rantz_ingredient_name>. Fycie wanted <$fycie_ingredient_name>. Bugs wanted <$bugs_ingredient_name>.");
+    return;
+}
+
+// TODO in OSRS this takes some time, and the spit is animated
+%chompybird_progress = ^chompybird_chompy_cooked;
+mes("You carefully place the chompy bird on the spit-roast.");
+mes("You add the other ingredients and cook the food.");
+~objbox(seasoned_chompy, "You use the <$rantz_ingredient_name>, <$bugs_ingredient_name> and the <$fycie_ingredient_name> with the chompy bird to make a seasoned chompy.");

--- a/data/src/scripts/quests/quest_chompybird/scripts/raw_chompy.rs2
+++ b/data/src/scripts/quests/quest_chompybird/scripts/raw_chompy.rs2
@@ -20,13 +20,30 @@ if (last_useitem ! raw_chompy)
 }
 
 // TODO allow cooking after quest
-if (%chompybird_progress ! ^chompybird_told_to_cook_chompy)
+if (%chompybird_progress < ^chompybird_told_to_cook_chompy)
 {
     // TODO this has a few different messages in different quest states on OSRS
     ~displaymessage(^dm_default);
     return;
 }
 
+if (%chompybird_progress = ^chompybird_told_to_cook_chompy)
+{
+    @cook_chompy_quest;
+    return;
+}
+
+if (%chompybird_progress = ^chompybird_chompy_cooked)
+{
+    // TODO auto hand in to Rantz
+    ~displaymessage(^dm_default);
+    return;
+}
+
+// TODO handle non-quest cooking
+~displaymessage(^dm_default);
+
+[label,cook_chompy_quest]
 def_int $bugs_ingredient = getbit_range(%chompybird_kills, ^chompybird_varbit_bugs_flavour_start, ^chompybird_varbit_bugs_flavour_end);
 def_int $fycie_ingredient = getbit_range(%chompybird_kills, ^chompybird_varbit_fycie_flavour_start, ^chompybird_varbit_fycie_flavour_end);
 

--- a/data/src/scripts/quests/quest_chompybird/scripts/raw_chompy.rs2
+++ b/data/src/scripts/quests/quest_chompybird/scripts/raw_chompy.rs2
@@ -115,4 +115,5 @@ if ($has_rantz_ingredient = false | $has_bugs_ingredient = false | $has_fycie_in
 %chompybird_progress = ^chompybird_chompy_cooked;
 mes("You carefully place the chompy bird on the spit-roast.");
 mes("You add the other ingredients and cook the food.");
-~objbox(seasoned_chompy, "You use the <$rantz_ingredient_name>, <$bugs_ingredient_name> and the <$fycie_ingredient_name> with the chompy bird to make a seasoned chompy.");
+mes("Eventually the chompy is cooked.");
+~objbox(seasoned_chompy, "You use the <$rantz_ingredient_name>, <$bugs_ingredient_name> and the <$fycie_ingredient_name>|with the chompy bird to make a seasoned chompy.");

--- a/data/src/scripts/quests/quest_fluffs/scripts/quest_fluffs.rs2
+++ b/data/src/scripts/quests/quest_fluffs/scripts/quest_fluffs.rs2
@@ -87,6 +87,11 @@ if(last_useitem = raw_sardine) {
     inv_add(inv, seasoned_sardine, 1);
     return;
 }
+
+if (last_useitem = raw_chompy) {
+    @quest_chompybird_add_ingredients_to_chompy_message;
+}
+
 ~displaymessage(^dm_default);
 
 [opheldu,raw_sardine]

--- a/data/src/scripts/skill_cooking/scripts/cooking_inv/scripts/gnome_cooking/cocktail_mixing.rs2
+++ b/data/src/scripts/skill_cooking/scripts/cooking_inv/scripts/gnome_cooking/cocktail_mixing.rs2
@@ -84,6 +84,7 @@ switch_obj(last_useitem) {
     case half_baked_gnomebowl : @add_bowl_ingredient(last_item);
     case half_baked_batta : @add_cocktail_ingredient(last_item);
     case half_baked_crunchies : @add_crunchies_ingredient(last_item);
+    case raw_chompy : @quest_chompybird_add_ingredients_to_chompy_message;
     case default : ~displaymessage(^dm_default);
 }
 

--- a/data/src/scripts/skill_cooking/scripts/cooking_inv/scripts/gnome_cooking/cocktail_mixing.rs2
+++ b/data/src/scripts/skill_cooking/scripts/cooking_inv/scripts/gnome_cooking/cocktail_mixing.rs2
@@ -84,7 +84,6 @@ switch_obj(last_useitem) {
     case half_baked_gnomebowl : @add_bowl_ingredient(last_item);
     case half_baked_batta : @add_cocktail_ingredient(last_item);
     case half_baked_crunchies : @add_crunchies_ingredient(last_item);
-    case raw_chompy : @quest_chompybird_add_ingredients_to_chompy_message;
     case default : ~displaymessage(^dm_default);
 }
 

--- a/data/src/scripts/skill_cooking/scripts/cooking_inv/scripts/gnome_cooking/gnome_battas.rs2
+++ b/data/src/scripts/skill_cooking/scripts/cooking_inv/scripts/gnome_cooking/gnome_battas.rs2
@@ -49,6 +49,7 @@ if_close;
 //p_stopaction;
 switch_obj(last_useitem) {
     case half_baked_batta : @add_batta_ingredient(last_item);
+    case raw_chompy : @quest_chompybird_add_ingredients_to_chompy_message;
     case default : ~displaymessage(^dm_default);
 }
 

--- a/data/src/scripts/skill_cooking/scripts/cooking_inv/scripts/gnome_cooking/gnome_battas.rs2
+++ b/data/src/scripts/skill_cooking/scripts/cooking_inv/scripts/gnome_cooking/gnome_battas.rs2
@@ -49,7 +49,6 @@ if_close;
 //p_stopaction;
 switch_obj(last_useitem) {
     case half_baked_batta : @add_batta_ingredient(last_item);
-    case raw_chompy : @quest_chompybird_add_ingredients_to_chompy_message;
     case default : ~displaymessage(^dm_default);
 }
 

--- a/data/src/scripts/skill_cooking/scripts/cooking_inv/scripts/pizza/pizza.rs2
+++ b/data/src/scripts/skill_cooking/scripts/cooking_inv/scripts/pizza/pizza.rs2
@@ -15,7 +15,6 @@ switch_obj (last_useitem) {
     case incomplete_pizza : mes("I think it's already got enough tomato on.");
     case half_baked_gnomebowl : @add_bowl_ingredient(last_item);
     case half_baked_batta : @add_batta_ingredient(last_item);
-    case raw_chompy : @quest_chompybird_add_ingredients_to_chompy_message;
     case default : ~displaymessage(^dm_default);
 };
 

--- a/data/src/scripts/skill_cooking/scripts/cooking_inv/scripts/pizza/pizza.rs2
+++ b/data/src/scripts/skill_cooking/scripts/cooking_inv/scripts/pizza/pizza.rs2
@@ -15,6 +15,7 @@ switch_obj (last_useitem) {
     case incomplete_pizza : mes("I think it's already got enough tomato on.");
     case half_baked_gnomebowl : @add_bowl_ingredient(last_item);
     case half_baked_batta : @add_batta_ingredient(last_item);
+    case raw_chompy : @quest_chompybird_add_ingredients_to_chompy_message;
     case default : ~displaymessage(^dm_default);
 };
 

--- a/data/src/scripts/skill_cooking/scripts/cooking_inv/scripts/stew/stew.rs2
+++ b/data/src/scripts/skill_cooking/scripts/cooking_inv/scripts/stew/stew.rs2
@@ -3,6 +3,7 @@ switch_obj (last_useitem) {
     case bowl_water : @make_incomplete_stew(last_slot);
     case incomplete_stew_meat : @make_uncooked_stew(last_slot, last_useslot);
     case bowl_empty : @no_water_stew_message;
+    case raw_chompy : @quest_chompybird_add_ingredients_to_chompy_message;
     case default : ~displaymessage(^dm_default);
 };
 

--- a/data/src/scripts/skill_cooking/scripts/cooking_inv/scripts/stew/stew.rs2
+++ b/data/src/scripts/skill_cooking/scripts/cooking_inv/scripts/stew/stew.rs2
@@ -3,7 +3,6 @@ switch_obj (last_useitem) {
     case bowl_water : @make_incomplete_stew(last_slot);
     case incomplete_stew_meat : @make_uncooked_stew(last_slot, last_useslot);
     case bowl_empty : @no_water_stew_message;
-    case raw_chompy : @quest_chompybird_add_ingredients_to_chompy_message;
     case default : ~displaymessage(^dm_default);
 };
 


### PR DESCRIPTION
- refactoring the toad (spawn chompy)/(explode) system
- plucking chompy, showing Rantz
- getting flavours from Rantz and kids
- filling half-full bellows
- cooking chompy on spit roast
- handing seasoned chompy to Rantz
- quest completion

**all that's left now** is to have Rantz shoot the chompy  , and add combat logic for player vs chompy