### PR TITLE
feat(engine): support `npc_sethuntmode(null)` to clear hunt mode

### DIFF
--- a/src/lostcity/engine/script/handlers/NpcOps.ts
+++ b/src/lostcity/engine/script/handlers/NpcOps.ts
@@ -198,7 +198,14 @@ const NpcOps: CommandHandlers = {
     }),
 
     [ScriptOpcode.NPC_SETHUNTMODE]: checkedHandler(ActiveNpc, state => {
-        state.activeNpc.huntMode = check(state.popInt(), HuntTypeValid).id;
+        // TODO is this authentic? or is there npc_clearhuntmode (or similar)?
+        const huntTypeId = state.popInt();
+
+        if (huntTypeId === -1) {
+            state.activeNpc.huntMode = -1;
+        } else {
+            state.activeNpc.huntMode = check(huntTypeId, HuntTypeValid).id;
+        }
     }),
 
     // https://x.com/JagexAsh/status/1795184135327089047


### PR DESCRIPTION
Not sure if this is authentic but it's required for chompybird and I don't see any other way to clear the hunt mode