### PR TITLE
fix(content): khazard minions maxranges, koftik dialogue changes:

### DIFF
--- a/data/src/scripts/quests/quest_arena/configs/quest_arena.npc
+++ b/data/src/scripts/quests/quest_arena/configs/quest_arena.npc
@@ -459,7 +459,8 @@ op2=Attack
 vislevel=132
 model1=model_2997_npc
 // wanderrange=TODO
-// maxrange=TODO
+// Guess, based off old videos they will likely hunt through the whole arena: https://youtu.be/qRUXxpnYUp4?si=o4ePw20m2vZrLNBG&t=416
+maxrange=25
 respawnrate=50
 hitpoints=116
 attack=120
@@ -485,7 +486,8 @@ vislevel=55
 model1=model_2880_npc
 model2=model_2876_npc
 // wanderrange=TODO
-// maxrange=TODO
+// Guess, based off old videos they will likely hunt through the whole arena: https://youtu.be/qRUXxpnYUp4?si=o4ePw20m2vZrLNBG&t=416
+maxrange=25
 // TODO respawnrate might be wrong, copying bouncers
 respawnrate=50
 hitpoints=60
@@ -519,7 +521,8 @@ recol2s=11426
 recol2d=6342
 model1=model_2967_npc
 // wanderrange=TODO
-// maxrange=TODO
+// Guess, based off old videos they will likely hunt through the whole arena: https://youtu.be/qRUXxpnYUp4?si=o4ePw20m2vZrLNBG&t=416
+maxrange=25
 // TODO respawnrate might be wrong, copying bouncers
 respawnrate=50
 hitpoints=40

--- a/data/src/scripts/quests/quest_upass/scripts/koftik.rs2
+++ b/data/src/scripts/quests/quest_upass/scripts/koftik.rs2
@@ -34,7 +34,7 @@ switch_int(%upass_progress) {
 [label,koftik_first_dialogue]
 // https://youtu.be/IUzRF8GrfSY?si=iJ9ytVtJONT4ok6q&t=65, https://youtu.be/ZxF473zUZfQ?si=nrGO9gJiP_CbpqJp&t=153
 ~chatplayer("<p,happy>Hello there, are you the King's scout?");
-~chatnpc("<p,happy>That I am, brave adventurer. King Lathas informed me that you need to cross these mountains.");
+~chatnpc("<p,happy>That I am, brave adventurer.|King Lathas informed me|that you need to cross these mountains."); // https://web.archive.org/web/20050421234903/http://www.trillionareguild.com/runescape/underground.php
 ~chatnpc("<p,neutral>I'm afraid you'll have to go through the ancient underground pass...");
 ~chatplayer("<p,happy>That's OK, I've travelled through many a cave in my time.");
 ~chatnpc("<p,shock>These caves are different... They're filled with the spirit of Zamorak!");
@@ -72,6 +72,7 @@ switch_int(%upass_progress) {
             ~chatnpc("<p,neutral>I found this cloth amongst the charred remains of some arrows.");
             ~chatplayer("<p,shock>Charred arrows? They must have been trying to burn something. Or someone!");
             inv_add(inv, damp_cloth, 1);
+            mes("Koftik gives you a damp cloth..."); // https://youtu.be/qGcENRGIcoI?si=k3ay_a8qM1TnQ_kT&t=25
         }
         ~chatplayer("<p,neutral>Interesting... we better keep our eyes open.");
         ~chatnpc("<p,neutral>I have also found the remains of a book...");
@@ -108,7 +109,7 @@ switch_int(%upass_progress) {
         ~chatplayer("<p,happy>Are you OK?");
         ~chatnpc("<p,neutral>The path of the righteous man is beset on all sides by the iniquities of the selfish and the tyranny of evil men.");
         ~chatplayer("<p,happy>Tyranny of the righteous? What?");
-        ~chatnpc("<p,neutral>So many paths to choose... Here we must all take our own path.");
+        ~chatnpc("<p,neutral>So many paths to choose...|Here we must all take our own path."); // https://web.archive.org/web/20050421234903/http://www.trillionareguild.com/runescape/underground.php
 }
 
 [opnpc1,npc_975]


### PR DESCRIPTION
- Define maxranges for khazard minions so they will hunt the player through the whole arena
- Linebreaks for Koftik based off old images
![3_koftik](https://github.com/user-attachments/assets/195fdbf8-f235-4935-af4b-99b66a043ef8)
![8_barbequegrate](https://github.com/user-attachments/assets/ce221548-0fcb-4f36-84ef-e426e09e46f3)
