### PR TITLE
fix(engine): unable to interact with bordering members locs on free world

### DIFF
--- a/src/lostcity/engine/GameMap.ts
+++ b/src/lostcity/engine/GameMap.ts
@@ -15,10 +15,10 @@ import EntityLifeCycle from '#lostcity/entity/EntityLifeCycle.js';
 import Loc from '#lostcity/entity/Loc.js';
 import { Position } from '#lostcity/entity/Position.js';
 
-import Environment from '#lostcity/util/Environment.js';
-
 import { LocAngle, LocLayer } from '@2004scape/rsmod-pathfinder';
 import * as rsmod from '@2004scape/rsmod-pathfinder';
+import Zone from '#lostcity/engine/zone/Zone.js';
+import ZoneGrid from '#lostcity/engine/zone/ZoneGrid.js';
 
 export default class GameMap {
     private static readonly OPEN: number = 0x0;
@@ -34,10 +34,19 @@ export default class GameMap {
 
     private static readonly MAPSQUARE: number = GameMap.X * GameMap.Y * GameMap.Z;
 
-    private multimap: Set<number> = new Set();
-    private freemap: Set<number> = new Set();
+    private readonly members: boolean;
+    private readonly zonemap: ZoneMap;
+    private readonly multimap: Set<number>;
+    private readonly freemap: Set<number>;
 
-    init(zoneMap: ZoneMap): void {
+    constructor(members: boolean) {
+        this.members = members;
+        this.zonemap = new ZoneMap();
+        this.multimap = new Set();
+        this.freemap = new Set();
+    }
+
+    init(): void {
         console.time('Loading game map');
 
         this.loadCsvMap(this.multimap, fs.readFileSync('data/src/maps/multiway.csv', 'ascii').replace(/\r/g, '').split('\n'));
@@ -51,16 +60,16 @@ export default class GameMap {
             const mapsquareZ: number = mz << 6;
 
             this.loadNpcs(Packet.load(`${path}n${mx}_${mz}`), mapsquareX, mapsquareZ);
-            this.loadObjs(Packet.load(`${path}o${mx}_${mz}`), mapsquareX, mapsquareZ, zoneMap);
+            this.loadObjs(Packet.load(`${path}o${mx}_${mz}`), mapsquareX, mapsquareZ);
             // collision
             const lands: Int8Array = new Int8Array(GameMap.MAPSQUARE); // 4 * 64 * 64 size is guaranteed for lands
             this.loadGround(lands, Packet.load(`${path}m${mx}_${mz}`), mapsquareX, mapsquareZ);
-            this.loadLocations(lands, Packet.load(`${path}l${mx}_${mz}`), mapsquareX, mapsquareZ, zoneMap);
+            this.loadLocations(lands, Packet.load(`${path}l${mx}_${mz}`), mapsquareX, mapsquareZ);
         }
         console.timeEnd('Loading game map');
     }
 
-    async initAsync(zoneMap: ZoneMap): Promise<void> {
+    async initAsync(): Promise<void> {
         console.time('Loading game map');
         const path: string = 'data/pack/server/maps/';
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -78,11 +87,11 @@ export default class GameMap {
                 await Packet.loadAsync(`${path}l${mx}_${mz}`)]);
 
             this.loadNpcs(npcData, mapsquareX, mapsquareZ);
-            this.loadObjs(objData, mapsquareX, mapsquareZ, zoneMap);
+            this.loadObjs(objData, mapsquareX, mapsquareZ);
             // collision
             const lands: Int8Array = new Int8Array(GameMap.MAPSQUARE); // 4 * 64 * 64 size is guaranteed for lands
             this.loadGround(lands, landData, mapsquareX, mapsquareZ);
-            this.loadLocations(lands, locData, mapsquareX, mapsquareZ, zoneMap);
+            this.loadLocations(lands, locData, mapsquareX, mapsquareZ);
         });
         await Promise.all(maps);
         console.timeEnd('Loading game map');
@@ -172,6 +181,30 @@ export default class GameMap {
         return this.freemap.has(Position.packCoord(0, x, z));
     }
 
+    getZone(x: number, z: number, level: number): Zone {
+        return this.zonemap.zone(x, z, level);
+    }
+
+    getZoneIndex(zoneIndex: number): Zone {
+        return this.zonemap.zoneByIndex(zoneIndex);
+    }
+
+    getZoneGrid(level: number): ZoneGrid {
+        return this.zonemap.grid(level);
+    }
+
+    getTotalZones(): number {
+        return this.zonemap.zoneCount();
+    }
+
+    getTotalLocs(): number {
+        return this.zonemap.locCount();
+    }
+
+    getTotalObjs(): number {
+        return this.zonemap.objCount();
+    }
+
     private loadNpcs(packet: Packet, mapsquareX: number, mapsquareZ: number): void {
         while (packet.available > 0) {
             const { x, z, level } = this.unpackCoord(packet.g2());
@@ -180,20 +213,20 @@ export default class GameMap {
             const count: number = packet.g1();
             for (let index: number = 0; index < count; index++) {
                 const id: number = packet.g2();
-                if (!Environment.NODE_MEMBERS && !this.isFreeToPlay(absoluteX, absoluteZ)) {
+                if (!this.members && !this.isFreeToPlay(absoluteX, absoluteZ)) {
                     continue;
                 }
                 const npcType: NpcType = NpcType.get(id);
                 const size: number = npcType.size;
                 const npc: Npc = new Npc(level, absoluteX, absoluteZ, size, size, EntityLifeCycle.RESPAWN, World.getNextNid(), npcType.id, npcType.moverestrict, npcType.blockwalk);
-                if (npcType.members && Environment.NODE_MEMBERS || !npcType.members) {
+                if (npcType.members && this.members || !npcType.members) {
                     World.addNpc(npc, -1);
                 }
             }
         }
     }
 
-    private loadObjs(packet: Packet, mapsquareX: number, mapsquareZ: number, zoneMap: ZoneMap): void {
+    private loadObjs(packet: Packet, mapsquareX: number, mapsquareZ: number): void {
         while (packet.available > 0) {
             const { x, z, level } = this.unpackCoord(packet.g2());
             const absoluteX: number = mapsquareX + x;
@@ -202,13 +235,13 @@ export default class GameMap {
             for (let index: number = 0; index < count; index++) {
                 const id: number = packet.g2();
                 const count: number = packet.g1();
-                if (!Environment.NODE_MEMBERS && !this.isFreeToPlay(absoluteX, absoluteZ)) {
+                if (!this.members && !this.isFreeToPlay(absoluteX, absoluteZ)) {
                     continue;
                 }
                 const objType: ObjType = ObjType.get(id);
                 const obj: Obj = new Obj(level, absoluteX, absoluteZ, EntityLifeCycle.RESPAWN, objType.id, count);
-                if (objType.members && Environment.NODE_MEMBERS || !objType.members) {
-                    zoneMap.zone(obj.x, obj.z, obj.level).addStaticObj(obj);
+                if (objType.members && this.members || !objType.members) {
+                    this.getZone(obj.x, obj.z, obj.level).addStaticObj(obj);
                 }
             }
         }
@@ -243,10 +276,11 @@ export default class GameMap {
                 for (let z: number = 0; z < GameMap.Z; z++) {
                     const absoluteZ: number = z + mapsquareZ;
 
+                    if (!this.members && !this.isFreeToPlay(absoluteX, absoluteZ) && !this.bordersFreeToPlay(absoluteX, absoluteZ)) {
+                        continue;
+                    }
+
                     if (x % 7 === 0 && z % 7 === 0) { // allocate per zone
-                        if (!Environment.NODE_MEMBERS && !this.isFreeToPlay(absoluteX, absoluteZ)) {
-                            continue;
-                        }
                         rsmod.allocateIfAbsent(absoluteX, absoluteZ, level);
                     }
 
@@ -272,7 +306,7 @@ export default class GameMap {
         }
     }
 
-    private loadLocations(lands: Int8Array, packet: Packet, mapsquareX: number, mapsquareZ: number, zoneMap: ZoneMap): void {
+    private loadLocations(lands: Int8Array, packet: Packet, mapsquareX: number, mapsquareZ: number): void {
         let locId: number = -1;
         let locIdOffset: number = packet.gsmart();
         while (locIdOffset !== 0) {
@@ -290,7 +324,7 @@ export default class GameMap {
                 const absoluteX: number = x + mapsquareX;
                 const absoluteZ: number = z + mapsquareZ;
 
-                if (!Environment.NODE_MEMBERS && !this.isFreeToPlay(absoluteX, absoluteZ)) {
+                if (!this.members && !this.isFreeToPlay(absoluteX, absoluteZ) && !this.bordersFreeToPlay(absoluteX, absoluteZ)) {
                     continue;
                 }
 
@@ -306,7 +340,7 @@ export default class GameMap {
                 const shape: number = info >> 2;
                 const angle: number = info & 0x3;
 
-                zoneMap.zone(absoluteX, absoluteZ, actualLevel).addStaticLoc(new Loc(actualLevel, absoluteX, absoluteZ, width, length, EntityLifeCycle.RESPAWN, locId, shape, angle));
+                this.getZone(absoluteX, absoluteZ, actualLevel).addStaticLoc(new Loc(actualLevel, absoluteX, absoluteZ, width, length, EntityLifeCycle.RESPAWN, locId, shape, angle));
 
                 if (type.blockwalk) {
                     this.changeLocCollision(shape, angle, type.blockrange, length, width, type.active, absoluteX, absoluteZ, actualLevel, true);
@@ -364,5 +398,9 @@ export default class GameMap {
         const x: number = (packed >> 6) & 0x3f;
         const level: number = (packed >> 12) & 0x3;
         return { x, z, level };
+    }
+
+    private bordersFreeToPlay(x: number, z: number): boolean {
+        return this.isFreeToPlay(x + 1, z) || this.isFreeToPlay(x - 1, z) || this.isFreeToPlay(x, z + 1) || this.isFreeToPlay(x, z - 1);
     }
 }

--- a/src/lostcity/engine/GameMap.ts
+++ b/src/lostcity/engine/GameMap.ts
@@ -6,8 +6,10 @@ import NpcType from '#lostcity/cache/config/NpcType.js';
 import ObjType from '#lostcity/cache/config/ObjType.js';
 import LocType from '#lostcity/cache/config/LocType.js';
 
-import ZoneMap from '#lostcity/engine/zone/ZoneMap.js';
 import World from '#lostcity/engine/World.js';
+import Zone from '#lostcity/engine/zone/Zone.js';
+import ZoneGrid from '#lostcity/engine/zone/ZoneGrid.js';
+import ZoneMap from '#lostcity/engine/zone/ZoneMap.js';
 
 import Npc from '#lostcity/entity/Npc.js';
 import Obj from '#lostcity/entity/Obj.js';
@@ -17,8 +19,6 @@ import { Position } from '#lostcity/entity/Position.js';
 
 import { LocAngle, LocLayer } from '@2004scape/rsmod-pathfinder';
 import * as rsmod from '@2004scape/rsmod-pathfinder';
-import Zone from '#lostcity/engine/zone/Zone.js';
-import ZoneGrid from '#lostcity/engine/zone/ZoneGrid.js';
 
 export default class GameMap {
     private static readonly OPEN: number = 0x0;

--- a/src/lostcity/engine/Login.ts
+++ b/src/lostcity/engine/Login.ts
@@ -164,7 +164,7 @@ class Login {
 
                 const player = World.getPlayerByUsername(username);
                 if (player) {
-                    World.getZone(player.x, player.z, player.level).leave(player);
+                    World.gameMap.getZone(player.x, player.z, player.level).leave(player);
                     World.players.remove(player.pid);
                     player.pid = -1;
                     player.terminate();

--- a/src/lostcity/engine/World.ts
+++ b/src/lostcity/engine/World.ts
@@ -65,8 +65,6 @@ import {makeCrcs, makeCrcsAsync} from '#lostcity/server/CrcTable.js';
 import {preloadClient, preloadClientAsync} from '#lostcity/server/PreloadedPacks.js';
 import {Position} from '#lostcity/entity/Position.js';
 import UpdateRebootTimer from '#lostcity/network/outgoing/model/UpdateRebootTimer.js';
-import ZoneGrid from '#lostcity/engine/zone/ZoneGrid.js';
-import ZoneMap from '#lostcity/engine/zone/ZoneMap.js';
 import WorldStat from '#lostcity/engine/WorldStat.js';
 import { FriendsServerOpcodes } from '#lostcity/server/FriendsServer.js';
 import UpdateFriendList from '#lostcity/network/outgoing/model/UpdateFriendList.js';
@@ -89,9 +87,11 @@ class World {
     private static readonly TIMEOUT_IDLE_TICKS: number = 75;
     private static readonly TIMEOUT_LOGOUT_TICKS: number = 100;
 
+    // the game/zones map
     readonly gameMap: GameMap;
-    readonly zoneMap: ZoneMap;
-    readonly invs: Set<Inventory>; // shared inventories (shops)
+
+    // shared inventories (shops)
+    readonly invs: Set<Inventory>;
 
     // entities
     readonly newPlayers: Set<Player>; // players joining at the end of this tick
@@ -123,8 +123,7 @@ class World {
     devMTime: Map<string, number> = new Map();
 
     constructor() {
-        this.gameMap = new GameMap();
-        this.zoneMap = new ZoneMap();
+        this.gameMap = new GameMap(Environment.NODE_MEMBERS);
         this.invs = new Set();
         this.newPlayers = new Set();
         this.players = new PlayerList(World.PLAYERS - 1);
@@ -411,14 +410,14 @@ class World {
             this.reload();
 
             if (!skipMaps) {
-                this.gameMap.init(this.zoneMap);
+                this.gameMap.init();
             }
         } else {
             console.time('World ready');
             await this.loadAsync();
 
             if (!skipMaps) {
-                await this.gameMap.initAsync(this.zoneMap);
+                await this.gameMap.initAsync();
             }
             console.timeEnd('World ready');
         }
@@ -980,7 +979,7 @@ class World {
             player.uid = ((Number(player.username37 & 0x1fffffn) << 11) | player.pid) >>> 0;
             player.tele = true;
 
-            this.getZone(player.x, player.z, player.level).enter(player);
+            this.gameMap.getZone(player.x, player.z, player.level).enter(player);
             player.onLogin(); // todo: check response from login script?
 
             if (this.shutdownTick > -1) {
@@ -1248,18 +1247,6 @@ class World {
         return inventory;
     }
 
-    getZone(x: number, z: number, level: number): Zone {
-        return this.zoneMap.zone(x, z, level);
-    }
-
-    getZoneIndex(zoneIndex: number): Zone {
-        return this.zoneMap.zoneByIndex(zoneIndex);
-    }
-
-    getZoneGrid(level: number): ZoneGrid {
-        return this.zoneMap.grid(level);
-    }
-
     computeSharedEvents(): void {
         const zones: Set<number> = new Set();
         for (const player of this.players) {
@@ -1271,7 +1258,7 @@ class World {
             }
         }
         for (const zoneIndex of zones) {
-            this.getZoneIndex(zoneIndex).computeShared();
+            this.gameMap.getZoneIndex(zoneIndex).computeShared();
         }
     }
 
@@ -1280,7 +1267,7 @@ class World {
         npc.x = npc.startX;
         npc.z = npc.startZ;
 
-        const zone = this.getZone(npc.x, npc.z, npc.level);
+        const zone = this.gameMap.getZone(npc.x, npc.z, npc.level);
         zone.enter(npc);
 
         switch (npc.blockWalk) {
@@ -1300,7 +1287,7 @@ class World {
     }
 
     removeNpc(npc: Npc, duration: number): void {
-        const zone = this.getZone(npc.x, npc.z, npc.level);
+        const zone = this.gameMap.getZone(npc.x, npc.z, npc.level);
         zone.leave(npc);
 
         switch (npc.blockWalk) {
@@ -1321,11 +1308,11 @@ class World {
     }
 
     getLoc(x: number, z: number, level: number, locId: number): Loc | null {
-        return this.getZone(x, z, level).getLoc(x, z, locId);
+        return this.gameMap.getZone(x, z, level).getLoc(x, z, locId);
     }
 
     getObj(x: number, z: number, level: number, objId: number, receiverId: number): Obj | null {
-        return this.getZone(x, z, level).getObj(x, z, objId, receiverId);
+        return this.gameMap.getZone(x, z, level).getObj(x, z, objId, receiverId);
     }
 
     trackZone(tick: number, zone: Zone): void {
@@ -1347,7 +1334,7 @@ class World {
             this.gameMap.changeLocCollision(loc.shape, loc.angle, type.blockrange, type.length, type.width, type.active, loc.x, loc.z, loc.level, true);
         }
 
-        const zone: Zone = this.getZone(loc.x, loc.z, loc.level);
+        const zone: Zone = this.gameMap.getZone(loc.x, loc.z, loc.level);
         zone.addLoc(loc);
         loc.setLifeCycle(this.currentTick + duration);
         this.trackZone(this.currentTick + duration, zone);
@@ -1356,14 +1343,14 @@ class World {
 
     mergeLoc(loc: Loc, player: Player, startCycle: number, endCycle: number, south: number, east: number, north: number, west: number): void {
         // console.log(`[World] mergeLoc => name: ${LocType.get(loc.type).name}`);
-        const zone: Zone = this.getZone(loc.x, loc.z, loc.level);
+        const zone: Zone = this.gameMap.getZone(loc.x, loc.z, loc.level);
         zone.mergeLoc(loc, player, startCycle, endCycle, south, east, north, west);
         this.trackZone(this.currentTick, zone);
     }
 
     animLoc(loc: Loc, seq: number): void {
         // console.log(`[World] animLoc => name: ${LocType.get(loc.type).name}, seq: ${seq}`);
-        const zone: Zone = this.getZone(loc.x, loc.z, loc.level);
+        const zone: Zone = this.gameMap.getZone(loc.x, loc.z, loc.level);
         zone.animLoc(loc, seq);
         this.trackZone(this.currentTick, zone);
     }
@@ -1375,7 +1362,7 @@ class World {
             this.gameMap.changeLocCollision(loc.shape, loc.angle, type.blockrange, type.length, type.width, type.active, loc.x, loc.z, loc.level, false);
         }
 
-        const zone: Zone = this.getZone(loc.x, loc.z, loc.level);
+        const zone: Zone = this.gameMap.getZone(loc.x, loc.z, loc.level);
         zone.removeLoc(loc);
         loc.setLifeCycle(this.currentTick + duration);
         this.trackZone(this.currentTick + duration, zone);
@@ -1395,7 +1382,7 @@ class World {
                 return;
             }
         }
-        const zone: Zone = this.getZone(obj.x, obj.z, obj.level);
+        const zone: Zone = this.gameMap.getZone(obj.x, obj.z, obj.level);
         zone.addObj(obj, receiverId);
         if (receiverId !== -1 && objType.tradeable && (objType.members && Environment.NODE_MEMBERS || !objType.members)) {
             // objs always reveal 100 ticks after being dropped.
@@ -1416,7 +1403,7 @@ class World {
         // console.log(`[World] revealObj => name: ${ObjType.get(obj.type).name}`);
         const duration: number = obj.reveal;
         const change: number = obj.lastChange;
-        const zone: Zone = this.getZone(obj.x, obj.z, obj.level);
+        const zone: Zone = this.gameMap.getZone(obj.x, obj.z, obj.level);
         zone.revealObj(obj, obj.receiverId);
         // objs next life cycle always starts from the last time they changed + the inputted duration.
         // accounting for reveal time here.
@@ -1428,14 +1415,14 @@ class World {
 
     changeObj(obj: Obj, receiverId: number, newCount: number): void {
         // console.log(`[World] changeObj => name: ${ObjType.get(obj.type).name}, receiverId: ${receiverId}, newCount: ${newCount}`);
-        const zone: Zone = this.getZone(obj.x, obj.z, obj.level);
+        const zone: Zone = this.gameMap.getZone(obj.x, obj.z, obj.level);
         zone.changeObj(obj, receiverId, obj.count, newCount);
         this.trackZone(this.currentTick, zone);
     }
 
     removeObj(obj: Obj, duration: number): void {
         // console.log(`[World] removeObj => name: ${ObjType.get(obj.type).name}, duration: ${duration}`);
-        const zone: Zone = this.getZone(obj.x, obj.z, obj.level);
+        const zone: Zone = this.gameMap.getZone(obj.x, obj.z, obj.level);
         zone.removeObj(obj);
         obj.setLifeCycle(this.currentTick + duration);
         this.trackZone(this.currentTick + duration, zone);
@@ -1443,13 +1430,13 @@ class World {
     }
 
     animMap(level: number, x: number, z: number, spotanim: number, height: number, delay: number): void {
-        const zone: Zone = this.getZone(x, z, level);
+        const zone: Zone = this.gameMap.getZone(x, z, level);
         zone.animMap(x, z, spotanim, height, delay);
         this.trackZone(this.currentTick, zone);
     }
 
     mapProjAnim(level: number, x: number, z: number, dstX: number, dstZ: number, target: number, spotanim: number, srcHeight: number, dstHeight: number, startDelay: number, endDelay: number, peak: number, arc: number): void {
-        const zone: Zone = this.getZone(x, z, level);
+        const zone: Zone = this.gameMap.getZone(x, z, level);
         zone.mapProjAnim(x, z, dstX, dstZ, target, spotanim, srcHeight, dstHeight, startDelay, endDelay, peak, arc);
         this.trackZone(this.currentTick, zone);
     }
@@ -1590,18 +1577,6 @@ class World {
 
     getTotalNpcs(): number {
         return this.npcs.count;
-    }
-
-    getTotalZones(): number {
-        return this.zoneMap.zoneCount();
-    }
-
-    getTotalLocs(): number {
-        return this.zoneMap.locCount();
-    }
-
-    getTotalObjs(): number {
-        return this.zoneMap.objCount();
     }
 
     getNpc(nid: number): Npc | undefined {

--- a/src/lostcity/engine/script/ScriptIterators.ts
+++ b/src/lostcity/engine/script/ScriptIterators.ts
@@ -87,7 +87,7 @@ export class HuntIterator extends ScriptIterator<Entity> {
                 const zoneZ: number = z << 3;
 
                 if (this.type === HuntModeType.PLAYER) {
-                    for (const player of World.getZone(zoneX, zoneZ, this.level).getAllPlayersSafe()) {
+                    for (const player of World.gameMap.getZone(zoneX, zoneZ, this.level).getAllPlayersSafe()) {
                         if (World.currentTick > this.tick) {
                             throw new Error('[HuntIterator] tried to use an old iterator. Create a new iterator instead.');
                         }
@@ -103,7 +103,7 @@ export class HuntIterator extends ScriptIterator<Entity> {
                         yield player;
                     }
                 } else if (this.type === HuntModeType.NPC) {
-                    for (const npc of World.getZone(zoneX, zoneZ, this.level).getAllNpcsSafe()) {
+                    for (const npc of World.gameMap.getZone(zoneX, zoneZ, this.level).getAllNpcsSafe()) {
                         if (World.currentTick > this.tick) {
                             throw new Error('[HuntIterator] tried to use an old iterator. Create a new iterator instead.');
                         }
@@ -127,7 +127,7 @@ export class HuntIterator extends ScriptIterator<Entity> {
                     }
                 } else if (this.type === HuntModeType.OBJ) {
                     // scripting only cares about dynamic objs??
-                    for (const obj of World.getZone(zoneX, zoneZ, this.level).getAllObjsSafe()) {
+                    for (const obj of World.gameMap.getZone(zoneX, zoneZ, this.level).getAllObjsSafe()) {
                         if (World.currentTick > this.tick) {
                             throw new Error('[HuntIterator] tried to use an old iterator. Create a new iterator instead.');
                         }
@@ -150,7 +150,7 @@ export class HuntIterator extends ScriptIterator<Entity> {
                         yield obj;
                     }
                 } else if (this.type === HuntModeType.SCENERY) {
-                    for (const loc of World.getZone(zoneX, zoneZ, this.level).getAllLocsSafe()) {
+                    for (const loc of World.gameMap.getZone(zoneX, zoneZ, this.level).getAllLocsSafe()) {
                         if (World.currentTick > this.tick) {
                             throw new Error('[HuntIterator] tried to use an old iterator. Create a new iterator instead.');
                         }
@@ -224,7 +224,7 @@ export class NpcHuntAllCommandIterator extends ScriptIterator<Entity> {
             for (let z: number = this.maxZ; z >= this.minZ; z--) {
                 const zoneZ: number = z << 3;
 
-                for (const npc of World.getZone(zoneX, zoneZ, this.level).getAllNpcsSafe()) {
+                for (const npc of World.gameMap.getZone(zoneX, zoneZ, this.level).getAllNpcsSafe()) {
                     if (World.currentTick > this.tick) {
                         throw new Error('[HuntIterator] tried to use an old iterator. Create a new iterator instead.');
                     }
@@ -282,7 +282,7 @@ export class NpcIterator extends ScriptIterator<Npc> {
 
     protected *generator(): IterableIterator<Npc> {
         if (this.type === NpcIteratorType.ZONE) {
-            for (const npc of World.getZone(this.x, this.z, this.level).getAllNpcsSafe()) {
+            for (const npc of World.gameMap.getZone(this.x, this.z, this.level).getAllNpcsSafe()) {
                 if (World.currentTick > this.tick) {
                     throw new Error('[NpcIterator] tried to use an old iterator. Create a new iterator instead.');
                 }
@@ -293,7 +293,7 @@ export class NpcIterator extends ScriptIterator<Npc> {
                 const zoneX: number = x << 3;
                 for (let z: number = this.maxZ; z >= this.minZ; z--) {
                     const zoneZ: number = z << 3;
-                    for (const npc of World.getZone(zoneX, zoneZ, this.level).getAllNpcsSafe()) {
+                    for (const npc of World.gameMap.getZone(zoneX, zoneZ, this.level).getAllNpcsSafe()) {
                         if (World.currentTick > this.tick) {
                             throw new Error('[NpcIterator] tried to use an old iterator. Create a new iterator instead.');
                         }
@@ -327,7 +327,7 @@ export class LocIterator extends ScriptIterator<Loc> {
     }
 
     protected *generator(): IterableIterator<Loc> {
-        for (const loc of World.getZone(this.x, this.z, this.level).getAllLocsSafe()) {
+        for (const loc of World.gameMap.getZone(this.x, this.z, this.level).getAllLocsSafe()) {
             if (World.currentTick > this.tick) {
                 throw new Error('[LocIterator] tried to use an old iterator. Create a new iterator instead.');
             }

--- a/src/lostcity/engine/script/handlers/LocOps.ts
+++ b/src/lostcity/engine/script/handlers/LocOps.ts
@@ -38,7 +38,7 @@ const LocOps: CommandHandlers = {
         check(duration, DurationValid);
 
         const created: Loc = new Loc(position.level, position.x, position.z, locType.width, locType.length, EntityLifeCycle.DESPAWN, locType.id, locShape, locAngle);
-        const locs: IterableIterator<Loc> = World.getZone(position.x, position.z, position.level).getLocsUnsafe(Position.packZoneCoord(position.x, position.z));
+        const locs: IterableIterator<Loc> = World.gameMap.getZone(position.x, position.z, position.level).getLocsUnsafe(Position.packZoneCoord(position.x, position.z));
         for (const loc of locs) {
             if (loc !== created && loc.angle === locAngle && loc.shape === locShape) {
                 World.removeLoc(loc, duration);
@@ -78,7 +78,7 @@ const LocOps: CommandHandlers = {
 
         const {level, x, z, angle, shape} = state.activeLoc;
         const created: Loc = new Loc(level, x, z, locType.width, locType.length, EntityLifeCycle.DESPAWN, locType.id, shape, angle);
-        const locs: IterableIterator<Loc> = World.getZone(x, z, level).getLocsUnsafe(Position.packZoneCoord(x, z));
+        const locs: IterableIterator<Loc> = World.gameMap.getZone(x, z, level).getLocsUnsafe(Position.packZoneCoord(x, z));
         for (const loc of locs) {
             if (loc !== created && loc.angle === angle && loc.shape === shape) {
                 World.removeLoc(loc, duration);
@@ -99,7 +99,7 @@ const LocOps: CommandHandlers = {
         const duration: number = check(state.popInt(), DurationValid);
 
         const {level, x, z, angle, shape} = state.activeLoc;
-        const locs: IterableIterator<Loc> = World.getZone(x, z, level).getLocsUnsafe(Position.packZoneCoord(x, z));
+        const locs: IterableIterator<Loc> = World.gameMap.getZone(x, z, level).getLocsUnsafe(Position.packZoneCoord(x, z));
         for (const loc of locs) {
             if (loc !== state.activeLoc && loc.angle === angle && loc.shape === shape) {
                 World.removeLoc(loc, duration);

--- a/src/lostcity/engine/script/handlers/ObjOps.ts
+++ b/src/lostcity/engine/script/handlers/ObjOps.ts
@@ -143,7 +143,7 @@ const ObjOps: CommandHandlers = {
 
         const obj: Obj = state.activeObj;
         const objType = ObjType.get(obj.type);
-        const zone: Zone = World.getZone(obj.x, obj.z, obj.level);
+        const zone: Zone = World.gameMap.getZone(obj.x, obj.z, obj.level);
         for (const o of zone.getObjsSafe(Position.packZoneCoord(obj.x, obj.z))) {
             if (o.type !== obj.type || o.count !== obj.count) {
                 continue;

--- a/src/lostcity/engine/script/handlers/ServerOps.ts
+++ b/src/lostcity/engine/script/handlers/ServerOps.ts
@@ -58,7 +58,7 @@ const ServerOps: CommandHandlers = {
         let count = 0;
         for (let x = Math.floor(from.x / 8); x <= Math.ceil(to.x / 8); x++) {
             for (let z = Math.floor(from.z / 8); z <= Math.ceil(to.z / 8); z++) {
-                for (const player of World.getZone(x << 3, z << 3, from.level).getAllPlayersSafe()) {
+                for (const player of World.gameMap.getZone(x << 3, z << 3, from.level).getAllPlayersSafe()) {
                     if (player.x >= from.x && player.x <= to.x && player.z >= from.z && player.z <= to.z) {
                         count++;
                     }
@@ -347,7 +347,7 @@ const ServerOps: CommandHandlers = {
     [ScriptOpcode.MAP_LOCADDUNSAFE]: state => {
         const pos: Position = check(state.popInt(), CoordValid);
 
-        for (const loc of World.getZone(pos.x, pos.z, pos.level).getAllLocsUnsafe()) {
+        for (const loc of World.gameMap.getZone(pos.x, pos.z, pos.level).getAllLocsUnsafe()) {
             const type = check(loc.type, LocTypeValid);
 
             if (type.active !== 1) {
@@ -391,15 +391,15 @@ const ServerOps: CommandHandlers = {
     },
 
     [ScriptOpcode.ZONECOUNT]: state => {
-        state.pushInt(World.getTotalZones());
+        state.pushInt(World.gameMap.getTotalZones());
     },
 
     [ScriptOpcode.LOCCOUNT]: state => {
-        state.pushInt(World.getTotalLocs());
+        state.pushInt(World.gameMap.getTotalLocs());
     },
 
     [ScriptOpcode.OBJCOUNT]: state => {
-        state.pushInt(World.getTotalObjs());
+        state.pushInt(World.gameMap.getTotalObjs());
     },
 
     [ScriptOpcode.MAP_FINDSQUARE]: state => {

--- a/src/lostcity/engine/zone/Zone.ts
+++ b/src/lostcity/engine/zone/Zone.ts
@@ -71,7 +71,7 @@ export default class Zone {
     enter(entity: PathingEntity): void {
         if (entity instanceof Player) {
             this.players.add(entity.uid);
-            World.getZoneGrid(this.level).flag(this.x, this.z);
+            World.gameMap.getZoneGrid(this.level).flag(this.x, this.z);
         } else if (entity instanceof Npc) {
             this.npcs.add(entity.nid);
         }
@@ -81,7 +81,7 @@ export default class Zone {
         if (entity instanceof Player) {
             this.players.delete(entity.uid);
             if (this.players.size === 0) {
-                World.getZoneGrid(this.level).unflag(this.x, this.z);
+                World.gameMap.getZoneGrid(this.level).unflag(this.x, this.z);
             }
         } else if (entity instanceof Npc) {
             this.npcs.delete(entity.nid);

--- a/src/lostcity/entity/BuildArea.ts
+++ b/src/lostcity/entity/BuildArea.ts
@@ -77,7 +77,7 @@ export default class BuildArea {
 
     *getNearbyPlayers(uid: number, x: number, z: number, originX: number, originZ: number): IterableIterator<Player> {
         players: for (const zoneIndex of this.proximitySort(x, z, this.activeZones)) {
-            for (const other of this.getNearby(World.getZoneIndex(zoneIndex).getAllPlayersSafe(), x, z, originX, originZ, this.viewDistance)) {
+            for (const other of this.getNearby(World.gameMap.getZoneIndex(zoneIndex).getAllPlayersSafe(), x, z, originX, originZ, this.viewDistance)) {
                 if (this.players.size >= BuildArea.PREFERRED_PLAYERS) {
                     break players;
                 }
@@ -94,7 +94,7 @@ export default class BuildArea {
 
     *getNearbyNpcs(x: number, z: number, originX: number, originZ: number): IterableIterator<Npc> {
         npcs: for (const zoneIndex of this.proximitySort(x, z, this.activeZones)) {
-            for (const npc of this.getNearby(World.getZoneIndex(zoneIndex).getAllNpcsSafe(), x, z, originX, originZ, 15)) {
+            for (const npc of this.getNearby(World.gameMap.getZoneIndex(zoneIndex).getAllNpcsSafe(), x, z, originX, originZ, 15)) {
                 if (this.npcs.size >= BuildArea.PREFERRED_NPCS) {
                     break npcs;
                 }

--- a/src/lostcity/entity/NetworkPlayer.ts
+++ b/src/lostcity/entity/NetworkPlayer.ts
@@ -296,7 +296,7 @@ export class NetworkPlayer extends Player {
 
         // update active zones
         for (const zoneIndex of activeZones) {
-            const zone: Zone = World.getZoneIndex(zoneIndex);
+            const zone: Zone = World.gameMap.getZoneIndex(zoneIndex);
             if (!loadedZones.has(zone.index)) {
                 zone.writeFullFollows(this);
             }

--- a/src/lostcity/entity/Npc.ts
+++ b/src/lostcity/entity/Npc.ts
@@ -843,7 +843,7 @@ export default class Npc extends PathingEntity {
         if (hunt.type === HuntModeType.OFF) {
             return;
         }
-        if (hunt.nobodyNear === HuntNobodyNear.PAUSEHUNT && !World.getZoneGrid(this.level).isFlagged(Position.zone(this.x), Position.zone(this.z), 5)) {
+        if (hunt.nobodyNear === HuntNobodyNear.PAUSEHUNT && !World.gameMap.getZoneGrid(this.level).isFlagged(Position.zone(this.x), Position.zone(this.z), 5)) {
             return;
         }
         if (!hunt.findKeepHunting && this.target !== null) {

--- a/src/lostcity/entity/PathingEntity.ts
+++ b/src/lostcity/entity/PathingEntity.ts
@@ -183,8 +183,8 @@ export default abstract class PathingEntity extends Entity {
         }
 
         if (Position.zone(previousX) !== Position.zone(this.x) || Position.zone(previousZ) !== Position.zone(this.z) || previousLevel != this.level) {
-            World.getZone(previousX, previousZ, previousLevel).leave(this);
-            World.getZone(this.x, this.z, this.level).enter(this);
+            World.gameMap.getZone(previousX, previousZ, previousLevel).leave(this);
+            World.gameMap.getZone(this.x, this.z, this.level).enter(this);
         }
     }
 


### PR DESCRIPTION
- The fix is the `bordersFreeToPlay` function to check if a members loc borders a free zone, then we do not want to unload it.
- Did refactor `GameMap` and `World` to put `ZoneMap` inside of `GameMap`.