### PR TITLE
fix(content): thieving chest teleporting, implement locked chests, remove trading after recently theiving

### DIFF
--- a/data/src/scripts/areas/area_ardougne_east/scripts/baker.rs2
+++ b/data/src/scripts/areas/area_ardougne_east/scripts/baker.rs2
@@ -11,3 +11,9 @@ if($option = 1) {
 } else if($option = 2) {
     ~chatplayer("<p,neutral>No thank you.");
 }
+
+[opnpc3,baker]
+if (map_clock < %last_stolen_from_stall_baker) {
+    @stall_owner_alert_guards;
+}
+~openshop_activenpc;

--- a/data/src/scripts/areas/area_ardougne_east/scripts/fur_trader.rs2
+++ b/data/src/scripts/areas/area_ardougne_east/scripts/fur_trader.rs2
@@ -11,3 +11,9 @@ if($option = 1) {
 } else if($option = 2) {
     ~chatplayer("<p,neutral>No thanks.");
 }
+
+[opnpc3,fur_trader]
+if (map_clock < %last_stolen_from_stall_fur) {
+    @stall_owner_alert_guards;
+}
+~openshop_activenpc;

--- a/data/src/scripts/areas/area_ardougne_east/scripts/gem_merchant.rs2
+++ b/data/src/scripts/areas/area_ardougne_east/scripts/gem_merchant.rs2
@@ -4,3 +4,9 @@ if (map_clock < %last_stolen_from_stall_gem) {
 }
 ~chatnpc("<p,neutral>Here, look at my lovely gems.");
 ~openshop_activenpc;
+
+[opnpc3,gem_merchant]
+if (map_clock < %last_stolen_from_stall_gem) {
+    @stall_owner_alert_guards;
+}
+~openshop_activenpc;

--- a/data/src/scripts/areas/area_ardougne_east/scripts/silk_merchant.rs2
+++ b/data/src/scripts/areas/area_ardougne_east/scripts/silk_merchant.rs2
@@ -2,7 +2,7 @@
 if (map_clock < %last_stolen_from_stall_silk) {
     @stall_owner_alert_guards;
 }
-if(inv_total(inv, silk) > 0) { //TODO - Add check for when player last stole from the Ardougne Silk Stall.
+if(inv_total(inv, silk) > 0) {
     ~chatplayer("<p,neutral>Hello. I have some fine silk from Al-Kharid to sell to you.");
     ~chatnpc("<p,quiz>Ah I may be interested in that. What sort of price were you looking at per piece of silk?");
     def_int $option = ~p_choice4("20 coins.", 1, "80 coins.", 2, "120 coins.", 3, "200 coins.", 4);

--- a/data/src/scripts/areas/area_ardougne_east/scripts/silver_merchant.rs2
+++ b/data/src/scripts/areas/area_ardougne_east/scripts/silver_merchant.rs2
@@ -12,3 +12,9 @@ if($option = 1) {
 } else if($option = 2) {
     ~chatplayer("<p,neutral>No thank you.");
 }
+
+[opnpc3,silver_merchant]
+if (map_clock < %last_stolen_from_stall_silver) {
+    @stall_owner_alert_guards;
+}
+~openshop_activenpc;

--- a/data/src/scripts/areas/area_ardougne_east/scripts/spice_seller.rs2
+++ b/data/src/scripts/areas/area_ardougne_east/scripts/spice_seller.rs2
@@ -11,3 +11,9 @@ if($option = 1) {
 } else if($option = 2) {
     ~chatplayer("<p,neutral>No thanks.");
 }
+
+[opnpc3,spice_seller]
+if (map_clock < %last_stolen_from_stall_spice) {
+    @stall_owner_alert_guards;
+}
+~openshop_activenpc;

--- a/data/src/scripts/areas/area_ardougne_west/scripts/mourner.rs2
+++ b/data/src/scripts/areas/area_ardougne_west/scripts/mourner.rs2
@@ -151,7 +151,7 @@ switch_int(%elena_progress) {
 ~chatplayer("<p,quiz>What brought the plague to Ardougne?");
 ~chatnpc("<p,neutral>It's all down to King Tyras of West Ardougne. It started came back from one of his visits to the lands west of here.");
 ~chatnpc("<p,neutral>Some of his men must have unknowingly caught it out there and brought it back with them.");
-~chatplayer("<p,quiz>Does he know how bad the sitation is now?");
+~chatplayer("<p,quiz>Does he know how bad the situation is now?");
 ~chatnpc("<p,angry>If he did he wouldn't care. I believe he wants his people to suffer, he's an evil man.");
 ~chatplayer("<p,shock>Isn't that treason?");
 ~chatnpc("<p,angry>He's not my king.");

--- a/data/src/scripts/areas/area_varrock/scripts/tea_seller.rs2
+++ b/data/src/scripts/areas/area_varrock/scripts/tea_seller.rs2
@@ -22,6 +22,9 @@ if ($choice = 2) {
 
 [opnpc3,tea_seller]
 ~require_members_store_owner;
+if (map_clock < %last_stolen_from_stall_tea) {
+    @stall_owner_alert_guards; //no guards nearby
+}
 ~openshop_activenpc;
 
 

--- a/data/src/scripts/quests/quest_fluffs/scripts/pet.rs2
+++ b/data/src/scripts/quests/quest_fluffs/scripts/pet.rs2
@@ -96,7 +96,7 @@ switch_obj(last_useitem) {
         npc_anim(cat_rollingover, 40); 
         npc_say("Purr!");
         p_delay(2);
-        ~chatplayer("<p,happy>That kitten loves to play with that ball of wool. I think it is its favourite.");
+        ~chatplayer("<p,happy>That kitten loves to play with that ball of wool.|I think it is its favourite."); //guessed linebreak
     case bucket_milk: //https://youtu.be/1vY_uGOq6qM&t=97s
         %cat_growth = setbit_range_toint(%cat_growth, 0, 0, 4);
         inv_del(inv, last_useitem, 1);

--- a/data/src/scripts/quests/quest_fluffs/scripts/quest_fluffs.rs2
+++ b/data/src/scripts/quests/quest_fluffs/scripts/quest_fluffs.rs2
@@ -175,13 +175,13 @@ if (%fluffs_progress = ^fluffs_paid_boy & last_useitem = bucket_milk) {
     npc_del;
     .npc_del;
     ~mesbox("Fluffs has run off home with her offspring.");
-} else if (oc_category(last_useitem) = category_57) { //TODO: test with all raw fish. tested sardine & salmon
+} else if (oc_category(last_useitem) = category_57 | oc_category(last_useitem) = category_58) { //TODO: test more. works with raw sardine & salmon, cooked trout
     def_string $fishname = lowercase(oc_name(last_useitem));
     anim(human_pickupfloor, 0);
     p_delay(0);
     npc_say("Hiss!");
     p_delay(3);
-    ~mesbox("The cat doesn't want <$fishname>.|It seems to be a very fussy cat!");
+    ~mesbox("The cat doesn't want that <$fishname>.|It seems to be a very fussy cat!");
 } else {
     ~displaymessage(^dm_default);
 }
@@ -216,15 +216,18 @@ mes("You find nothing.");
 p_delay(4);
 mes("You can hear kittens mewing close by...");
 
-[opheld5,fluffs_kitten] //TODO: All of this is guessed -- test this in OSRS.
+[opheld5,fluffs_kitten]
 inv_delslot(inv, last_slot);
-npc_add(coord, lost_kitten, ^max_32bit_int);
-mes("You drop Fluffs' kitten.");
+npc_add(coord, lost_kitten, 10);
 npc_setmode(none);
+p_delay(0);
+mes("You place the kitten on the floor.");
+p_delay(0);
+npc_say("Mew!");
+p_delay(0);
 npc_walk(%fluffs_crate);
-p_delay(5);
-mes("It runs back to the crate.");
-npc_del;
+p_delay(4);
+~mesbox("The kitten has run off!");
 
 [queue,fluffs_complete] //imgur.com/6ePHvef
 // Random quest complete jingle.

--- a/data/src/scripts/skill_thieving/configs/chests/trapped_chest.dbrow
+++ b/data/src/scripts/skill_thieving/configs/chests/trapped_chest.dbrow
@@ -40,6 +40,7 @@ data=experience,2500
 data=respawn_ticks,200
 data=loot,bloodrune,2,2,128
 data=loot,coins,500,500,128
+data=tele_coord,0_40_52_24_9
 
 [trapped_chest_chest_ardougne_castle]
 table=trapped_chest
@@ -51,3 +52,4 @@ data=loot,coins,1000,1000,128
 data=loot,raw_shark,1,1,128
 data=loot,adamantite_ore,1,1,128
 data=loot,uncut_sapphire,1,1,128
+data=tele_coord,0_42_51_8_17

--- a/data/src/scripts/skill_thieving/configs/chests/trapped_chest.dbtable
+++ b/data/src/scripts/skill_thieving/configs/chests/trapped_chest.dbtable
@@ -4,3 +4,4 @@ column=level,int
 column=experience,int
 column=respawn_ticks,int
 column=loot,namedobj,int,int,int
+column=tele_coord,coord

--- a/data/src/scripts/skill_thieving/scripts/chest/trapped_chest.rs2
+++ b/data/src/scripts/skill_thieving/scripts/chest/trapped_chest.rs2
@@ -8,7 +8,7 @@
 @activate_trapped_chest;
 
 [oploc1,chest_steel_arrowtips]
-@activate_trapped_chest;
+@activate_locked_chest;
 
 [oploc1,chest_blood_runes]
 @activate_trapped_chest;
@@ -25,14 +25,19 @@
 [oploc2,chest_50_coins]
 ~attempt_trapped_chest(loc_type, loc_coord, loc_angle, loc_shape);
 
-[oploc2,chest_steel_arrowtips] //TODO: implement real functionality
-~attempt_trapped_chest(loc_type, loc_coord, loc_angle, loc_shape);
+[oploc2,chest_steel_arrowtips]
+~attempt_locked_chest;
 
 [oploc2,chest_blood_runes]
 ~attempt_trapped_chest(loc_type, loc_coord, loc_angle, loc_shape);
 
 [oploc2,chest_ardougne_castle]
 ~attempt_trapped_chest(loc_type, loc_coord, loc_angle, loc_shape);
+
+[oplocu,chest_steel_arrowtips]
+if (last_useitem = lockpick) {
+    ~attempt_locked_chest;
+}
 
 [proc,attempt_trapped_chest](loc $loc, coord $loc_coord, int $loc_angle, locshape $loc_shape)
 p_arrivedelay;
@@ -59,3 +64,54 @@ if ($current_level < $thieving_level) {
 }
 
 ~disarm_trapped_chest($data, $loc, $loc_coord, $loc_angle, $loc_shape);
+
+[label,activate_locked_chest]
+mes("This chest is locked");
+sound_synth(locked, 0, 0);
+
+[proc,attempt_locked_chest]
+//TODO: is gas random event possible?
+db_find(trapped_chest:loc, loc_type);
+def_dbrow $data = db_findnext;
+def_int $thieving_level = db_getfield($data, trapped_chest:level, 0);
+def_int $experience = db_getfield($data, trapped_chest:experience, 0);
+def_int $respawn_ticks = db_getfield($data, trapped_chest:respawn_ticks, 0);
+def_int $current_level = stat(thieving);
+mes("You attempt to pick the lock.");
+
+if ($current_level < $thieving_level) {
+    ~mesbox("You are not a high enough level to pick this lock.");
+    return;
+}
+
+if (inv_total(inv, lockpick) < 1) {
+    mes("You need a lockpick for this lock.");
+    return;
+}
+
+mes("You manage to pick the lock.");
+sound_synth(locked, 0, 0);
+p_delay(1);
+mes("You open the chest.");
+sound_synth(chest_open, 0, 0);
+p_delay(1);
+mes("You find treasure inside!");
+anim(human_openchest, 0);
+stat_advance(thieving, $experience);
+~trapped_chest_check_for_reward($data);
+loc_change(loc_2574, 3); //opened chest
+p_delay(3);
+loc_change(loc_2572, $respawn_ticks); //looted chest
+
+[oploc1,loc_2572]
+mes("It looks like this chest has already been looted.");
+
+[oploc2,loc_2572]
+mes("It looks like this chest has already been looted.");
+
+[oplocu,loc_2572]
+if (last_useitem = lockpick) {
+    mes("It looks like this chest has already been looted.");
+} else {
+    ~displaymessage(^dm_default);
+}

--- a/data/src/scripts/skill_thieving/scripts/chest/trapped_chest.rs2
+++ b/data/src/scripts/skill_thieving/scripts/chest/trapped_chest.rs2
@@ -25,7 +25,7 @@
 [oploc2,chest_50_coins]
 ~attempt_trapped_chest(loc_type, loc_coord, loc_angle, loc_shape);
 
-[oploc2,chest_steel_arrowtips]
+[oploc2,chest_steel_arrowtips] //TODO: implement real functionality
 ~attempt_trapped_chest(loc_type, loc_coord, loc_angle, loc_shape);
 
 [oploc2,chest_blood_runes]

--- a/data/src/scripts/skill_thieving/scripts/thieving.rs2
+++ b/data/src/scripts/skill_thieving/scripts/thieving.rs2
@@ -122,6 +122,7 @@ loc_change(loc_2574, $respawn_ticks);
 if (db_getfieldcount($data, trapped_chest:tele_coord) > 0) {
     p_delay(3);
     mes("Suddenly a second magical trap triggers.");
+    sound_synth(chest_open, 0, 0);
     p_telejump(db_getfield($data, trapped_chest:tele_coord, 0));
 }
 

--- a/data/src/scripts/skill_thieving/scripts/thieving.rs2
+++ b/data/src/scripts/skill_thieving/scripts/thieving.rs2
@@ -88,10 +88,6 @@ loc_change(market_stall, $respawn_ticks);
 p_arrivedelay;
 ~require_members_feature;
 
-if (loc_type = chest_steel_arrowtips) { //hardcode
-    mes("This chest is locked"); //osrs
-    return;
-}
 mes("You have activated a trap on the chest.");
 anim(human_picklock_chest, 0);
 sound_synth(lever, 0, 0);

--- a/data/src/scripts/skill_thieving/scripts/thieving.rs2
+++ b/data/src/scripts/skill_thieving/scripts/thieving.rs2
@@ -88,6 +88,10 @@ loc_change(market_stall, $respawn_ticks);
 p_arrivedelay;
 ~require_members_feature;
 
+if (loc_type = chest_steel_arrowtips) { //hardcode
+    mes("This chest is locked"); //osrs
+    return;
+}
 mes("You have activated a trap on the chest.");
 anim(human_picklock_chest, 0);
 sound_synth(lever, 0, 0);
@@ -118,6 +122,12 @@ stat_advance(thieving, $experience);
 def_int $respawn_ticks = db_getfield($data, trapped_chest:respawn_ticks, 0);
 
 loc_change(loc_2574, $respawn_ticks);
+
+if (db_getfieldcount($data, trapped_chest:tele_coord) > 0) {
+    p_delay(3);
+    mes("Suddenly a second magical trap triggers.");
+    p_telejump(db_getfield($data, trapped_chest:tele_coord, 0));
+}
 
 [proc,pick_pocket_check_for_reward](dbrow $data)
 def_int $count = calc(db_getfieldcount($data, pickpocket:loot) - 1);


### PR DESCRIPTION
- Blood-Rune chest now teleports you to Elena's house
- Shark chest now teleports you to Pillars of Zanash
- Steel Arrowtips chest now works as intended
- Fixed Mourner typo
- Removed option to Trade with merchants you've recently thieved from
TODO on chests: correct damage formula