### PR TITLE
refactor(content): remove default mesanim

### DIFF
--- a/data/src/pack/seq.pack
+++ b/data/src/pack/seq.pack
@@ -589,7 +589,7 @@
 588=chat_neutral1
 589=chat_neutral2
 590=chat_neutral3
-591=chat_default
+591=chat_neutral4
 592=chat_shifty1
 593=chat_shifty2
 594=chat_shifty3

--- a/data/src/scripts/areas/area_ardougne_east/scripts/fur_trader.rs2
+++ b/data/src/scripts/areas/area_ardougne_east/scripts/fur_trader.rs2
@@ -2,7 +2,7 @@
 if (map_clock < %last_stolen_from_stall_fur) {
     @stall_owner_alert_guards;
 }
-~chatnpc("<p,default>Would you like to trade in fur?");
+~chatnpc("<p,happy>Would you like to trade in fur?");
 
 def_int $option = ~p_choice2("Yes please.", 1, "No thanks.", 2);
 

--- a/data/src/scripts/areas/area_ardougne_west/scripts/clerk.rs2
+++ b/data/src/scripts/areas/area_ardougne_west/scripts/clerk.rs2
@@ -37,7 +37,7 @@ switch_int(%elena_progress) {
 
 [label,clerk_surely_you_dont_let_them_run_everything_for_you]
 ~chatplayer("<p,quiz>Surely you don't let them run everything for you?");
-~chatnpc("<p,default>Well, they do know what they're doing here. If they did start doing something badly <nc_name(bravek)>, the city warder, would have the power to override. I can't see that happening though.");
+~chatnpc("<p,neutral>Well, they do know what they're doing here. If they did start doing something badly <nc_name(bravek)>, the city warder, would have the power to override. I can't see that happening though.");
 @multi2("I'll try asking them then.", clerk_ill_try_asking_them_then, "Can I speak to <nc_name(bravek)> anyway?", clerk_can_i_speak_to_bravek_anyway);
 
 [label,clerk_can_i_speak_to_bravek_anyway]

--- a/data/src/scripts/areas/area_ardougne_west/scripts/mourner.rs2
+++ b/data/src/scripts/areas/area_ardougne_west/scripts/mourner.rs2
@@ -96,7 +96,7 @@ if (~inzone_coord_pair_table(ardougne_west, coord) = true) {
 [label,mourner_so_whats_a_mourner]
 ~chatplayer("<p,quiz>So what's a mourner?");
 ~chatnpc("<p,neutral>We're working for King Lathas of East Ardougne. He has tasked us with containing the accursed plague sweeping West Ardougne.");
-~chatnpc("<p,default>We also do our best to ease these people's suffering. We're nicknamed mourners because we spend a lot of time at plague victim funerals, no one else is allowed to risk attending.");
+~chatnpc("<p,neutral>We also do our best to ease these people's suffering. We're nicknamed mourners because we spend a lot of time at plague victim funerals, no one else is allowed to risk attending.");
 ~chatnpc("<p,neutral>It's a demanding job, and we get little thanks from the people here.");
 
 [label,mourner_i_havent_got_the_plague_though]

--- a/data/src/scripts/areas/area_brimhaven/scripts/davon.rs2
+++ b/data/src/scripts/areas/area_brimhaven/scripts/davon.rs2
@@ -1,15 +1,15 @@
 [opnpc1,davon]
-~chatnpc("<p,default>Psst! Come here if you want to do some amulet trading.");
+~chatnpc("<p,neutral>Psst! Come here if you want to do some amulet trading.");
 def_int $option = ~p_choice3("What are you selling?", 1, "What do you mean pssst?", 2, "Why don't you ever restock some types of amulets?", 3);
 
 switch_int ($option) {
     case 1: ~openshop_activenpc;
 
     case 2:
-    ~chatplayer("<p,default>What do you mean pssst?");
-    ~chatnpc("<p,default>Errr, I was...I was clearing my throat.");
+    ~chatplayer("<p,neutral>What do you mean pssst?");
+    ~chatnpc("<p,neutral>Errr, I was...I was clearing my throat.");
 
     case 3:
-    ~chatplayer("<p,default>Why don't you ever restock some types of amulets?");
-    ~chatnpc("<p,default>Some of these amulets are very hard to get. I have to wait until an adventurer supplies me.");
+    ~chatplayer("<p,neutral>Why don't you ever restock some types of amulets?");
+    ~chatnpc("<p,neutral>Some of these amulets are very hard to get.|I have to wait until an adventurer supplies me.");
 }

--- a/data/src/scripts/areas/area_draynor/scripts/morgan.rs2
+++ b/data/src/scripts/areas/area_draynor/scripts/morgan.rs2
@@ -20,7 +20,7 @@ switch_int (~p_choice3("No, vampires are scary!", 1, "Ok, I'm up for an adventur
     case default: ~displaymessage(^dm_default);
 }
 
-~chatnpc("<p,default>I think first you should seek help. I have a friend who is a retired vampire hunter, his name is Dr. Harlow. He may be able to give you some tips. He can normally be found in the Jolly Boar Inn in Varrock, he's a bit of");
+~chatnpc("<p,neutral>I think first you should seek help. I have a friend who is a retired vampire hunter, his name is Dr. Harlow. He may be able to give you some tips. He can normally be found in the Jolly Boar Inn in Varrock, he's a bit of");
 ~chatnpc("<p,quiz>an old soak these days. Mention his old friend Morgan, I'm sure he wouldn't want me killed by a vampire.");
 ~quest_vampire_set_progress(^quest_vampire_started);
 ~chatplayer("<p,quiz>I'll look him up then.");

--- a/data/src/scripts/areas/area_gnome/scripts/aluft_gianne.rs2
+++ b/data/src/scripts/areas/area_gnome/scripts/aluft_gianne.rs2
@@ -9,7 +9,7 @@ switch_int(%gnome_restaurant_progress) {
     case 6 : @gnome_restaurant_complete;
     case default :
         if (%gnome_restaurant_progress = 7 | %gnome_restaurant_progress > 16) {
-            ~chatplayer("<p,default>Hello again Aluft.");
+            ~chatplayer("<p,neutral>Hello again Aluft.");
             ~chatnpc("<p,happy>Well hello there <displayname()>.");
             ~chatnpc("<p,neutral>Have you come to help me out?");
             @gnome_restaurant_job_start;
@@ -33,7 +33,7 @@ if ($category = category_128 | $category = category_125) {
         case 6 : @gnome_restaurant_complete;
         case default :
             if (%gnome_restaurant_progress = 7 | %gnome_restaurant_progress > 16) {
-                ~chatplayer("<p,default>Hello again Aluft.");
+                ~chatplayer("<p,neutral>Hello again Aluft.");
                 ~chatnpc("<p,happy>Well hello there <displayname()>.");
                 ~chatnpc("<p,neutral>Have you come to help me out?");
                 @gnome_restaurant_job_start;

--- a/data/src/scripts/areas/area_gnome/scripts/blurberry.rs2
+++ b/data/src/scripts/areas/area_gnome/scripts/blurberry.rs2
@@ -13,8 +13,8 @@ switch_int(%gnome_bar_progress) {
     case default :
         if (%gnome_bar_progress = 7 | %gnome_bar_progress > 12) {
             // rsc dialogue
-            ~chatplayer("<p,default>Hello again Blurberry!");
-            ~chatnpc("<p,default>Well hello traveller.");
+            ~chatplayer("<p,neutral>Hello again Blurberry!");
+            ~chatnpc("<p,neutral>Well hello traveller.");
             ~chatnpc("<p,neutral>I'm quite busy as usual, any chance you could help?");
             @gnome_bar_cocktail_job_start;
         }
@@ -30,7 +30,7 @@ if(testbit(%barcrawl_progress, ^blurberry_index) = false & last_useitem = barcra
 def_category $category = oc_category(last_useitem);
 if ($category = category_83 | $category = category_15) {
     switch_int(%gnome_bar_progress) {
-        case 0 : ~chatnpc("<p,default>Nice cocktail, but I don't need any right now...");
+        case 0 : ~chatnpc("<p,neutral>Nice cocktail, but I don't need any right now...");
         case 1 : @gnome_bar_assign_fruit_blast;
         case 2 : @gnome_bar_assign_drunk_dragon;
         case 3 : @gnome_bar_assign_ssg;
@@ -39,7 +39,7 @@ if ($category = category_83 | $category = category_15) {
         case 6 : @gnome_bar_complete;
         case default :
             if (%gnome_bar_progress = 7 | %gnome_bar_progress > 12) {
-                ~chatnpc("<p,default>Nice cocktail, but I don't need any right now...");
+                ~chatnpc("<p,neutral>Nice cocktail, but I don't need any right now...");
             }
             if (%gnome_bar_progress > 7 & %gnome_bar_progress < 13) {
                 @gnome_bar_cocktail_job_finish;

--- a/data/src/scripts/areas/area_gnome/scripts/gnome_bar.rs2
+++ b/data/src/scripts/areas/area_gnome/scripts/gnome_bar.rs2
@@ -1,12 +1,12 @@
 // *********************** TUTORIAL ************************
 [label,gnome_bar_start]
-~chatplayer("<p,default>Hello.");
+~chatplayer("<p,neutral>Hello.");
 ~chatnpc("<p,happy>Well hello there <displayname()>. If you're looking for a cocktail|the barman will happily make you one.");
-~chatplayer("<p,default>He looks pretty busy.");
+~chatplayer("<p,neutral>He looks pretty busy.");
 ~chatnpc("<p,happy>I know, I just can't find any skilled staff.|I don't suppose you're looking for some part time work?|The pay isn't great but its a good way to meet people.");
 def_int $choice = ~p_choice2("No thanks, I prefer to stay this side of the bar.", 1, "Ok then I'll give it a go.", 2);
 if ($choice = 1) {
-    ~chatplayer("<p,default>No thanks, I prefer to stay this side of the bar.");
+    ~chatplayer("<p,neutral>No thanks, I prefer to stay this side of the bar.");
     return;
 }
 ~chatplayer("<p,happy>Ok then I'll give it a go.");
@@ -15,10 +15,10 @@ inv_add(inv, cocktail_guide, 1);
 %gnome_bar_progress = 1;
 ~chatnpc("<p,happy>Here, take this cocktail guide. The book tells you how to|make all the cocktails we serve. I'll tell you what I need|and you can make them.");
 ~chatplayer("<p,happy>Sounds easy enough.");
-~chatnpc("<p,default>Take a look at the book then come and talk to me.");
+~chatnpc("<p,neutral>Take a look at the book then come and talk to me.");
 
 [label,gnome_bar_assign_fruit_blast]
-~chatplayer("<p,default>Hello Blurberry.");
+~chatplayer("<p,neutral>Hello Blurberry.");
 ~chatnpc("<p,happy>Hi, are you ready to make your first cocktail?");
 ~chatplayer("<p,happy>Absolutely.");
 ~chatnpc("<p,happy>Ok then, to start with make a Fruit Blast. Here, you'll|need these ingredients, but I'm afraid I can't give you|any more if you mess up.");
@@ -30,7 +30,7 @@ inv_add(inv, knife, 1);
 inv_add(inv, cocktail_shaker, 1);
 %gnome_bar_progress = 2;
 ~mesbox("Blurberry gives you two lemons, one orange, one pineapple, a cocktail shaker, a glass and a knife.");
-~chatnpc("<p,default>Let me know when you're done.");
+~chatnpc("<p,neutral>Let me know when you're done.");
 
 [label,gnome_bar_assign_drunk_dragon]
 ~chatnpc("<p,neutral>So where's my Fruit Blast?");
@@ -60,7 +60,7 @@ if (inv_total(inv, fruit_blast) < 1) {
 }
 
 [label,gnome_bar_assign_ssg]
-~chatplayer("<p,default>Hello Blurberry.");
+~chatplayer("<p,neutral>Hello Blurberry.");
 ~chatnpc("<p,quiz>Hello again <displayname()>, how did you do?");
 if (inv_total(inv, drunk_dragon) > 0) {
     ~chatplayer("<p,happy>Here you go.");
@@ -182,8 +182,8 @@ if (inv_total(inv, blurberry_special) < 1) {
 //         ~chatnpc("<p,happy>I can see how that would make it hard to mix cocktails.|I'll give you another one, but please try not lose any|more.");
 //         @exit;
 //     }
-//     ~chatplayer("<p,default>I've not finished yet.");
-//     ~chatnpc("<p,default>Ok, well let me know when you're done.");
+//     ~chatplayer("<p,neutral>I've not finished yet.");
+//     ~chatnpc("<p,neutral>Ok, well let me know when you're done.");
 //     @exit;
 // }
 if (inv_total(inv, $premade_cocktail) > 0) {
@@ -197,8 +197,8 @@ if (inv_total(inv, $premade_cocktail) > 0) {
 [label,gnome_bar_cocktail_job_start]
 def_int $choice = ~p_choice2("I'm quite busy myself, sorry.", 1, "Ok then, what do you need?", 2);
 if ($choice = 1) {
-    ~chatplayer("<p,default>I'm quite busy myself, sorry.");
-    ~chatnpc("<p,default>That's ok, come back when you're free.");
+    ~chatplayer("<p,neutral>I'm quite busy myself, sorry.");
+    ~chatnpc("<p,neutral>That's ok, come back when you're free.");
     return;
 }
 ~chatplayer("<p,happy>Ok then, what do you need?");
@@ -207,24 +207,24 @@ def_int $rand = randominc(5);
 %gnome_bar_progress = calc(7 + $rand);
 switch_int($rand) {
     case 1 : 
-        ~chatnpc("<p,default>Can you make me one Pineapple Punch, one Choc Saturday and one Drunk Dragon!");
-        ~chatplayer("<p,default>Ok then I'll be back soon.");
+        ~chatnpc("<p,neutral>Can you make me one Pineapple Punch, one Choc Saturday and one Drunk Dragon!");
+        ~chatplayer("<p,neutral>Ok then I'll be back soon.");
     case 2 :
-        ~chatnpc("<p,default>Ok, I need two Wizard Blizzards and an SGG!");
-        ~chatplayer("<p,default>No problem!");
+        ~chatnpc("<p,neutral>Ok, I need two Wizard Blizzards and an SGG!");
+        ~chatplayer("<p,neutral>No problem!");
     case 3 :
-        ~chatnpc("<p,default>Ok, I need one Wizard Blizzard, one Pineapple Punch, one Blurberry Special and two Fruit Blasts!");
-        ~chatplayer("<p,default>I'll do my best.");
+        ~chatnpc("<p,neutral>Ok, I need one Wizard Blizzard, one Pineapple Punch, one Blurberry Special and two Fruit Blasts!");
+        ~chatplayer("<p,neutral>I'll do my best.");
     case 4 :
-        ~chatnpc("<p,default>I just need two SGG's and one Blurberry Special!");
-        ~chatplayer("<p,default>No problem!");
+        ~chatnpc("<p,neutral>I just need two SGG's and one Blurberry Special!");
+        ~chatplayer("<p,neutral>No problem!");
     case default : 
-        ~chatnpc("<p,default>I just need one Fruit Blast!");
-        ~chatplayer("<p,default>No problem!");
+        ~chatnpc("<p,neutral>I just need one Fruit Blast!");
+        ~chatplayer("<p,neutral>No problem!");
 }
 
 [label,gnome_bar_cocktail_job_finish]
-~chatplayer("<p,default>Hi.");
+~chatplayer("<p,neutral>Hi.");
 ~chatnpc("<p,neutral>Have you made the order?");
 switch_int(%gnome_bar_progress) {
     case 8 : 
@@ -278,18 +278,18 @@ if (%gnome_bar_progress = 13) {
 // "Making gnome cocktails earns 60 xp, with no bonus from Blurberry"
 // no bonus xp for gnome bar
 if (inv_total(inv, $cocktail1) >= $count1 & inv_total(inv, $cocktail2) >= $count2 & inv_total(inv, $cocktail3) >= $count3 & inv_total(inv, $cocktail4) >= $count4) {
-    ~chatplayer("<p,default>Here you go, <$order>.");
+    ~chatplayer("<p,neutral>Here you go, <$order>.");
     inv_del(inv, $cocktail1, $count1);
     inv_del(inv, $cocktail2, $count2);
     inv_del(inv, $cocktail3, $count3);
     inv_del(inv, $cocktail4, $count4);
     %gnome_bar_progress = 13;
     ~mesbox("You give blurberry <$order>.");
-    ~chatnpc(append("<p,default>", $order_succeed));
+    ~chatnpc(append("<p,neutral>", $order_succeed));
     inv_add(inv, coins, $coins);
     ~mesbox("Blurberry gives you <tostring($coins)> gold coins.");
     return;
 }
 ~chatplayer("<p,sad>Not yet.");
-~chatnpc("<p,default>Ok, I need <$order>.");
-~chatnpc("<p,default>Let me know when you're done.");
+~chatnpc("<p,neutral>Ok, I need <$order>.");
+~chatnpc("<p,neutral>Let me know when you're done.");

--- a/data/src/scripts/areas/area_gnome/scripts/gnome_barman.rs2
+++ b/data/src/scripts/areas/area_gnome/scripts/gnome_barman.rs2
@@ -28,7 +28,7 @@ switch_int($choice) {
         return;
     case 3 :
         ~chatplayer("<p,neutral>Actually I'd like to sell some drinks.");
-        ~chatnpc("<p,default>If you want to sell any cocktails you've made yourself|I suggest you talk to Blurberry, he's the one who owns|the bar.");
+        ~chatnpc("<p,neutral>If you want to sell any cocktails you've made yourself|I suggest you talk to Blurberry, he's the one who owns|the bar.");
         ~chatplayer("<p,neutral>Thank you.");
         return;
     case 5 : @gnome_barman_barcrawl;

--- a/data/src/scripts/areas/area_gnome/scripts/gnome_restaurant.rs2
+++ b/data/src/scripts/areas/area_gnome/scripts/gnome_restaurant.rs2
@@ -1,17 +1,17 @@
 [label,gnome_restaurant_start]
-~chatplayer("<p,default>Hello.");
+~chatplayer("<p,neutral>Hello.");
 ~chatnpc("<p,happy>Well hello there. Are you hungry? If so you've come to|the right place. Eat green, eat gnome cuisine. My|waiter will be glad to take your order.");
-~chatplayer("<p,default>Thanks.");
+~chatplayer("<p,neutral>Thanks.");
 ~chatnpc("<p,quiz>On the other hand if you looking for some work, I have a cook's position available.");
 def_int $choice = ~p_choice2("No thanks, I'm no cook.", 1, "Ok, I'll give it a go.", 2);
 if ($choice = 1) {
-    ~chatplayer("<p,default>No thanks, I'm no cook.");
+    ~chatplayer("<p,neutral>No thanks, I'm no cook.");
     ~chatnpc("<p,quiz>In that case, please eat and enjoy.");
     return;
 }
 ~chatplayer("<p,quiz>Ok, I'll give it a go.");
 ~chatnpc("<p,happy>Well that's great. I'm Aluft Gianne, owner of this|restaurant, and you are...?");
-~chatplayer("<p,default>Most people call me <displayname()>.");
+~chatplayer("<p,neutral>Most people call me <displayname()>.");
 ~chatnpc("<p,happy>Really? Sorry, how rude of me. It just takes a little|while to get used to the funny names you humans|have.");
 ~chatnpc("<p,happy>Of course if you're going to work for me I'll have to|see what you're like first. Here, take a look at our|menu.");
 %gnome_restaurant_progress = 1;
@@ -22,7 +22,7 @@ inv_add(inv, gianne_cook_book, 1);
 
 
 [label,gnome_restaurant_assign_cheese_tom_batta]
-~chatplayer("<p,default>Hi Mr Gianne.");
+~chatplayer("<p,neutral>Hi Mr Gianne.");
 ~chatnpc("<p,happy>Hello <displayname()>. So what did you think of the book?");
 ~chatplayer("<p,confused>I'm not too sure about toad's legs.");
 ~chatnpc("<p,happy>They're a gnome delicacy, you'll love them. But we'll start with something simple, can you make me a cheese and tomato gnome batta? Here's what you need.");
@@ -33,18 +33,18 @@ inv_add(inv, gianne_dough, 1);
 inv_add(inv, batta_tin, 1);
 %gnome_restaurant_progress = 2;
 ~mesbox("Aluft gives you one tomato, some cheese, some equa leaves and some dough");
-~chatplayer("<p,default>Thanks!");
+~chatplayer("<p,neutral>Thanks!");
 ~chatnpc("<p,happy>Let me know how you get on.");
 
 
 [label,gnome_restaurant_assign_chocolate_bomb]
-~chatplayer("<p,default>Hi Mr Gianne.");
+~chatplayer("<p,neutral>Hi Mr Gianne.");
 ~chatnpc("<p,happy>Call me Aluft. So how did you get on?");
 if (inv_total(inv, cheese_tom_batta) > 0) {
-    ~chatplayer("<p,default>No problem, it was easy.");
+    ~chatplayer("<p,neutral>No problem, it was easy.");
     ~mesbox("You give Aluft the batta. He sniffs it then takes a bite...");
     ~chatnpc("<p,happy>Not bad, not bad at all.");
-    ~chatnpc("<p,default>Ok now for something a little harder. Try and make me a chocolate bomb. They're my favourite. Here's everything you need.");
+    ~chatnpc("<p,neutral>Ok now for something a little harder. Try and make me a chocolate bomb. They're my favourite. Here's everything you need.");
     inv_del(inv, cheese_tom_batta, 1);
     inv_add(inv, chocolate_bar, 4);
     inv_add(inv, equa_leaves, 1);
@@ -62,7 +62,7 @@ if (inv_total(inv, batta_tin) < 1) {
     if ($choice = 1) {
         ~chatplayer("<p,sad>I'm afraid I've lost the batta tin you gave to me.");
         inv_add(inv, batta_tin, 1);
-        ~chatnpc("<p,default>Ok, I'll give you another one. Obviously I can't expect|you to cook without the proper utensils.");
+        ~chatnpc("<p,neutral>Ok, I'll give you another one. Obviously I can't expect|you to cook without the proper utensils.");
         return;
     }
 } else {
@@ -70,17 +70,17 @@ if (inv_total(inv, batta_tin) < 1) {
 }
 if (inv_total(inv, cheese_tom_batta) < 1) {
     ~chatplayer("<p,confused>Erm, I've not quite finished it yet.");
-    ~chatnpc("<p,default>Ok, let me know when you have. I just need one cheese and tomato batta.");
+    ~chatnpc("<p,neutral>Ok, let me know when you have. I just need one cheese and tomato batta.");
 }
 
 [label,gnome_restaurant_assign_toad_batta]
-~chatplayer("<p,default>Hello Aluft.");
+~chatplayer("<p,neutral>Hello Aluft.");
 ~chatnpc("<p,quiz>Hello there, how did you get on?");
 if (inv_total(inv, chocolate_bomb) > 0) {
     ~chatplayer("<p,happy>Here you go.");
     ~mesbox("You give Aluft the chocolate bomb. He takes a bite...");
     ~chatnpc("<p,happy>Yes, yes, yes, that's superb. I'm really impressed.");
-    ~chatnpc("<p,default>Ok then, can you make me a toad batta?  Here's what|you need.");
+    ~chatnpc("<p,neutral>Ok then, can you make me a toad batta?  Here's what|you need.");
     inv_del(inv, chocolate_bomb, 1);
     inv_add(inv, cheese, 1);
     inv_add(inv, gianne_dough, 1);
@@ -99,30 +99,30 @@ if (inv_total(inv, gnomebowl_mould) < 1) {
     if ($choice = 1) {
         ~chatplayer("<p,sad>I'm afraid I've lost the gnomebowl mould you gave to me.");
         inv_add(inv, gnomebowl_mould, 1);
-        ~chatnpc("<p,default>Ok, I'll give you another one. Obviously I can't expect|you to cook without the proper utensils.");
+        ~chatnpc("<p,neutral>Ok, I'll give you another one. Obviously I can't expect|you to cook without the proper utensils.");
         return;
     }
 } else {
     ~gnome_restaurant_food_check(premade_chocolate_bomb, "gnomebowl");
 }
 if (inv_total(inv, chocolate_bomb) < 1) {
-    ~chatplayer("<p,default>I haven't made it yet.");
-    ~chatnpc("<p,default>Just follow the instructions carefully. I need one chocolate bomb.");
+    ~chatplayer("<p,neutral>I haven't made it yet.");
+    ~chatnpc("<p,neutral>Just follow the instructions carefully. I need one chocolate bomb.");
     return;
 }
 
 [label,gnome_restaurant_assign_worm_hole]
-~chatplayer("<p,default>Hi Mr Gianne.");
-~chatnpc("<p,default>Aluft.");
-~chatplayer("<p,default>Sorry, Aluft.");
+~chatplayer("<p,neutral>Hi Mr Gianne.");
+~chatnpc("<p,neutral>Aluft.");
+~chatplayer("<p,neutral>Sorry, Aluft.");
 ~chatnpc("<p,quiz>So where's my toad batta?");
 if (inv_total(inv, toad_batta) > 0) {
     ~chatplayer("<p,happy>Here you go, that was no problem.");
     ~mesbox("You give Aluft the toad batta. He takes a bite...");
     ~chatnpc("<p,happy>Ooh, that's some good toad. Very nice.");
-    ~chatnpc("<p,default>Let's see if you can make a worm hole.");
+    ~chatnpc("<p,neutral>Let's see if you can make a worm hole.");
     ~chatplayer("<p,confused>A worm hole?");
-    ~chatnpc("<p,default>Yes, it's in the cook book I gave you. You'll have to get the worms from the swamp. But here's everything else you'll need. Let me know when you're done.");
+    ~chatnpc("<p,neutral>Yes, it's in the cook book I gave you. You'll have to get the worms from the swamp. But here's everything else you'll need. Let me know when you're done.");
     inv_del(inv, toad_batta, 1);
     inv_add(inv, gianne_dough, 1);
     inv_add(inv, onion, 2);
@@ -136,27 +136,27 @@ if (inv_total(inv, batta_tin) < 1) {
     if ($choice = 1) {
         ~chatplayer("<p,sad>I'm afraid I've lost the batta tin you gave to me.");
         inv_add(inv, batta_tin, 1);
-        ~chatnpc("<p,default>Ok, I'll give you another one. Obviously I can't expect|you to cook without the proper utensils.");
+        ~chatnpc("<p,neutral>Ok, I'll give you another one. Obviously I can't expect|you to cook without the proper utensils.");
         return;
     }
 } else {
     ~gnome_restaurant_food_check(premade_toad_batta, "batta");
 }
 if (inv_total(inv, toad_batta) < 1) {
-    ~chatplayer("<p,default>I'm not done yet.");
-    ~chatnpc("<p,default>Ok, quick as you can though.");
+    ~chatplayer("<p,neutral>I'm not done yet.");
+    ~chatnpc("<p,neutral>Ok, quick as you can though.");
     ~chatplayer("<p,happy>No problem.");
     return;
 }
 
 [label,gnome_restaurant_assign_toad_crunchies]
-~chatplayer("<p,default>Hello again Aluft.");
+~chatplayer("<p,neutral>Hello again Aluft.");
 ~chatnpc("<p,quiz>Hello <displayname()>, how did you do?");
 if (inv_total(inv, worm_hole) > 0) {
     ~chatplayer("<p,happy>Here you go.");
     ~mesbox("You give Aluft the worm hole. He takes a bite...");
     ~chatnpc("<p,happy>Hmm, that's actually really good.");
-    ~chatnpc("<p,default>How about you make me some toad crunchies for desert? Then I'll decide whether I can take you on.");
+    ~chatnpc("<p,neutral>How about you make me some toad crunchies for desert? Then I'll decide whether I can take you on.");
     ~chatplayer("<p,confused>Toad crunchies?");
     ~chatnpc("<p,happy>Thats right, here's all you need except the toad's legs.");
     inv_del(inv, worm_hole, 1);
@@ -166,7 +166,7 @@ if (inv_total(inv, worm_hole) > 0) {
     inv_add(inv, crunchy_tray, 1);
     %gnome_restaurant_progress = 6;
     ~mesbox("Aluft gives you some dough, some equa leaves, and some gnome spice.");
-    ~chatnpc("<p,default>Let me know when you're done.");
+    ~chatnpc("<p,neutral>Let me know when you're done.");
     return;
 }
 if (inv_total(inv, gnomebowl_mould) < 1) {
@@ -174,7 +174,7 @@ if (inv_total(inv, gnomebowl_mould) < 1) {
     if ($choice = 1) {
         ~chatplayer("<p,sad>I'm afraid I've lost the gnomebowl mould you gave to me.");
         inv_add(inv, gnomebowl_mould, 1);
-        ~chatnpc("<p,default>Ok, I'll give you another one. Obviously I can't expect|you to cook without the proper utensils.");
+        ~chatnpc("<p,neutral>Ok, I'll give you another one. Obviously I can't expect|you to cook without the proper utensils.");
         return;
     }
 } else {
@@ -182,14 +182,14 @@ if (inv_total(inv, gnomebowl_mould) < 1) {
 }
 
 if (inv_total(inv, worm_hole) < 1) {
-    ~chatplayer("<p,default>I'm not done yet.");
-    ~chatnpc("<p,default>Ok, quick as you can though. I need one worm hole.");
+    ~chatplayer("<p,neutral>I'm not done yet.");
+    ~chatnpc("<p,neutral>Ok, quick as you can though. I need one worm hole.");
     ~chatplayer("<p,happy>No problem.");
     return;
 }
 
 [label,gnome_restaurant_complete]
-~chatplayer("<p,default>Hi Aluft.");
+~chatplayer("<p,neutral>Hi Aluft.");
 ~chatnpc("<p,quiz>Hello <displayname()>, how are you getting on?");
 if (inv_total(inv, toad_crunchies) > 0) {
     ~chatplayer("<p,happy>Here, see what you think.");
@@ -211,7 +211,7 @@ if (inv_total(inv, crunchy_tray) < 1) {
         // No typos here. choice uses 'crunchy', and chat uses 'crunchie'. This is from osrs
         ~chatplayer("<p,sad>I'm afraid I've lost the crunchie tray you gave to me.");
         inv_add(inv, crunchy_tray, 1);
-        ~chatnpc("<p,default>Ok, I'll give you another one. Obviously I can't expect|you to cook without the proper utensils.");
+        ~chatnpc("<p,neutral>Ok, I'll give you another one. Obviously I can't expect|you to cook without the proper utensils.");
         return;
     }
 } else {
@@ -219,14 +219,14 @@ if (inv_total(inv, crunchy_tray) < 1) {
 }
 
 if (inv_total(inv, toad_crunchies) < 1) {
-    ~chatplayer("<p,default>No luck so far.");
-    ~chatnpc("<p,default>Ok then but don't take too long. I need some toad crunchies.");
+    ~chatplayer("<p,neutral>No luck so far.");
+    ~chatnpc("<p,neutral>Ok then but don't take too long. I need some toad crunchies.");
     return;
 }
 
 [proc,gnome_restaurant_food_check](obj $food, string $food_name)
 if (inv_total(inv, $food) > 0) {
-    ~chatplayer("<p,default>I think I've got one.");
+    ~chatplayer("<p,neutral>I think I've got one.");
     ~chatnpc("<p,neutral>That looks identical to the <$food_name> I cooked not five|minutes ago. You'll have to prove to me that you can|make one yourself.");
     @exit;
 }
@@ -263,14 +263,14 @@ if ($container_total < 3) {
         if ($crunchy_tray_total < 1) inv_add(inv, crunchy_tray, 1);
         if ($batta_tin_total < 1) inv_add(inv, batta_tin, 1);
         if ($gnomebowl_mould_total < 1) inv_add(inv, gnomebowl_mould, 1);
-        ~chatnpc("<p,default>Ok, I'll give you some more. Obviously I can't expect|you to cook without the proper utensils.");
+        ~chatnpc("<p,neutral>Ok, I'll give you some more. Obviously I can't expect|you to cook without the proper utensils.");
         return;
     }
 } else {
     $choice = ~p_choice2("Sorry Alufy, I'm too busy.", 1, "I would be glad to help.", 2);
 }
 if ($choice = 1) {
-    ~chatplayer("<p,default>Sorry Alufy, I'm too busy.");
+    ~chatplayer("<p,neutral>Sorry Alufy, I'm too busy.");
     ~chatnpc("<p,happy>No worries, let me know when you're free.");
     return;
 }
@@ -280,38 +280,38 @@ def_int $rand = randominc(9);
 switch_int($rand) {
     case 1 : 
         ~chatnpc("<p,neutral>Can you make me two worm batta's, a toad batta, and a vegetable batta please?");
-        ~chatplayer("<p,default>Ok then.");
+        ~chatplayer("<p,neutral>Ok then.");
     case 2 :
         ~chatnpc("<p,neutral>Ok, I need a chocolate bomb, two portions of choc chip crunchies and two portions of toad crunchies.");
-        ~chatplayer("<p,default>No problem.");
+        ~chatplayer("<p,neutral>No problem.");
     case 3 :
         ~chatnpc("<p,neutral>I need two portions of choc chip crunchies please.");
-        ~chatplayer("<p,default>No problem.");
+        ~chatplayer("<p,neutral>No problem.");
     case 4 :
         ~chatnpc("<p,neutral>I just need a chocolate bomb and two portions of choc chip crunchies please.");
-        ~chatplayer("<p,default>No problem.");
+        ~chatplayer("<p,neutral>No problem.");
     case 5 :
         ~chatnpc("<p,quiz>Excellent, I need two vegetable batta's and a worm hole.");
-        ~chatplayer("<p,default>No problem.");
+        ~chatplayer("<p,neutral>No problem.");
     case 6 : 
         ~chatnpc("<p,neutral>can you make me a a veg ball, a tangled toad's legs, and a worm hole please?");
-        ~chatplayer("<p,default>Ok then.");
+        ~chatplayer("<p,neutral>Ok then.");
     case 7 :
         ~chatnpc("<p,neutral>I need a cheese and tomato batta, a veg ball, and two portions of worm crunchies please.");
-        ~chatplayer("<p,default>Ok, I'll do my best.");
+        ~chatplayer("<p,neutral>Ok, I'll do my best.");
     case 8 : 
         ~chatnpc("<p,neutral>Can you make a two portions of spicy crunchies, a fruit batta, a chocolate bomb, and a veg ball please chef.");
-        ~chatplayer("<p,default>I'll try.");
+        ~chatplayer("<p,neutral>I'll try.");
     case default :
         ~chatnpc("<p,neutral>I just need a tangled toad's legs and two portions of worm crunchies please.");
-        ~chatplayer("<p,default>Ok, I'll do my best.");
+        ~chatplayer("<p,neutral>Ok, I'll do my best.");
 }
 
 [label,gnome_restaurant_job_finish]
-~chatplayer("<p,default>Hi Aluft.");
+~chatplayer("<p,neutral>Hi Aluft.");
 switch_int(%gnome_restaurant_progress) {
     case 8 :
-        ~chatnpc("<p,default>Hello again, are the dishes ready?");
+        ~chatnpc("<p,neutral>Hello again, are the dishes ready?");
         ~gnome_restaurant_job_checks("All done, here you go.", "two worm batta's, a toad batta, and a vegetable batta", "I need ", ", be as quick as you can", 45,
         worm_batta, 2, 
         toad_batta, 1, 
@@ -319,7 +319,7 @@ switch_int(%gnome_restaurant_progress) {
         null, 0, 
         null, 0);
     case 9 :
-        ~chatnpc("<p,default>Hello again, are the dishes ready?");
+        ~chatnpc("<p,neutral>Hello again, are the dishes ready?");
         ~gnome_restaurant_job_checks("Here you go Aluft.", "a chocolate bomb, two portions of choc chip crunchies and two portions of toad crunchies", "Ok, I need ", ". Don't take too long, it's a full house tonight.", 75,
         chocolate_bomb, 1, 
         choc_chip_crunchies, 2, 
@@ -327,7 +327,7 @@ switch_int(%gnome_restaurant_progress) {
         null, 0, 
         null, 0);
     case 10 :
-        ~chatnpc("<p,default>Hello again <displayname()> how did you do?");
+        ~chatnpc("<p,neutral>Hello again <displayname()> how did you do?");
         ~gnome_restaurant_job_checks("Here you go Aluft.", "two portions of choc chip crunchies", "I just need ", ". Should be easy", 30,
         choc_chip_crunchies, 2, 
         null, 0, 
@@ -335,7 +335,7 @@ switch_int(%gnome_restaurant_progress) {
         null, 0, 
         null, 0);
     case 11 :
-        ~chatnpc("<p,default>Hello again <displayname()> how did you do?");
+        ~chatnpc("<p,neutral>Hello again <displayname()> how did you do?");
         ~gnome_restaurant_job_checks("Here you go Aluft.", "a chocolate bomb and two portions of choc chip crunchies", "I need ", " please", 45,
         chocolate_bomb, 1, 
         choc_chip_crunchies, 2, 
@@ -343,7 +343,7 @@ switch_int(%gnome_restaurant_progress) {
         null, 0, 
         null, 0);
     case 12 :
-        ~chatnpc("<p,default>Hello again <displayname()> how did you do?");
+        ~chatnpc("<p,neutral>Hello again <displayname()> how did you do?");
         ~gnome_restaurant_job_checks("Here you go Aluft.", "two vegetable batta's and a worm hole", "Ok, I need  ", ", but try not to take too long, it's a full house tonight", 45,
         vegetable_batta, 2, 
         worm_hole, 1, 
@@ -351,7 +351,7 @@ switch_int(%gnome_restaurant_progress) {
         null, 0, 
         null, 0);
     case 13 :
-        ~chatnpc("<p,default>Hello again, are the dishes ready?");
+        ~chatnpc("<p,neutral>Hello again, are the dishes ready?");
         ~gnome_restaurant_job_checks("All done, here you go.", "a veg ball, a tangled toad's legs, and a worm hole", "I need ", " please", 45,
         veg_ball, 1, 
         tangled_toads_legs, 1, 
@@ -359,7 +359,7 @@ switch_int(%gnome_restaurant_progress) {
         null, 0, 
         null, 0);
     case 14 :
-        ~chatnpc("<p,default>Hello again <displayname()> how did you do?");
+        ~chatnpc("<p,neutral>Hello again <displayname()> how did you do?");
         ~gnome_restaurant_job_checks("Here you go Aluft.", "a cheese and tomato batta, a veg ball, and two portions of worm crunchies", "I need ", " please", 60,
         cheese_tom_batta, 1, 
         veg_ball, 1, 
@@ -367,7 +367,7 @@ switch_int(%gnome_restaurant_progress) {
         null, 0, 
         null, 0);
     case 15 :
-        ~chatnpc("<p,default>Hello again, are the dishes ready?");
+        ~chatnpc("<p,neutral>Hello again, are the dishes ready?");
         ~gnome_restaurant_job_checks("Here you go Aluft.", "two portions of spicy crunchies, a fruit batta, a chocolate bomb, and a veg ball", "I need ", " please", 45,
         spicy_crunchies, 2, 
         fruit_batta, 1, 
@@ -375,7 +375,7 @@ switch_int(%gnome_restaurant_progress) {
         veg_ball, 1, 
         null, 0);
     case 16 :
-        ~chatnpc("<p,default>Hello again, are the dishes ready?");
+        ~chatnpc("<p,neutral>Hello again, are the dishes ready?");
         ~gnome_restaurant_job_checks("Here you go Aluft.", "a tangled toad's legs and two portions of worm crunchies", "I just need ", " please", 45,
         tangled_toads_legs, 1, 
         worm_crunchies, 2, 
@@ -384,13 +384,13 @@ switch_int(%gnome_restaurant_progress) {
         null, 0);
 }
 if (%gnome_restaurant_progress = 17) {
-    ~chatnpc("<p,default>Can you stay and make another dish?");
+    ~chatnpc("<p,neutral>Can you stay and make another dish?");
     @gnome_restaurant_job_start;
 }
 
 [proc,gnome_restaurant_job_checks](string $finish, string $order, string $order_fail_start, string $order_fail_end, int $coins, namedobj $dish1, int $count1, namedobj $dish2, int $count2, namedobj $dish3, int $count3, namedobj $dish4, int $count4, namedobj $dish5, int $count5)
 if (inv_total(inv, $dish1) >= $count1 & inv_total(inv, $dish2) >= $count2 & inv_total(inv, $dish3) >= $count3 & inv_total(inv, $dish4) >= $count4 & inv_total(inv, $dish5) >= $count5) {
-    ~chatplayer(append("<p,default>", $finish));
+    ~chatplayer(append("<p,neutral>", $finish));
     inv_del(inv, $dish1, $count1);
     inv_del(inv, $dish2, $count2);
     inv_del(inv, $dish3, $count3);
@@ -401,7 +401,7 @@ if (inv_total(inv, $dish1) >= $count1 & inv_total(inv, $dish2) >= $count2 & inv_
     stat_advance(cooking, calc(($count1 + $count2 + $count3 + $count4 + $count5) * 600));
     %gnome_restaurant_progress = 17;
     ~mesbox("You give Aluft <$order>.");
-    ~chatnpc("<p,default>They look great, well done. Here's your share of the profit.");
+    ~chatnpc("<p,neutral>They look great, well done. Here's your share of the profit.");
     inv_add(inv, coins, $coins);
     ~mesbox("Aluft gives you <tostring($coins)> gold coins.");
     return;
@@ -435,10 +435,10 @@ if ($container_total < 3) {
         if ($crunchy_tray_total < 1) inv_add(inv, crunchy_tray, 1);
         if ($batta_tin_total < 1) inv_add(inv, batta_tin, 1);
         if ($gnomebowl_mould_total < 1) inv_add(inv, gnomebowl_mould, 1);
-        ~chatnpc("<p,default>Ok, I'll give you some more. Obviously I can't expect|you to cook without the proper utensils.");
+        ~chatnpc("<p,neutral>Ok, I'll give you some more. Obviously I can't expect|you to cook without the proper utensils.");
         return;
     }
 }
 
 ~chatplayer("<p,sad>I'm not done yet.");
-~chatnpc("<p,default><$order_fail_start><$order><$order_fail_end>.");
+~chatnpc("<p,neutral><$order_fail_start><$order><$order_fail_end>.");

--- a/data/src/scripts/areas/area_gnome/scripts/gnomes.rs2
+++ b/data/src/scripts/areas/area_gnome/scripts/gnomes.rs2
@@ -85,31 +85,31 @@ switch_int ($rand) {
         ~chatplayer("<p,neutral>Hey I know that. Where's it from?");
         ~chatnpc("<p,neutral>Existentialism for insects.");
     case 3 :
-        ~chatnpc("<p,neutral>My mum says: A friendly look, a kindly smile one good act, and life's worthwhile!");
-        ~chatplayer("<p,neutral>Sweet.");
+        ~chatnpc("<p,happy>My mum says: A friendly look, a kindly smile one good act, and life's worthwhile!");
+        ~chatplayer("<p,happy>Sweet.");
     case 4 :
         ~chatnpc("<p,neutral>I wrote a few children's books.");
-        ~chatplayer("<p,neutral>Really.");
+        ~chatplayer("<p,bored>Really.");
         ~chatnpc("<p,neutral>Yep... but not on purpose!");
     case 5 :
         ~chatnpc("<p,neutral>The human mind is a tremendous thing.");
     case 6 :
-        ~chatnpc("<p,neutral>Bla bla bla!");
+        ~chatnpc("<p,angry>Bla bla bla!");
         ~chatplayer("<p,neutral>What?");
-        ~chatnpc("<p,neutral>Bla bla bla!");
+        ~chatnpc("<p,angry>Bla bla bla!");
         ~mesbox("Rude little gnome!");
     case 7 :
         ~chatnpc("<p,neutral>Real generosity is doing something nice for someone who will never find it out.");
-        ~chatplayer("<p,neutral>Thanks for the quote.");
+        ~chatplayer("<p,happy>Thanks for the quote.");
     case 8 :
-        ~chatnpc("<p,neutral>Hardy, ha ha! Hee, hee hee!");
-        ~chatplayer("<p,neutral>Are you OK?");
-        ~chatnpc("<p,neutral>I'm a little tree gnome. That is me!");
-        ~chatplayer("<p,neutral>I've heard better.");
+        ~chatnpc("<p,laugh>Hardy, ha ha! Hee, hee hee!");
+        ~chatplayer("<p,confused>Are you OK?");
+        ~chatnpc("<p,happy>I'm a little tree gnome. That is me!");
+        ~chatplayer("<p,bored>I've heard better.");
     case 9 :
         ~chatnpc("<p,neutral>I have a riddle for you.");
         ~chatplayer("<p,neutral>OK.");
-        ~chatnpc("<p,default>I am the beginning of eternity and the end of time and|space. I am the beginning of every end and the end of|every place. What am I?");
+        ~chatnpc("<p,neutral>I am the beginning of eternity and the end of time and|space. I am the beginning of every end and the end of|every place. What am I?");
         ~chatplayer("<p,confused>Err...?");
         ~chatplayer("<p,angry>Erm...not sure...annoying.");
         ~chatnpc("<p,laugh>I'm 'e'! Hee hee! Do you get it?");

--- a/data/src/scripts/areas/area_gnome/scripts/rometti.rs2
+++ b/data/src/scripts/areas/area_gnome/scripts/rometti.rs2
@@ -1,6 +1,6 @@
 [opnpc1,npc_601]
 ~chatplayer("<p,neutral>Hello.");
-~chatnpc("<p,default>Hello traveller. Have a look at my latest range of|gnome fashion. Rometti is the ultimate label in gnome|high society.");
+~chatnpc("<p,neutral>Hello traveller. Have a look at my latest range of|gnome fashion. Rometti is the ultimate label in gnome|high society.");
 ~chatplayer("<p,bored>Really.");
 ~chatnpc("<p,neutral>Pastels are all the rage this season.");
 def_int $choice = ~p_choice2("I've no time for fashion.", 1, "OK then, let's have a look.", 2);

--- a/data/src/scripts/areas/area_karamja/scripts/jiminua.rs2
+++ b/data/src/scripts/areas/area_karamja/scripts/jiminua.rs2
@@ -1,13 +1,13 @@
 [opnpc1,jiminua]
-~chatnpc("<p,default>Welcome to the Jungle Store.|Can I help you at all?");
+~chatnpc("<p,happy>Welcome to the Jungle Store.|Can I help you at all?");
 
 def_int $option = ~p_choice2("Yes please. What are you selling?", 1, "No thanks.", 2);
 
 switch_int ($option) {
     case 1:
-    ~chatplayer("<p,default>Yes please. What are you selling?");
+    ~chatplayer("<p,happy>Yes please. What are you selling?");
     ~openshop_activenpc;
 
     case 2:
-    ~chatplayer("<p,default>No thanks.");
+    ~chatplayer("<p,neutral>No thanks.");
 }

--- a/data/src/scripts/areas/area_port_sarim/scripts/wydin.rs2
+++ b/data/src/scripts/areas/area_port_sarim/scripts/wydin.rs2
@@ -62,5 +62,5 @@ p_opnpc(3);
 p_opnpc(3);
 
 [label,wydin_recommend_no]
-~chatplayer("<p,default>I don't like the sound of that.");
+~chatplayer("I don't like the sound of that."); // no anim
 ~chatnpc("<p,neutral>Well, it's your choice, but I do recommend them.");

--- a/data/src/scripts/areas/area_shilo/scripts/fernahei.rs2
+++ b/data/src/scripts/areas/area_shilo/scripts/fernahei.rs2
@@ -1,5 +1,5 @@
 [opnpc1,fernahei]
-~chatnpc("<p,default>Welcome to Fernahei's Fishing Shop Bwana!|Would you like to see my items?");
+~chatnpc("<p,neutral>Welcome to Fernahei's Fishing Shop Bwana!|Would you like to see my items?");
 def_int $option = ~p_choice2("Yes please!", 1, "No, but thanks for the offer.", 2);
 
 switch_int ($option) {
@@ -7,6 +7,6 @@ switch_int ($option) {
     ~chatplayer("<p,happy>Yes please!");
     ~openshop_activenpc;
     case 2:
-    ~chatplayer("<p,default>No, but thanks for the offer.");
-    ~chatnpc("<p,default>That's fine and thanks for your interest.");
+    ~chatplayer("<p,neutral>No, but thanks for the offer.");
+    ~chatnpc("<p,neutral>That's fine and thanks for your interest.");
 }

--- a/data/src/scripts/areas/area_shilo/scripts/obli.rs2
+++ b/data/src/scripts/areas/area_shilo/scripts/obli.rs2
@@ -1,5 +1,5 @@
 [opnpc1,obli]
-~chatnpc("<p,default>Welcome to Obli's General Store Bwana!|Would you like to see my items?");
+~chatnpc("<p,neutral>Welcome to Obli's General Store Bwana!|Would you like to see my items?");
 def_int $option = ~p_choice2("Yes please!", 1, "No, but thanks for the offer.", 2);
 
 switch_int ($option) {
@@ -7,5 +7,5 @@ switch_int ($option) {
     ~chatplayer("<p,happy>Yes please!");
     ~openshop_activenpc;
     case 2:
-    ~chatplayer("<p,default>No, but thanks for the offer.");
+    ~chatplayer("<p,neutral>No, but thanks for the offer.");
 }

--- a/data/src/scripts/areas/area_varrock/scripts/father_lawrence.rs2
+++ b/data/src/scripts/areas/area_varrock/scripts/father_lawrence.rs2
@@ -8,9 +8,9 @@ switch_int (%romeojuliet_progress) {
     case ^romeojuliet_spoken_apothecary:
         ~chatnpc("<p,quiz>Did you find the Apothecary?");
         if(inv_total(inv, cadaver) > 0) {
-            ~chatplayer("<p,default>I've got the Cadaver potion.");
-            ~chatnpc("<p,default>Good! Good work! Ok, take it to Juliet, she's expecting you.");
-            ~chatnpc("<p,default>I'll talk to Romeo and make sure he knows what to do.");
+            ~chatplayer("<p,happy>I've got the Cadaver potion.");
+            ~chatnpc("<p,happy>Good! Good work! Ok, take it to Juliet, she's expecting you.");
+            ~chatnpc("<p,happy>I'll talk to Romeo and make sure he knows what to do.");
         } else if(inv_total(inv, cadaver_berries) > 0) {
             ~chatplayer("<p,happy>I am on my way back to him with the ingredients.");
             ~chatnpc("<p,happy>Good work. Get the potion to Juliet when you have it.");
@@ -18,7 +18,7 @@ switch_int (%romeojuliet_progress) {
         } else {
             ~chatplayer("<p,neutral>Yes, I must find some berries.");
             ~chatnpc("<p,neutral>Well, take care. They are poisonous to the touch.");
-            ~chatnpc("<p,default>You will need gloves.");
+            ~chatnpc("<p,neutral>You will need gloves.");
         }
     case default:
         ~chatnpc("<p,happy>Oh to be a father in the times of whiskey.");

--- a/data/src/scripts/areas/area_varrock/scripts/gertrude.rs2
+++ b/data/src/scripts/areas/area_varrock/scripts/gertrude.rs2
@@ -108,8 +108,8 @@ def_int $option = ~p_choice3("Well, I suppose I could.", 1, "What's in it for me
 if($option = 1) {
     ~chatplayer("<p,neutral>Well, I suppose I could.");
     ~chatnpc("<p,happy>Really? Thank you so much!|I really have no idea where she could be!");
-    ~chatnpc("<p,default>I think my sons, Shilop and Wilough, saw the cat last.|They'll be out in the market place.");
-    ~chatplayer("<p,default>Alright then, I'll see what I can do.");
+    ~chatnpc("<p,neutral>I think my sons, Shilop and Wilough, saw the cat last.|They'll be out in the market place.");
+    ~chatplayer("<p,happy>Alright then, I'll see what I can do.");
     %fluffs_progress = ^fluffs_started;
     ~send_quest_progress(questlist:fluffs, %fluffs_progress, ^fluffs_complete);
 } else if($option = 2) {

--- a/data/src/scripts/areas/area_varrock/scripts/gypsy.rs2
+++ b/data/src/scripts/areas/area_varrock/scripts/gypsy.rs2
@@ -115,7 +115,7 @@ if ($option = 1) {
     }
 } else if ($option = 2) {
     ~chatplayer("<p,neutral>How do you know how old I think you are?");
-    ~chatnpc("<p,default>I have the power to know. Just as I have the power to foresee the future.");
+    ~chatnpc("<p,neutral>I have the power to know. Just as I have the power to foresee the future.");
     $option = ~p_choice3("Ok, what am I thinking now?", 1, "Ok, but how old are you?", 2, "Go on then, what's my future?", 3);
 
     if ($option = 1) {

--- a/data/src/scripts/areas/area_varrock/scripts/harlow.rs2
+++ b/data/src/scripts/areas/area_varrock/scripts/harlow.rs2
@@ -48,8 +48,8 @@ if (inv_total(inv, stake) > 0) {
     inv_add(inv, stake, 1);
     ~objboxt(stake, "Dr Harlow hands you a stake.");
 }
-~chatnpc("<p,default>You'll need a hammer as well, to drive it in properly, your everyday general store hammer will do. One last thing... It's wise to carry garlic with you, vampires are somewhat weakened if they can smell garlic. Morgan");
-~chatnpc("<p,quiz>always liked garlic, you should try his house. But remember, a vampire is still a dangerous foe!");
+~chatnpc("<p,neutral>You'll need a hammer as well, to drive it in properly, your everyday general store hammer will do. One last thing... It's wise to carry garlic with you, vampires are somewhat weakened if they can smell garlic. Morgan");
+~chatnpc("<p,neutral>always liked garlic, you should try his house. But remember, a vampire is still a dangerous foe!");
 ~chatplayer("<p,happy>Thank you very much!");
 
 [label,harlow_decline_drink]

--- a/data/src/scripts/general/configs/human.mesanim
+++ b/data/src/scripts/general/configs/human.mesanim
@@ -46,12 +46,6 @@ len2=chat_quiz2
 len3=chat_quiz3
 len4=chat_quiz4
 
-[default]
-len1=chat_default
-len2=chat_default
-len3=chat_default
-len4=chat_default
-
 [shifty]
 len1=chat_shifty1
 len2=chat_shifty2

--- a/data/src/scripts/general/configs/human.mesanim
+++ b/data/src/scripts/general/configs/human.mesanim
@@ -20,7 +20,7 @@ len4=chat_short
 len1=chat_neutral1
 len2=chat_neutral2
 len3=chat_neutral3
-len4=chat_default
+len4=chat_neutral4
 
 [shock]
 len1=chat_shock1

--- a/data/src/scripts/general/configs/human.seq
+++ b/data/src/scripts/general/configs/human.seq
@@ -3054,7 +3054,7 @@ iframe70=anim_329
 iframe71=anim_19
 iframe72=anim_66
 
-[chat_default]
+[chat_neutral4]
 replayoff=12
 frame1=anim_241
 frame2=anim_241

--- a/data/src/scripts/minigames/game_duelarena/scripts/fadli.rs2
+++ b/data/src/scripts/minigames/game_duelarena/scripts/fadli.rs2
@@ -1,33 +1,33 @@
 [opnpc1,fadli]
-~chatplayer("<p,default>Hi.");
-~chatnpc("<p,default>What?");
+~chatplayer("<p,neutral>Hi.");
+~chatnpc("<p,neutral>What?");
 
 def_int $option = ~p_choice4("What do you do?", 1, "What is this place?", 2, "I'd like to access my bank, please.", 3, "Do you watch any matches?", 4);
 
 switch_int ($option) {
     case 1:
-    ~chatplayer("<p,default>What do you do?");
-    ~chatnpc("<p,default>You can store your stuff here if you want. You can dump anything you don't want to carry whilst you're fighting duels and then pick it up again on the way out.");
-    ~chatnpc("<p,default>To be honest I'm wasted here.");
-    ~chatnpc("<p,default>I should be winning duels in the arena! I'm the best warrior in Al Kharid!");
-    ~chatplayer("<p,default>Easy, tiger!");
+    ~chatplayer("<p,neutral>What do you do?");
+    ~chatnpc("<p,neutral>You can store your stuff here if you want. You can dump anything you don't want to carry whilst you're fighting duels and then pick it up again on the way out.");
+    ~chatnpc("<p,neutral>To be honest I'm wasted here.");
+    ~chatnpc("<p,neutral>I should be winning duels in the arena! I'm the best warrior in Al Kharid!");
+    ~chatplayer("<p,neutral>Easy, tiger!");
 
     case 2:
-    ~chatplayer("<p,default>What is this place?");
-    ~chatnpc("<p,default>Isn't it obvious?");
-    ~chatnpc("<p,default>This is the Duel Arena...duh!");
+    ~chatplayer("<p,neutral>What is this place?");
+    ~chatnpc("<p,neutral>Isn't it obvious?");
+    ~chatnpc("<p,neutral>This is the Duel Arena...duh!");
 
     case 3:
-    ~chatplayer("<p,default>I'd like to access my bank, please.");
-    ~chatnpc("<p,default>Sure.");
+    ~chatplayer("<p,neutral>I'd like to access my bank, please.");
+    ~chatnpc("<p,neutral>Sure.");
     @openbank;
 
     case 4:
-    ~chatplayer("<p,default>Do you watch any matches?");
-    ~chatnpc("<p,default>When I can.");
-    ~chatnpc("<p,default>Most aren't any good so I throw rotten fruit at them!");
-    ~chatplayer("<p,default>Heh. Can I buy some?");
-    ~chatnpc("<p,default>Sure.");
+    ~chatplayer("<p,neutral>Do you watch any matches?");
+    ~chatnpc("<p,neutral>When I can.");
+    ~chatnpc("<p,neutral>Most aren't any good so I throw rotten fruit at them!");
+    ~chatplayer("<p,neutral>Heh. Can I buy some?");
+    ~chatnpc("<p,neutral>Sure.");
     ~require_members_store_owner; // complete guess, this could be earlier in the dialogue
     ~openshop_activenpc;
 }

--- a/data/src/scripts/minigames/game_duelarena/scripts/hamid.rs2
+++ b/data/src/scripts/minigames/game_duelarena/scripts/hamid.rs2
@@ -2,26 +2,26 @@
 
 // TODO - Treasure Trails
 
-~chatplayer("<p,default>Hi!");
-~chatnpc("<p,default>Hello traveller. How can I be of assistance?");
+~chatplayer("<p,neutral>Hi!");
+~chatnpc("<p,neutral>Hello traveller. How can I be of assistance?");
 
 def_int $choice = ~p_choice3("Can you heal me?", 1, "What's a Monk doing in a place such as this?", 2, "Which monastery do you come from?", 3);
 
 switch_int ($choice) {
     case 1:
-    ~chatplayer("<p,default>Can you heal me?");
-    ~chatnpc("<p,default>You'd be better off speaking to one of the nurses.");
-    ~chatnpc("<p,default>They are so... nice... afterall!"); // Typo consistent with OSRS.
+    ~chatplayer("<p,neutral>Can you heal me?");
+    ~chatnpc("<p,neutral>You'd be better off speaking to one of the nurses.");
+    ~chatnpc("<p,neutral>They are so... nice... afterall!"); // Typo consistent with OSRS.
 
     case 2:
-    ~chatplayer("<p,default>What's a Monk doing in a place such as this?");
-    ~chatnpc("<p,default>Well don't tell anyone but I came here because of the nurses!");
-    ~chatplayer("<p,default>Really?");
-    ~chatnpc("<p,default>It beats being stuck in the monastery!");
+    ~chatplayer("<p,neutral>What's a Monk doing in a place such as this?");
+    ~chatnpc("<p,neutral>Well don't tell anyone but I came here because of the nurses!");
+    ~chatplayer("<p,neutral>Really?");
+    ~chatnpc("<p,neutral>It beats being stuck in the monastery!");
 
     case 3:
-    ~chatplayer("<p,default>Which monastery do you come from?");
-    ~chatnpc("<p,default>I belong to a monastery north of Falador.");
-    ~chatplayer("<p,default>You're a long way from home?");
-    ~chatnpc("<p,default>Yeh. I miss the guys.");
+    ~chatplayer("<p,neutral>Which monastery do you come from?");
+    ~chatnpc("<p,neutral>I belong to a monastery north of Falador.");
+    ~chatplayer("<p,neutral>You're a long way from home?");
+    ~chatnpc("<p,neutral>Yeh. I miss the guys.");
 }

--- a/data/src/scripts/minigames/game_duelarena/scripts/heal.rs2
+++ b/data/src/scripts/minigames/game_duelarena/scripts/heal.rs2
@@ -1,17 +1,17 @@
 [opnpc1,_healer]
-~chatplayer("<p,default>Hi!");
-~chatnpc("<p,default>Hi. How can I help you?");
+~chatplayer("<p,neutral>Hi!");
+~chatnpc("<p,neutral>Hi. How can I help you?");
 
 def_int $choice = ~p_choice3("Can you heal me?", 0, "Do you see a lot of injured fighters?", 1, "Do you come here often?", 2);
 
 switch_int ($choice) {
     case 0:
-    ~chatplayer("<p,default>Can you heal me?");
+    ~chatplayer("<p,neutral>Can you heal me?");
 
     if (stat(hitpoints) >= stat_base(hitpoints)) {
-        ~chatnpc("<p,default>You look healthy to me!");
+        ~chatnpc("<p,neutral>You look healthy to me!");
     } else {
-        ~chatnpc("<p,default>Of course!");
+        ~chatnpc("<p,neutral>Of course!");
         npc_anim(human_pickpocket, 0);
         p_delay(0);
         mes("You feel a little better.");
@@ -20,15 +20,15 @@ switch_int ($choice) {
     }
 
     case 1:
-    ~chatplayer("<p,default>Do you see a lot of injured fighters?");
-    ~chatnpc("<p,default>Yes I do. Thankfully we can cope with almost anything.|Jaraah really is a wonderful surgeon, his methods are a little unorthodox but he gets the job done.");
-    ~chatnpc("<p,default>I shouldn't tell you this but his nickname is 'The Butcher'.");
-    ~chatplayer("<p,default>That's reassuring.");
+    ~chatplayer("<p,neutral>Do you see a lot of injured fighters?");
+    ~chatnpc("<p,neutral>Yes I do. Thankfully we can cope with almost anything.|Jaraah really is a wonderful surgeon, his methods are a little unorthodox but he gets the job done.");
+    ~chatnpc("<p,neutral>I shouldn't tell you this but his nickname is 'The Butcher'.");
+    ~chatplayer("<p,neutral>That's reassuring.");
 
     case 2:
-    ~chatplayer("<p,default>Do you come here often?");
-    ~chatnpc("<p,default>I work here, so yes!");
-    ~chatnpc("<p,default>You're silly!");
+    ~chatplayer("<p,neutral>Do you come here often?");
+    ~chatnpc("<p,neutral>I work here, so yes!");
+    ~chatnpc("<p,neutral>You're silly!");
 }
 
 [opnpc3,_healer]
@@ -36,7 +36,7 @@ switch_int ($choice) {
 
 [label,heal_duelarena]
 if (stat(hitpoints) >= stat_base(hitpoints)) {
-    ~chatnpc("<p,default>You look healthy to me!");
+    ~chatnpc("<p,neutral>You look healthy to me!");
 } else {
     npc_anim(human_pickpocket, 0);
     p_delay(0);

--- a/data/src/scripts/minigames/game_duelarena/scripts/jaraah.rs2
+++ b/data/src/scripts/minigames/game_duelarena/scripts/jaraah.rs2
@@ -1,17 +1,17 @@
 [opnpc1,jaraah]
-~chatplayer("<p,default>Hi!");
-~chatnpc("<p,default>What? Can't you see I'm busy?!");
+~chatplayer("<p,neutral>Hi!");
+~chatnpc("<p,neutral>What? Can't you see I'm busy?!");
 
 def_int $choice = ~p_choice3("Can you heal me?", 0, "You must see some gruesome things?", 1, "Why do they call you 'The Butcher'?", 2);
 
 switch_int ($choice) {
     case 0:
-    ~chatplayer("<p,default>Can you heal me?");
+    ~chatplayer("<p,neutral>Can you heal me?");
 
     if (stat(hitpoints) >= stat_base(hitpoints)) {
-        ~chatnpc("<p,default>You look healthy to me!");
+        ~chatnpc("<p,neutral>You look healthy to me!");
     } else {
-        ~chatnpc("<p,default>Okay, this will hurt you more than it will me.");
+        ~chatnpc("<p,neutral>Okay, this will hurt you more than it will me.");
         npc_anim(human_pickpocket, 0);
         p_delay(0);
         mes("You feel a little better.");
@@ -20,15 +20,15 @@ switch_int ($choice) {
     }
 
     case 1:
-    ~chatplayer("<p,default>You must see some gruesome things?");
-    ~chatnpc("<p,default>It's a gruesome business and with the tools they give me it gets more gruesome before it gets better!");
+    ~chatplayer("<p,neutral>You must see some gruesome things?");
+    ~chatnpc("<p,neutral>It's a gruesome business and with the tools they give me it gets more gruesome before it gets better!");
 
     case 2:
-    ~chatplayer("<p,default>Why do they call you 'The Butcher'?");
-    ~chatnpc("<p,default>'The Butcher'?'");
-    ~chatnpc("<p,default>Ha!");
-    ~chatnpc("<p,default>Would you like me to demonstrate?");
-    ~chatplayer("<p,default>Er...I'll give it a miss, thanks.");
+    ~chatplayer("<p,neutral>Why do they call you 'The Butcher'?");
+    ~chatnpc("<p,neutral>'The Butcher'?'");
+    ~chatnpc("<p,neutral>Ha!");
+    ~chatnpc("<p,neutral>Would you like me to demonstrate?");
+    ~chatplayer("<p,neutral>Er...I'll give it a miss, thanks.");
 }
 
 [opnpc3,jaraah]

--- a/data/src/scripts/minigames/game_duelarena/scripts/mubariz.rs2
+++ b/data/src/scripts/minigames/game_duelarena/scripts/mubariz.rs2
@@ -3,38 +3,38 @@
 // RS3 dialogue: https://runescape.wiki/w/Transcript:Mubariz?oldid=27948630
 // To try and take as many updates into account, any older reference/image/video would be fantastic.
 [opnpc1,mubariz]
-~chatplayer("<p,default>Hi!");
-~chatnpc("<p,default>Welcome to the Duel Arena!");
-~chatplayer("<p,default>Thanks! I need some information.");
-~chatnpc("<p,default>What would you like to know?");
+~chatplayer("<p,neutral>Hi!");
+~chatnpc("<p,neutral>Welcome to the Duel Arena!");
+~chatplayer("<p,neutral>Thanks! I need some information.");
+~chatnpc("<p,neutral>What would you like to know?");
 
 def_int $choice = ~p_choice4("What is this place?", 0, "How do I challenge someone to a duel?", 1, "What kind of options are there?", 2, "This place looks really old, where did it come from?", 3);
 
 switch_int ($choice) {
     case 0:
-    ~chatplayer("<p,default>What is this place?");
-    ~chatnpc("<p,default>The Duel Arena has six duel arenas where you can fight other players in a controlled environment. We have our own dedicated hospital where we guarantee to put you back together, even if you lose.");
-    ~chatnpc("<p,default>Inbetween the arenas are walkways where you can watch the fights and challenge other players.");
-    ~chatplayer("<p,default>Sounds great. Thanks!");
-    ~chatnpc("<p,default>See you in the arenas!");
+    ~chatplayer("<p,neutral>What is this place?");
+    ~chatnpc("<p,neutral>The Duel Arena has six duel arenas where you can fight other players in a controlled environment. We have our own dedicated hospital where we guarantee to put you back together, even if you lose.");
+    ~chatnpc("<p,neutral>Inbetween the arenas are walkways where you can watch the fights and challenge other players.");
+    ~chatplayer("<p,neutral>Sounds great. Thanks!");
+    ~chatnpc("<p,neutral>See you in the arenas!");
 
     case 1:
-    ~chatplayer("<p,default>How do I challenge someone to a duel?");
-    ~chatnpc("<p,default>When you go to the arena you'll go up an access ramp to the walkways that overlook the duel arenas.|From the walkway you can watch the duels and challenge other players.");
-    ~chatnpc("<p,default>You'll know you're in the right place as you'll have a 'Challenge' option when you right-click a player.");
+    ~chatplayer("<p,neutral>How do I challenge someone to a duel?");
+    ~chatnpc("<p,neutral>When you go to the arena you'll go up an access ramp to the walkways that overlook the duel arenas.|From the walkway you can watch the duels and challenge other players.");
+    ~chatnpc("<p,neutral>You'll know you're in the right place as you'll have a 'Challenge' option when you right-click a player.");
 
     case 2:
-    ~chatplayer("<p,default>What kind of options are there?");
-    ~chatnpc("<p,default>You and your opponent can offer items as a stake. If you win, you recieve what your opponent staked, but, if you lose, your oppenent will get whatever items you staked.");
-    ~chatnpc("<p,default>You can choose to use rules to spice things up a bit. For instance if you both agree to use the 'No Magic' rule then neither player can use magic to attack the other player. The fight will be restricted to ranging and");
-    ~chatnpc("<p,default>melee only.");
-    ~chatnpc("<p,default>The rules are fairly self-evident with lots of different combinations for you to try out!");
-    ~chatplayer("<p,default>Cool! Thanks!");
+    ~chatplayer("<p,neutral>What kind of options are there?");
+    ~chatnpc("<p,neutral>You and your opponent can offer items as a stake. If you win, you recieve what your opponent staked, but, if you lose, your oppenent will get whatever items you staked.");
+    ~chatnpc("<p,neutral>You can choose to use rules to spice things up a bit. For instance if you both agree to use the 'No Magic' rule then neither player can use magic to attack the other player. The fight will be restricted to ranging and");
+    ~chatnpc("<p,neutral>melee only.");
+    ~chatnpc("<p,neutral>The rules are fairly self-evident with lots of different combinations for you to try out!");
+    ~chatplayer("<p,neutral>Cool! Thanks!");
 
     case 3:
-    ~chatplayer("<p,default>This place looks really old, where did it come from?");
-    ~chatnpc("<p,default>The archaeologists that are excavating the area east of Varrock have been working on this site as well. From these cliffs they uncovered this huge building. The experts think it may date back to the second age!");
-    ~chatnpc("<p,default>Now that the archaeologists have moved out, a group of warriors, headed by myself, have bought the land and converted it to a set of duel arenas. The best fighters around the world come here to fight!");
-    ~chatplayer("<p,default>I challenge you!");
-    ~chatnpc("<p,default>Ho! Ho! Ho!");
+    ~chatplayer("<p,neutral>This place looks really old, where did it come from?");
+    ~chatnpc("<p,neutral>The archaeologists that are excavating the area east of Varrock have been working on this site as well. From these cliffs they uncovered this huge building. The experts think it may date back to the second age!");
+    ~chatnpc("<p,neutral>Now that the archaeologists have moved out, a group of warriors, headed by myself, have bought the land and converted it to a set of duel arenas. The best fighters around the world come here to fight!");
+    ~chatplayer("<p,neutral>I challenge you!");
+    ~chatnpc("<p,neutral>Ho! Ho! Ho!");
 }

--- a/data/src/scripts/minigames/game_duelarena/scripts/zahwa.rs2
+++ b/data/src/scripts/minigames/game_duelarena/scripts/zahwa.rs2
@@ -5,37 +5,37 @@ def_int $random = random(8);
 switch_int ($random) {
     case 0:
     ~chatplayer("<p,happy>Hi!");
-    ~chatnpc("<p,default>Hi!");
+    ~chatnpc("<p,neutral>Hi!");
 
     case 1:
     ~chatplayer("<p,happy>Hi!");
     ~chatnpc("<p,sad>Ughhhh....");
 
     case 2:
-    ~chatplayer("<p,default>Hi!");
-    ~chatnpc("<p,default>I could've 'ad 'im!");
-    ~chatplayer("<p,default>Er...");
-    ~chatnpc("<p,default>I was robbed!");
-    ~chatplayer("<p,default>Right.");
-    ~chatnpc("<p,default>It was rigged I tell you!");
-    ~chatplayer("<p,default>Uh huh.");
-    ~chatnpc("<p,default>Leave me alone!");
+    ~chatplayer("<p,neutral>Hi!");
+    ~chatnpc("<p,neutral>I could've 'ad 'im!");
+    ~chatplayer("<p,neutral>Er...");
+    ~chatnpc("<p,neutral>I was robbed!");
+    ~chatplayer("<p,neutral>Right.");
+    ~chatnpc("<p,neutral>It was rigged I tell you!");
+    ~chatplayer("<p,neutral>Uh huh.");
+    ~chatnpc("<p,neutral>Leave me alone!");
 
     case 3:
-    ~chatplayer("<p,default>Are you alright?");
-    ~chatnpc("<p,default>NURSE!");
+    ~chatplayer("<p,neutral>Are you alright?");
+    ~chatnpc("<p,neutral>NURSE!");
 
     case 4:
-    ~chatplayer("<p,default>Are you alright?");
-    ~chatnpc("<p,default>Do I look alright?!");
+    ~chatplayer("<p,neutral>Are you alright?");
+    ~chatnpc("<p,neutral>Do I look alright?!");
 
     case 5:
-    ~chatplayer("<p,default>Are you alright?");
-    ~chatnpc("<p,default>Yeh. The nurses here are...wonderful!");
+    ~chatplayer("<p,neutral>Are you alright?");
+    ~chatnpc("<p,neutral>Yeh. The nurses here are...wonderful!");
 
     case 6:
-    ~chatplayer("<p,default>Are you alright?");
-    ~chatnpc("<p,default>It's just a flesh wound!");
+    ~chatplayer("<p,neutral>Are you alright?");
+    ~chatnpc("<p,neutral>It's just a flesh wound!");
 
     case 7:
     ~chatplayer("<p,confused>Are you alright?");

--- a/data/src/scripts/quests/quest_chompybird/scripts/bugs.rs2
+++ b/data/src/scripts/quests/quest_chompybird/scripts/bugs.rs2
@@ -11,12 +11,12 @@ switch_int(%chompybird_progress) {
 
         ~chatnpc("<p,neutral>Hey you Creature, Dad says you's is gonna get da stabbers!");
         ~chatplayer("<p,happy>That's right... I'm making some 'stabbers' for Rantz.");
-        ~chatnpc("<p,default>Dat's great...Dad want's to hunt da chompy... Da chompy is our bestest yumms! Yous needies da scratchers for makin' dem huh? I's wants some bright pretties for em!");
+        ~chatnpc("<p,neutral>Dat's great...Dad want's to hunt da chompy... Da chompy is our bestest yumms! Yous needies da scratchers for makin' dem huh? I's wants some bright pretties for em!");
 
         ~doubleobjbox(chisel, knife, "Bugs shows you a chisel and a knife.");
 
         ~chatplayer("<p,neutral>How many 'bright pretties' do you want?");
-        ~chatnpc("<p,default>Bugs wants lots of bright pretties, this many!|@blu@~ Bugs quickly opens and closes his hands in front ~|@blu@~ of you to indicate a number of bright pretties. ~|@blu@~ It looks like he wants 10 gold coins.~");
+        ~chatnpc("<p,neutral>Bugs wants lots of bright pretties, this many!|@blu@~ Bugs quickly opens and closes his hands in front ~|@blu@~ of you to indicate a number of bright pretties. ~|@blu@~ It looks like he wants 10 gold coins.~");
 
         switch_int(~p_choice2("Ok, I'll give you 10 bright pretties.", 1, "Er, sorry, I can't give you that many...", 2)) {
             case 1:

--- a/data/src/scripts/quests/quest_chompybird/scripts/fycie.rs2
+++ b/data/src/scripts/quests/quest_chompybird/scripts/fycie.rs2
@@ -11,12 +11,12 @@ switch_int(%chompybird_progress) {
 
         ~chatnpc("<p,neutral>Hey you Creature, I know's what you is You's a|'uman!");
         ~chatplayer("<p,happy>That's right... I'm making some 'stabbers' for Rantz.");
-        ~chatnpc("<p,default>Dat's great...Dad want's to hunt da chompy... Da chompy is our bestest yumms! Yous needies da scratchers for makin' dem huh? I's wants some bright pretties for em!");
+        ~chatnpc("<p,neutral>Dat's great...Dad want's to hunt da chompy... Da chompy is our bestest yumms! Yous needies da scratchers for makin' dem huh? I's wants some bright pretties for em!");
 
         ~objbox(feather, "Fycie shows you the flufsies...you count 25 of them.");
 
         ~chatplayer("<p,neutral>How many 'bright pretties' do you want?");
-        ~chatnpc("<p,default>Mee's wants lots of bright pretties, this many!|@blu@~ Fycie quickly opens and closes her hands in front ~|@blu@~ of you to indicate a number of bright pretties. ~|@blu@~ It looks like she wants 50 gold coins.~");
+        ~chatnpc("<p,neutral>Mee's wants lots of bright pretties, this many!|@blu@~ Fycie quickly opens and closes her hands in front ~|@blu@~ of you to indicate a number of bright pretties. ~|@blu@~ It looks like she wants 50 gold coins.~");
 
         switch_int(~p_choice2("Ok, I'll give you 50 bright pretties.", 1, "Er, sorry, I can't give you that many...", 2)) {
             case 1:

--- a/data/src/scripts/quests/quest_chompybird/scripts/rantz.rs2
+++ b/data/src/scripts/quests/quest_chompybird/scripts/rantz.rs2
@@ -4,7 +4,7 @@ switch_int(%chompybird_progress) {
     case ^chompybird_not_started:
         ~chatnpc("<p,neutral>Hey you creature! Make me some stabbers! I wanna hunt da chompy?");
         ~chatplayer("<p,confused>Stabbers?");
-        ~chatnpc("<p,default>For da stabbie chucker, I's wanna hunt da chompy! Da chompy is der bestest yummies for Rantz, Fycie and Bugs! Creature knows what Rantz wants... flyin' to stabbie da chompy!");
+        ~chatnpc("<p,neutral>For da stabbie chucker, I's wanna hunt da chompy! Da chompy is der bestest yummies for Rantz, Fycie and Bugs! Creature knows what Rantz wants... flyin' to stabbie da chompy!");
         
         ~objbox(ogre_bow,"The ogre shows you a huge but crude bow and then starts to nod energetically in an effort to help you understand.");
 
@@ -89,7 +89,7 @@ switch_int(%chompybird_progress) {
             mes("[debug] TODO currently unimplemented");
         } else {
             // TODO mesanim TBC
-            ~chatnpc("<p,default>Hey You! Got da chompy yet?");
+            ~chatnpc("<p,neutral>Hey You! Got da chompy yet?");
             ~chatplayer("<p,neutral>Yep, here's your chompy Bird!");
             @rantz_show_chompy;
         }
@@ -100,7 +100,7 @@ switch_int(%chompybird_progress) {
         @hand_chompy_to_rantz;
     case ^chompybird_complete:
         // TODO message tbc
-        ~chatnpc("<p,default>Tank's very much for da chompy...|Fycie an Bugs like very much da chompy yumms!");
+        ~chatnpc("<p,neutral>Tank's very much for da chompy...|Fycie an Bugs like very much da chompy yumms!");
 
     // TODO dialog to buy ogre bow back from Rantz
 }
@@ -234,7 +234,7 @@ if (inv_total(inv, ogre_arrow) > 0) {
 switch_int(~p_choice2("How do I make the 'stabbers' again?", 1, "Ok, I'll make the 'stabbers' for you.", 2)) {
     case 1:
         ~chatplayer("<p,neutral>How do I make the 'stabbers' again?");
-        ~chatnpc("<p,default>Grrr creature... you's no good stabber maker! You's make da stabbie bit from da dog bones, and get da sticksies from da Achey tree... simple see? Oh and da flufsies from da flappers as well!");
+        ~chatnpc("<p,neutral>Grrr creature... you's no good stabber maker! You's make da stabbie bit from da dog bones, and get da sticksies from da Achey tree... simple see? Oh and da flufsies from da flappers as well!");
         ~chatplayer("<p,quiz>Oh, so I need logs from the achey tree, bones from a canine... and feathers?");
         ~chatnpc("<p,happy>Is just what Rantz sayed!|@blu@~ The hulking ogre nods excitedly. ~");
     case 2:
@@ -273,7 +273,7 @@ inv_del(inv, ogre_arrow, 6);
 switch_int(~p_choice5("How do we make the chompys come?", 1, "What are 'fatsy toadies'?", 2, "Where do we put the 'fatsy toadies'?", 3, "What do you mean 'sneaky..sneaky, stick da chompy?'", 4, "Ok, thanks.", 5)) {
     case 1:
         ~chatplayer("<p,neutral>How do we make the chompys come?");
-        ~chatnpc("<p,default>Chompys love da fatsy toadies. Toadies get big on der swamp gas and der chompys are licking der lips for em as me is licking lips for da chompy. Da chompys don't like da smaller toadies from nearby swampy.");
+        ~chatnpc("<p,neutral>Chompys love da fatsy toadies. Toadies get big on der swamp gas and der chompys are licking der lips for em as me is licking lips for da chompy. Da chompys don't like da smaller toadies from nearby swampy.");
         %chompybird_progress = ^chompybird_kids_play_with_toad;
         ~chatnpc("<p,happy>Dey's fussie eaters just like Rantz. Fycie an' Bugs play with toadies and blower dey's all times making fatsy toadies.");
         @toadies_questions;

--- a/data/src/scripts/quests/quest_elena/scripts/edmond.rs2
+++ b/data/src/scripts/quests/quest_elena/scripts/edmond.rs2
@@ -22,7 +22,7 @@ switch_int(%elena_progress) {
         ~chatplayer("<p,happy>Hi <nc_name(edmond)>, I've got the gas mask now.");
         ~chatnpc("<p,neutral>Good stuff, now for the digging. Beneath are the Ardougne sewers. There you'll find access to West Ardougne.");
         if(%elena_progress = ^quest_elena_gasmask) ~quest_elena_set_progress(^quest_elena_started_mud_patch);
-        ~chatnpc("<p,default>The problem is the soil is rock hard. You'll need to pour on some buckets of water to soften it up. I'll keep an eye out for the mourners.");
+        ~chatnpc("<p,neutral>The problem is the soil is rock hard. You'll need to pour on some buckets of water to soften it up. I'll keep an eye out for the mourners.");
     }
     case ^quest_elena_opened_tunnel: {
         ~chatplayer("<p,confused><nc_name(edmond)>, I can't get through to West Ardougne! There's an iron grill blocking my way. I can't pull it off alone.");

--- a/data/src/scripts/quests/quest_fluffs/scripts/quest_fluffs.rs2
+++ b/data/src/scripts/quests/quest_fluffs/scripts/quest_fluffs.rs2
@@ -9,11 +9,11 @@ switch_int (%fluffs_progress) {
     case ^fluffs_paid_boy:
         ~chatplayer("<p,neutral>Where did you say you saw Fluffs?");
         ~chatnpc("<p,neutral>Weren't you listening? I saw the flea bag|in the old lumber mill just north east of here.|Just walk past the Jolly Boar Inn|and you should find it.");
-    case default: //guessed mesanims
-        ~chatplayer("<p,neutral>Hello again.");
+    case default: 
+        ~chatplayer("<p,happy>Hello again.");
         ~chatnpc("<p,angry>You think you're tough do you?");
-        ~chatplayer("<p,neutral>Pardon?");
-        ~chatnpc("<p,angry>I can beat anyone up.");
+        ~chatplayer("<p,shock>Pardon?");
+        ~chatnpc("<p,angry>I can beat anyone up!");
         ~chatplayer("<p,bored>Really?");
         ~mesbox("The boy begins to jump around with his fists up.|You decide it's best not to kill him just yet.");
 }
@@ -22,7 +22,7 @@ switch_int (%fluffs_progress) {
 ~chatplayer("<p,neutral>Hello there, I've been looking for you.");
 ~chatnpc("<p,neutral>I didn't mean to take it!|I just forgot to pay."); //imgur.com/jk6y117
 ~chatplayer("<p,neutral>What? I'm trying to help your mum find Fluffs.");
-~chatnpc("<p,default>Ohh...well, in that case I might be able to help.|Fluffs followed me to my secret play area,|I haven't seen her since.");
+~chatnpc("<p,neutral>Ohh...well, in that case I might be able to help.|Fluffs followed me to my secret play area,|I haven't seen her since.");
 ~chatplayer("<p,quiz>Where is this play area?");
 ~chatnpc("<p,neutral>If I told you that, it wouldn't be a secret.");
 def_int $option = ~p_choice3("Tell me sonny, or I will hurt you.", 1, "What will make you tell me?", 2, "Well never mind, it's Fluffs' loss.", 3);
@@ -37,7 +37,7 @@ switch_int ($option) {
         ~chatplayer("<p,bored>How much?");
         ~chatnpc("<p,neutral>100 coins should cover it.");
         ~chatplayer("<p,angry>100 coins!|Why should I pay you?");
-        ~chatnpc("<p,default>You shouldn't,|but I won't help otherwise.|I never liked that cat anyway,|so what do you say?");
+        ~chatnpc("<p,neutral>You shouldn't,|but I won't help otherwise.|I never liked that cat anyway,|so what do you say?");
         @fluffs_pay;
     case 3:
         ~chatplayer("<p,neutral>Well, never mind, it's Fluffs' loss.");
@@ -61,9 +61,9 @@ switch_int ($option) {
         %fluffs_progress = ^fluffs_paid_boy;
         ~objbox(coins_25, "You give the lad 100 coins."); //imgur.com/jhDCIvP
         ~chatplayer("<p,neutral>There you go, now where did you see Fluffs ?"); //intentional
-        ~chatnpc("<p,default>I play at an abandoned lumber mill to the north east.|Just beyond the Jolly Boar Inn.|I saw Fluffs running around in there.");
+        ~chatnpc("<p,neutral>I play at an abandoned lumber mill to the north east.|Just beyond the Jolly Boar Inn.|I saw Fluffs running around in there.");
         ~chatplayer("<p,neutral>Anything else?");
-        ~chatnpc("<p,default>Well, you'll have to find the broken fence to get in.|I'm sure you can manage that.");
+        ~chatnpc("<p,neutral>Well, you'll have to find the broken fence to get in.|I'm sure you can manage that.");
 }
 
 [oploc1,loc_2618]
@@ -107,7 +107,7 @@ if(last_useitem = doogle_leaves) {
 
 [opnpc1,fluffs]
 if(%fluffs_progress >= ^fluffs_rescued) {
-    ~chatplayer("<p,default>Oh, it looks like Fluffs has returned.|I'd better leave her alone."); //OSRS
+    ~chatplayer("<p,neutral>Oh, it looks like Fluffs has returned.|I'd better leave her alone."); //OSRS
     return;
 }
 ~fluffs_attack;

--- a/data/src/scripts/quests/quest_mcannon/scripts/locs/mcannon_broken_cannon.rs2
+++ b/data/src/scripts/quests/quest_mcannon/scripts/locs/mcannon_broken_cannon.rs2
@@ -1,6 +1,6 @@
 [oploc1,broken_cannon]
 if (%mcannon_progress = ^mcannon_tasked_with_fixing_cannon) {
-    ~chatplayer("<p,default>I guess I'd better fix it with the toolkit I was given.");
+    ~chatplayer("<p,neutral>I guess I'd better fix it with the toolkit I was given.");
     %mcannon_progress = ^mcannon_inspected_cannon_first_time;
 } else if (%mcannon_progress = ^mcannon_inspected_cannon_first_time) {
     mes("You inspect the multi cannon.");

--- a/data/src/scripts/quests/quest_mcannon/scripts/npcs/dwarf_commander.rs2
+++ b/data/src/scripts/quests/quest_mcannon/scripts/npcs/dwarf_commander.rs2
@@ -15,7 +15,7 @@ switch_int(%mcannon_progress) {
 }
 
 [label,dwarf_commander_start_quest]
-~chatplayer("<p,default>Hello.");
+~chatplayer("<p,neutral>Hello.");
 ~chatnpc("<p,happy>Hello traveller, I'm pleased to see you.|We were hoping to find an extra pair of hands.|That's if you don't mind helping?");;
 ~chatplayer("<p,quiz>Why, what's wrong?");
 ~chatnpc("<p,sad>As part of the Dwarven Black Guard,|it is our duty to protect these mines,|but we just don't have the man power.|Could you help?");
@@ -25,7 +25,7 @@ switch_int(%mcannon_progress) {
 );
 
 [label,im_too_busy_mining]
-~chatplayer("<p,default>I'm sorry, I'm too busy mining.");
+~chatplayer("<p,neutral>I'm sorry, I'm too busy mining.");
 ~chatnpc("<p,sad>Ok then, we'll have to find someone else.");
 
 [label,id_love_to_help]
@@ -34,12 +34,12 @@ if (%mcannon_progress = ^mcannon_not_started) {
     %mcannon_progress = ^mcannon_tasked_with_fixing_railings;
     ~send_quest_progress_colour(questlist:mcannon, %mcannon_progress, ^mcannon_complete);
 }
-~chatnpc("<p,default>Thank you, we have no time to waste.|The Goblins are attacking from the forests to the south,|they managed to get through the broken railings,|could you please replace them with these new ones?");
-~chatplayer("<p,default>Sounds easy enough...");
+~chatnpc("<p,neutral>Thank you, we have no time to waste.|The Goblins are attacking from the forests to the south,|they managed to get through the broken railings,|could you please replace them with these new ones?");
+~chatplayer("<p,neutral>Sounds easy enough...");
 ~mesbox("The Dwarf Commander gives you six railings.");
 inv_add(inv, mcannon_railing, 6);
-~chatnpc("<p,default>Let me know once you've fixed the railings.");    
-~chatplayer("<p,default>Ok, commander.");
+~chatnpc("<p,neutral>Let me know once you've fixed the railings.");    
+~chatplayer("<p,neutral>Ok, commander.");
 
 [label,dwarf_commander_how_goes_fixing_those_fences]
 ~chatplayer("<p,happy>Hello.");
@@ -126,7 +126,7 @@ mes("The Dwarf Commander gives you a tool kit.");
 ~chatnpc("<p,happy>Let me know how you get on.");
 
 [label,mcannon_ive_done_enough_for_today]
-~chatplayer("<p,default>Sorry, I've done enough for today.");
+~chatplayer("<p,neutral>Sorry, I've done enough for today.");
 ~chatnpc("<p,neutral>Fair enough, take care traveller.");
 
 [label,dwarf_commander_still_fixing_cannon]

--- a/data/src/scripts/quests/quest_sheepherder/scripts/npcs/doctor_orbon.rs2
+++ b/data/src/scripts/quests/quest_sheepherder/scripts/npcs/doctor_orbon.rs2
@@ -11,7 +11,7 @@ switch_int(%sheepherder_progress) {
 ~chatnpc("<p,quiz>How do you feel?|No heavy flu, shivers, nausea or loss of appetite?");
 ~chatplayer("<p,quiz>Uh... no... I feel fine...");
 ~chatnpc("<p,quiz>How about nightmares then? Are you experiencing any problems with especially scary nightmares?");
-~chatplayer("<p,default>No... not since I was young.");
+~chatplayer("<p,neutral>No... not since I was young.");
 ~chatnpc("<p,happy>Good, good, I had to make sure.|This plague really has an incredible fast contagion rate. It spreads faster than the common cold!");
 @multi2(
     "The plague? Tell me more.", doctor_orbon_more_about_plague,

--- a/data/src/scripts/quests/quest_sheepherder/scripts/npcs/farmer_brumty.rs2
+++ b/data/src/scripts/quests/quest_sheepherder/scripts/npcs/farmer_brumty.rs2
@@ -16,7 +16,7 @@ switch_int(%sheepherder_progress) {
 // Should also hypothetically never be seen since Brumty is in the pen on our Revision.
 // sheepherder_tasked_with_talking_to_dr_orbon
 [label,farmer_brumty_before_talking_to_orbon]
-~chatplayer("<p,default>Hello there. I've spoken to Councillor Halgrive. He has asked me to round up your sheep and slaughter them.");
+~chatplayer("<p,neutral>Hello there. I've spoken to Councillor Halgrive. He has asked me to round up your sheep and slaughter them.");
 ~chatnpc("<p,sad>Well, I always knew someone would have to. Make sure you're careful about it; there should be a cattleprod in the barn you can use to herd up the sheep.");
 
 [label,farmer_brumty_during_sheep_herder]

--- a/data/src/scripts/quests/quest_squire/scripts/quest_squire.rs2
+++ b/data/src/scripts/quests/quest_squire/scripts/quest_squire.rs2
@@ -59,7 +59,7 @@ if($option = 1) {
 def_int $option = ~p_choice2("So would these dwarves make another one?", 1, "Well I hope you find it soon.", 2);
 if($option = 1) {
     ~chatplayer("<p,quiz>So would these dwarves make another one?");
-    ~chatnpc("<p,default>I'm not a hundred percent sure the Imcando tribe exists anymore. I should think Reldo, the palace librarian in Varrock, will know; he has done a lot of research on the races of RuneScape.");
+    ~chatnpc("<p,neutral>I'm not a hundred percent sure the Imcando tribe exists anymore. I should think Reldo, the palace librarian in Varrock, will know; he has done a lot of research on the races of RuneScape.");
     ~chatnpc("<p,happy>I don't suppose you could try and track down the Imcando dwarves for me? I've got so much work to do...");
     $option = ~p_choice2("Ok, I'll give it a go.", 1, "No, I've got lots of mining work to do.", 2);
     if($option = 1) {
@@ -118,7 +118,7 @@ if(%squire_progress = 3) {
 ~chatplayer("<p,quiz>So are there any Imcando left at all?");
 ~chatnpc("<p,happy>I believe a few of them survived,|but with the bulk of their population destroyed|their numbers have dwindled even further.");
 ~chatnpc("<p,happy>I believe I remember a couple living in Asgarnia|near the cliffs on the Asgarnian southern peninsula,|but they DO tend to keep to themselves.");
-~chatnpc("<p,default>They tend not to tell people that they're the descendants of the Imcando, which is why people think that the tribe has died out totally, but you may well have more luck talking to them if you bring them some");
+~chatnpc("<p,neutral>They tend not to tell people that they're the descendants of the Imcando, which is why people think that the tribe has died out totally, but you may well have more luck talking to them if you bring them some");
 ~chatnpc("<p,neutral>redberry pie. They REALLY like redberry pie.");
 %squire_progress = 2;
 
@@ -140,7 +140,7 @@ if(inv_total(inv, redberry_pie) >= 1) {
 
 [label,thurgo_special_sword_pre_pie]
 ~chatplayer("<p,quiz>Can you make me a special sword?");
-~chatnpc("<p,default>No, I don't do that anymore. I'm getting old."); 
+~chatnpc("<p,neutral>No, I don't do that anymore. I'm getting old."); 
 
 [label,thurgo_redberry_pie]
 ~chatplayer("<p,quiz>Would you like a redberry pie?");
@@ -153,10 +153,10 @@ inv_del(inv, redberry_pie, 1);
 
 [label,thurgo_special_sword_post_pie]
 ~chatplayer("<p,quiz>Can you make me a special sword?");
-~chatnpc("<p,default>Well, after bringing me my favorite food I guess I should give it a go. What sort of sword is it?");
-~chatplayer("<p,default>I need you to make a sword for one of Falador's knights. He had one which was passed down through five generations, but his squire has lost it. So we need an identical one to replace it.");
-~chatnpc("<p,default>A Knight's sword eh? Well I'd need to know exactly how it looked before I could make a new one.");
-~chatnpc("<p,happy>All the Faladian knights used to have swords with unique designs according to their position. Could you bring me a picture or something?");
+~chatnpc("<p,neutral>Well, after bringing me my favorite food I guess I should give it a go. What sort of sword is it?");
+~chatplayer("<p,neutral>I need you to make a sword for one of Falador's knights. He had one which was passed down through five generations, but his squire has lost it. So we need an identical one to replace it.");
+~chatnpc("<p,neutral>A Knight's sword eh? Well I'd need to know exactly how it looked before I could make a new one.");
+~chatnpc("<p,neutral>All the Faladian knights used to have swords with unique designs according to their position. Could you bring me a picture or something?");
 %squire_progress = 4;
 ~chatplayer("<p,neutral>I'll go and ask his squire and see if I can find one.");
 
@@ -167,14 +167,14 @@ if(%squire_progress = 4 | %squire_progress = 5 & inv_total(inv, portrait) = 0) {
     ~chatplayer("<p,neutral>Sorry, not yet.");
     ~chatnpc("<p,happy>Well, come back when you do.");
 } else if (%squire_progress = 5 & inv_total(inv, portrait) >= 1) {
-    ~chatplayer("<p,default>I have found a picture of the sword I would like you to make.");
+    ~chatplayer("<p,neutral>I have found a picture of the sword I would like you to make.");
     ~mesbox("You give the portrait to Thurgo. Thurgo studies the portrait.");
-    ~chatnpc("<p,default>Ok. You'll need to get me some stuff in order for me to make this.");
-    ~chatnpc("<p,default>I'll need two iron bars to make the sword to start with. I'll also need an ore called blurite. It's useless for making actual weapons for fighting with, but I'll need some as decoration for the hilt.");
-    ~chatnpc("<p,default>It is fairly rare sort of ore... The only place I know where to get it is under this cliff here...");
+    ~chatnpc("<p,neutral>Ok. You'll need to get me some stuff in order for me to make this.");
+    ~chatnpc("<p,neutral>I'll need two iron bars to make the sword to start with. I'll also need an ore called blurite. It's useless for making actual weapons for fighting with, but I'll need some as decoration for the hilt.");
+    ~chatnpc("<p,neutral>It is fairly rare sort of ore... The only place I know where to get it is under this cliff here...");
     ~chatnpc("<p,sad>But it is guarded by a very powerful ice giant.");
-    ~chatnpc("<p,happy>Most of the rocks in that cliff are pretty useless, and don't contain much of anything, but there's DEFINITELY some blurite in there.");
-    ~chatnpc("<p,default>You'll need a little bit of mining experience to be able to find it.");
+    ~chatnpc("<p,neutral>Most of the rocks in that cliff are pretty useless, and don't contain much of anything, but there's DEFINITELY some blurite in there.");
+    ~chatnpc("<p,neutral>You'll need a little bit of mining experience to be able to find it.");
     %squire_progress = 6;
     ~chatplayer("<p,neutral>Ok. I'll go and find them then.");
 } else if (%squire_progress = 6) {
@@ -198,9 +198,9 @@ if(inv_total(inv, blurite_ore) >= 1 & inv_total(inv, iron_bar) >= 2) {
     ~chatnpc("<p,happy>Just remember to call in with more pie some time!");
     return;
 } else if(inv_total(inv, blurite_ore) >= 1) {
-    ~chatplayer("<p,default>I don't have enough iron bars...");
+    ~chatplayer("<p,neutral>I don't have enough iron bars...");
 } else {
-    ~chatplayer("<p,default>I don't have any blurite ore yet...");
+    ~chatplayer("<p,neutral>I don't have any blurite ore yet...");
 }
 ~chatnpc("<p,shifty>Better go get some then, huh?");
 

--- a/data/src/scripts/skill_cooking/scripts/cooking_guild.rs2
+++ b/data/src/scripts/skill_cooking/scripts/cooking_guild.rs2
@@ -12,7 +12,7 @@ if ($is_inside = false) {
         return;
     }
     if (inv_total(worn, chefshat) < 1) {
-        ~chatnpc_specific("Head chef", npc_847, "<p,default>You can't come in here unless you're wearing a chef's hat, or something like that.");
+        ~chatnpc_specific("Head chef", npc_847, "<p,neutral>You can't come in here unless you're wearing a chef's hat, or something like that.");
         return;
     }
 }

--- a/data/src/scripts/skill_crafting/scripts/crafting_guild/crafting_guild.rs2
+++ b/data/src/scripts/skill_crafting/scripts/crafting_guild/crafting_guild.rs2
@@ -7,7 +7,7 @@ if (~check_axis(coord, loc_coord, loc_angle) = true) {
     if (inv_total(worn, brown_apron) < 1) {
         ~chatnpc_specific(nc_name(master_crafter), master_crafter, "<p,neutral>Where's your brown apron? You can't come in here unless you're wearing one.");
         if (inv_total(inv, brown_apron) < 1) {
-            ~chatplayer("<p,default>Err... I haven't got one.");
+            ~chatplayer("<p,neutral>Err... I haven't got one.");
         }
         return;
     }

--- a/data/src/scripts/skill_mining/scripts/dwarf_mining_guild.rs2
+++ b/data/src/scripts/skill_mining/scripts/dwarf_mining_guild.rs2
@@ -5,18 +5,18 @@
 [label,dwarf_at_entrance]
 switch_int(~p_choice2("What have you got in the guild?", 0, "No thanks, I'm fine.", 2)) {
     case 0:
-    ~chatplayer("<p,quiz>What have you to in the guild?");
+    ~chatplayer("<p,quiz>What have you got in the guild?");
     ~chatnpc("<p,happy>Ooh, it's WONDERFUL! There are lots of coal rocks, and even a few mithril rocks in the guild, all exclusively for people with atleast level 60 mining.");
     ~chatnpc("<p,happy>There's no better mining site anywhere near here.");
     if (stat(mining) > 60) {
         ~chatplayer("<p,happy>It's a good thing I have level <tostring(stat(mining))> Mining.");
         ~chatnpc("<p,happy>Yes, that's amazing! Did you want anything else?");
     } else {
-        ~chatplayer("<p,default>So you won't let me go in there?");
-        ~chatnpc("<p,default>Sorry, but rules are rules.|Go do some more training first.|Can I help you with anything else?");
+        ~chatplayer("<p,neutral>So you won't let me go in there?");
+        ~chatnpc("<p,neutral>Sorry, but rules are rules.|Go do some more training first.|Can I help you with anything else?");
     }
     @dwarf_at_entrance;
 
     case 2:
-    ~chatplayer("<p,quiz>No thanks, I'm fine.");
+    ~chatplayer("<p,bored>No thanks, I'm fine.");
 }

--- a/data/src/scripts/tutorial/scripts/guides/quest_guide.rs2
+++ b/data/src/scripts/tutorial/scripts/guides/quest_guide.rs2
@@ -31,11 +31,11 @@ switch_int(%tutorial_progress) {
 def_int $choice = ~p_choice2("Yes!", 1, "Nope, I'm ready to move on!", 2);
 
 if ($choice = 1) {
-    ~chatplayer("<p,default>Yes!");
+    ~chatplayer("<p,neutral>Yes!");
     ~quest_guide_journal_info_no_intro;
 } else {
-    ~chatplayer("<p,default>Nope, I'm ready to move on!");
-    ~chatnpc("<p,default>Okay then.");
+    ~chatplayer("<p,neutral>Nope, I'm ready to move on!");
+    ~chatnpc("<p,neutral>Okay then.");
 }
 
 [label,quest_guide_not_ready_to_leave_yet]

--- a/data/src/scripts/tutorial/scripts/guides/runescape_guide.rs2
+++ b/data/src/scripts/tutorial/scripts/guides/runescape_guide.rs2
@@ -9,7 +9,7 @@ switch_int(%tutorial_progress) {
 
 [label,runescape_guide_welcome]
 if (map_production = false) {
-    ~chatnpc("<p,default>Do you want to skip the tutorial?");
+    ~chatnpc("<p,neutral>Do you want to skip the tutorial?");
     def_int $choice = ~p_choice2("Yes please.", 1, "No, thank you.", 2);
     if ($choice = 1) {
         %tutorial_progress = ^tutorial_complete;

--- a/data/src/scripts/tutorial/scripts/guides/survival_guide.rs2
+++ b/data/src/scripts/tutorial/scripts/guides/survival_guide.rs2
@@ -113,35 +113,35 @@ switch_int($choice) {
 }
 
 [proc,survival_recap_skills]
-~chatplayer("<p,default>Tell me about my stats again.");
+~chatplayer("<p,neutral>Tell me about my stats again.");
 ~chatnpc("<p,neutral>To look at your stats, click on the bar graph icon found near your backpack icon. You can check your skill levels here.");
 // OSRS specific
 //~chatnpc("<p,neutral>Every skill is listed in the skills menu. Here you can see what your current levels are and how much experience you have.");
 ~chatnpc("<p,neutral>As you move your mouse over any of the icons here, look at the bottom of the menu and you will see the exact amount of experience you have and how much is needed to get to the next level.");
 // Re-enable this line when we get skill menus.
-//~chatnpc("<p,default>You can also click on a skill to open the relevant skillguide. In the skillguide, you can see all of the unlocks available in that skill. ");
+//~chatnpc("<p,neutral>You can also click on a skill to open the relevant skillguide. In the skillguide, you can see all of the unlocks available in that skill. ");
 
 [proc,survival_recap_woodcutting]
-~chatplayer("<p,default>Tell me about Woodcutting again.");
+~chatplayer("<p,neutral>Tell me about Woodcutting again.");
 ~chatnpc("<p,neutral>Woodcutting, eh? Don't worry, newcomer, it's really very easy. Simply equip your axe and click on a nearby tree to chop away.");
 ~chatnpc("<p,neutral>As you explore the mainland you will discover many different kinds of trees that will require different levels of Woodcutting to chop down.");
 ~chatnpc("<p,neutral>Logs are not only useful for making fires. Many archers use the skill known as Fletching to craft their own bows and arrows from trees.");
 
 [proc,survival_recap_fishing]
-~chatplayer("<p,default>Tell me about Fishing again.");
+~chatplayer("<p,neutral>Tell me about Fishing again.");
 ~chatnpc("<p,neutral>Ah, yes. Fishing! Fishing is undoubtedly one the more popular hobbies here in Runescape!");
 ~chatnpc("<p,neutral>Whenever you see sparkling waters, you can be sure there's probably some good fishing to be had there!");
 ~chatnpc("<p,neutral>Not only are fish absolutely delicious when cooked, there are always fighters willing to buy a well cooked fish when they're low on health.");
 ~chatnpc("<p,quiz>I would recommend everybody has a go at Fishing at least once in their lives! Was there anything else you wished to hear again?");
 
 [proc,survival_recap_firemaking]
-~chatplayer("<p,default>Tell me about Firemaking again.");
+~chatplayer("<p,neutral>Tell me about Firemaking again.");
 ~chatnpc("<p,neutral>Certainly, newcomer. When you have logs simply use your tinderbox on then. If successful, you will start a fire.");
 ~chatnpc("<p,neutral>You can also set fire to logs you find lying on the floor already, and some other things can also be set alight...");
 ~chatnpc("<p,neutral>A tinderbox is always a useful item to keep around!");
 
 [proc,survival_recap_cooking]
-~chatplayer("<p,default>Tell me about Cooking again.");
+~chatplayer("<p,neutral>Tell me about Cooking again.");
 ~chatnpc("<p,neutral>Yes, the most basic of survival techniques. Most simple meals can be cooked on a fire by right clicking on the food, selecting use, then left clicking on the fire.");
 ~chatnpc("<p,neutral>Eating food will restore a little health. The harder something is to cook, the more it will heal you. Somewhere around here is a chef who will tell you more about food and cooking it.");
 


### PR DESCRIPTION
removes the `default` mesanim as it almost certainly doesn't exist (591 is always used as 4-line neutral, no leaks have ever shown it being used)