### PR TITLE
fix(engine): npc_arrivedelay delaying 0-2 ticks 

### DIFF
--- a/data/src/scripts/skill_combat/scripts/npc/npc_death.rs2
+++ b/data/src/scripts/skill_combat/scripts/npc/npc_death.rs2
@@ -1,9 +1,18 @@
+// videos of death:
+// - https://youtu.be/Vsnkdq8OOMg?t=209
+// - https://youtu.be/mrqmLFGEsOE?t=69
+// - https://youtu.be/fZGgcIlfoeI?t=33
+// - https://youtu.be/TiJ7bmcXVK0?t=33
+// - https://youtu.be/OHx58MJ2itw?t=338
+// - https://youtu.be/aJDlEmyPpk8?t=140
+// - https://youtu.be/QCUMECkwUb0?t=103
+
 [proc,npc_death]
 // npc_walk(npc_coord) is unnecessary due to npc_setmode(none).
 // But they do it in this screenshot so might be good to do it here just incase: https://i.imgur.com/AfQ1MfF.png
 npc_walk(npc_coord);
 npc_setmode(none);
-npc_arrivedelay;
+npc_arrivedelay; // arrivedelay for up to two ticks (current osrs too) https://youtu.be/Vsnkdq8OOMg?t=209
 if (finduid(%npc_aggressive_player) = true) {
     if (npc_param(death_sound) ! null) {
         sound_synth(npc_param(death_sound), 0, 0);
@@ -11,5 +20,5 @@ if (finduid(%npc_aggressive_player) = true) {
     %aggressive_npc = null;
 }
 npc_anim(npc_param(death_anim), 0);
-npc_delay(2);
+npc_delay(1); // osrs has an extra tick of delay here. I think this delay can vary from npc to npc
 npc_del;

--- a/data/src/scripts/skill_combat/scripts/player/player_magic.rs2
+++ b/data/src/scripts/skill_combat/scripts/player/player_magic.rs2
@@ -223,6 +223,7 @@ if(npc_type = salarin_the_twisted) {
     }
 }
 // if maxhit is defined then damage npc
+~npc_retaliate(calc($duration / 30 + 1)); // delayed an extra tick in osrs
 if ($maxhit ! null) {
     // damage npc
     // mes("Duration: <tostring($duration)>, Duration (ticks): <tostring(calc($duration / 30))>");
@@ -239,7 +240,6 @@ if ($maxhit ! null) {
 // spell visual
 spotanim_npc(db_getfield($spell_data, magic_spell_table:spotanim_target, 0), $duration);
 // npc auto retal
-~npc_retaliate(calc($duration / 30 + 1)); // delayed an extra tick in osrs
 npc_heropoints($damage);
 
 

--- a/src/lostcity/engine/script/handlers/NpcOps.ts
+++ b/src/lostcity/engine/script/handlers/NpcOps.ts
@@ -480,10 +480,16 @@ const NpcOps: CommandHandlers = {
 
     // https://x.com/JagexAsh/status/1432296606376906752
     [ScriptOpcode.NPC_ARRIVEDELAY]: checkedHandler(ActiveNpc, state => {
-        if (state.activeNpc.lastMovement < World.currentTick) {
+        if (state.activeNpc.lastMovement < World.currentTick - 1) {
             return;
         }
-        state.activeNpc.delay = 1;
+        // if the npc moved 1 tick ago, delay for 2 ticks. If npc moved 2 ticks ago, delay for 1 tick
+        if (state.activeNpc.lastMovement === World.currentTick) {
+            state.activeNpc.delay = 2;
+        } else {
+            state.activeNpc.delay = 1;
+        }
+        
         state.execution = ScriptState.NPC_SUSPENDED;
     }),
 };


### PR DESCRIPTION
reduces 2nd npc_delay in npc_death to match:
- https://youtu.be/Vsnkdq8OOMg?t=209
- https://youtu.be/mrqmLFGEsOE?t=69
- https://youtu.be/fZGgcIlfoeI?t=33
- https://youtu.be/TiJ7bmcXVK0?t=33
- https://youtu.be/OHx58MJ2itw?t=338
- https://youtu.be/aJDlEmyPpk8?t=140
- https://youtu.be/QCUMECkwUb0?t=103

Magic was also always speeding up death (due to auto retal queue being later in the script)