### PR TITLE
fix(engine): Safer checks when applying NPC timer

### DIFF
--- a/src/lostcity/entity/Npc.ts
+++ b/src/lostcity/entity/Npc.ts
@@ -99,9 +99,7 @@ export default class Npc extends PathingEntity {
             this.baseLevels[index] = level;
         }
 
-        if (npcType.timer !== -1) {
-            this.setTimer(npcType.timer);
-        }
+        this.setTimer(npcType.timer);
 
         this.vars = new Int32Array(VarNpcType.count);
         this.varsString = new Array(VarNpcType.count);
@@ -286,8 +284,10 @@ export default class Npc extends PathingEntity {
     }
 
     setTimer(interval: number) {
-        this.timerInterval = interval;
-        this.timerClock = 0;
+        if (interval !== -1) {
+            this.timerInterval = interval;
+            this.timerClock = 0;
+        }
     }
 
     executeScript(script: ScriptState) {


### PR DESCRIPTION
This fixes an issue with `npc_changetype` setting an invalid `ai_timer` on the new NPC.
Example of the issue:

https://github.com/user-attachments/assets/bc301a86-4db1-4b62-ba8c-26eb29ca87f9

