### PR TITLE
chore(engine): typescript `5.5.4`

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "prisma-kysely": "^1.8.0",
     "sort-package-json": "^2.10.0",
     "tinybench": "^2.8.0",
-    "typescript": "^5.4.5",
+    "typescript": "^5.5.4",
     "vitest": "^1.6.0"
   },
   "optionalDependencies": {


### PR DESCRIPTION
Allows for the implicit type guard in https://github.com/2004Scape/Server/blob/main/src/lostcity/server/FriendsServerRepository.ts#L101 to function correctly

@Pazaz I'm not sure how that PR (#817) passed CI / ran locally 🤔 I was able to get the error that @ultraviolet-jordan reported when I changed my IDE to use `5.4.5` explicitly. But I would have expected CI to fail and for the friends server not to run locally...