### PR TITLE
fix(content): tutorial island typos

### DIFF
--- a/data/src/scripts/areas/area_varrock/scripts/kanel.rs2
+++ b/data/src/scripts/areas/area_varrock/scripts/kanel.rs2
@@ -1,2 +1,2 @@
 [opnpc1,kanel]
-mes("The boy is busy playing."); //guess
+mes("The boy is busy playing.");

--- a/data/src/scripts/areas/area_varrock/scripts/philop.rs2
+++ b/data/src/scripts/areas/area_varrock/scripts/philop.rs2
@@ -1,2 +1,2 @@
 [opnpc1,philop]
-mes("The boy is busy playing."); //guess
+mes("The boy is busy playing.");

--- a/data/src/scripts/quests/quest_fluffs/scripts/pet.rs2
+++ b/data/src/scripts/quests/quest_fluffs/scripts/pet.rs2
@@ -17,7 +17,7 @@ def_int $attent = getbit_range(%cat_growth, 5, 10); //attention    (0-40-45-50)
 def_int $growth = getbit_range(%cat_growth, 11,19); //growth       (0-120-320)
 def_int $vermin = getbit_range(%cat_growth, 20,26); //rats caught  (0-100)
 if($attent = 0) { 
-    $attent = 28;
+    $attent = 29; //default attent for a new kitten is supposed to be 28
 }
 if(oc_category(nc_param(npc_type, pet_item_id)) ! overgrown) {
     npc_say("Meow!"); //done every 90s, no random chance
@@ -55,11 +55,7 @@ if(oc_category(nc_param(npc_type, pet_item_id)) = kitten) {
             ~chatplayer("<p,worried>I think it's really hungry!"); 
         case 20:
             mes("Your kitten has run away to look for food.");
-            %follower_obj = null;
-            %follower_uid = null;
-            %cat_growth = 0;
-            p_delay(0);
-            npc_del;
+            ~follower_death;
     }
 
     %cat_growth = setbit_range_toint(%cat_growth, calc($attent + 1), 5, 10);
@@ -72,11 +68,7 @@ if(oc_category(nc_param(npc_type, pet_item_id)) = kitten) {
             ~chatplayer("<p,neutral>I think it's feeling lonely."); //738
         case 50:
             mes("Your kitten got lonely and ran off.");
-            %follower_obj = null;
-            %follower_uid = null;
-            %cat_growth = 0;
-            p_delay(0);
-            npc_del;
+            ~follower_death;
     }
 }
 
@@ -162,14 +154,10 @@ if ($choice = 2) {
 if_close;
 say("Shoo cat!");
 npc_say("Meeeooow!");
-%follower_obj = null;
-%follower_uid = null;
-%cat_growth = 0;
-%npc_attacking_uid = uid;
 npc_setmode(playerescape);
 p_delay(4); //guessed delay
 mes("The cat has run away."); //after or before delay?
-npc_del;
+~follower_death;
 
 [opnpc5,_petcat]
 if (%npc_attacking_uid ! uid | %follower_uid ! npc_uid) {

--- a/data/src/scripts/tutorial/scripts/guides/combat_instructor.rs2
+++ b/data/src/scripts/tutorial/scripts/guides/combat_instructor.rs2
@@ -95,7 +95,7 @@ if (%tutorial_progress = ^combat_instructor_after_rat_kill_melee) {
 ~chatnpc("<p,neutral>Before going into combat with an opponent it is wise to put the mouse over them and see what combat level they are.");
 ~chatnpc("<p,neutral>Green coloured writing usually means it will be an easy fight for you, red means you will probably lose, yellow means they are around your level and orange means they are slightly stronger.");
 ~chatnpc("<p,neutral>Sometimes things will go your way, sometimes they won't. There is no such thing as a guaranteed win, but if the odds are  on your side, you stand the best chance of walking away victorious.");
-~chatnpc("<p,quiz>Now, was there something else you wanted to hear about again.");
+~chatnpc("<p,quiz>Now, was there something else you wanted to hear about again?");
 @combat_instructor_recap_questions;
 
 [label,combat_instructor_melee_combat_recap]

--- a/data/src/scripts/tutorial/scripts/guides/financial_advisor.rs2
+++ b/data/src/scripts/tutorial/scripts/guides/financial_advisor.rs2
@@ -14,7 +14,7 @@ if (%tutorial_progress = ^tutorial_opened_financial_advisor_door) {
 ~chatnpc("<p,neutral>Let's start with combat, as it is probably still fresh in your mind. Many enemies, both human and monster will drop items when they die.");
 ~chatnpc("<p,neutral>Now, the next way to earn money quickly is by quests. Many people on RuneScape have things they need doing, which they will reward you for.");
 ~chatnpc("<p,neutral>By getting a high level in skills such as cooking, mining, smithing or fishing, you can create your own items and sell them for pure profit.");
-~chatnpc("<p,neutral>Well that's about covers it. Come back if you'd like to go over this again.");
+~chatnpc("<p,neutral>Well that about covers it. Come back if you'd like to go over this again.");
 if (%tutorial_progress = ^tutorial_opened_financial_advisor_door) {
     %tutorial_progress = ^financial_advisor_talked_to;
     ~set_tutorial_progress;
@@ -30,11 +30,11 @@ if (%tutorial_progress = ^tutorial_opened_financial_advisor_door) {
 
 [label,financial_advisor_recap]
 ~chatnpc("<p,neutral>Okay, making money. Quite.");
-~chatnpc("<p,happy>Well there are three basic ways of making money here; Combat, Quests and Trading. I will talk you through each of tem very quickly.");
+~chatnpc("<p,happy>Well there are three basic ways of making money here; Combat, Quests and Trading. I will talk you through each of them very quickly.");
 ~chatnpc("<p,happy>Let's start with combat, as it is probably still fresh in your mind. Many enemies, both human and monster will drop items when they die.");
 ~chatnpc("<p,happy>Now, the next way to earn money quickly is by quests. Many people on RuneScape have things they need doing, which they will reward you for.");
 ~chatnpc("<p,happy>By getting a high level in skills such as cooking, mining, smithing or fishing, you can create your own items and sell them for pure profit.");
-~chatnpc("<p,happy>Well that's about covers it. Come back if you'd like to go over this again.");
+~chatnpc("<p,happy>Well that about covers it. Come back if you'd like to go over this again.");
 
 [label,financial_advisor_no_thanks]
 

--- a/data/src/scripts/tutorial/scripts/guides/master_chef.rs2
+++ b/data/src/scripts/tutorial/scripts/guides/master_chef.rs2
@@ -65,7 +65,7 @@ switch_int($option) {
         ~master_chef_recap_options;
     case 2:
         ~chatplayer("<p,neutral>Tell me about range cooking again.");
-        ~chatnpc("<p,neutral>The range is the only place you can cook a lot of the more complex foods in Runescape. To cook on a range, right click the item you would like to cook, select 'use' then left click the range.");
+        ~chatnpc("<p,neutral>The range is the only place you can cook a lot of the more complex foods in RuneScape. To cook on a range, right click the item you would like to cook, select 'use' then left click the range.");
         ~master_chef_recap_options;
     case 3:
         ~chatplayer("<p,neutral>Tell me about music again.");

--- a/data/src/scripts/tutorial/scripts/guides/mining_instructor.rs2
+++ b/data/src/scripts/tutorial/scripts/guides/mining_instructor.rs2
@@ -105,6 +105,7 @@ switch_int(%tutorial_progress) {
 ~chatnpc("<p,neutral>It's a pretty straightfoward skill as I'm sure you discovered while making me that lovely bronze dagger.");
 ~chatnpc("<p,neutral>The higher Smithing level you reach, the better quality of metal you can work with. You start off on bronze and work your way up as your Smithing skills increase.");
 ~chatnpc("<p,quiz>Anything else, <displayname>?");
+@mining_instructor_recap;
 
 [label,mining_instructor_ready_to_move_on]
 ~chatplayer("<p,neutral>Nope, I'm ready to move on!");

--- a/data/src/scripts/tutorial/scripts/guides/survival_guide.rs2
+++ b/data/src/scripts/tutorial/scripts/guides/survival_guide.rs2
@@ -129,7 +129,7 @@ switch_int($choice) {
 
 [proc,survival_recap_fishing]
 ~chatplayer("<p,neutral>Tell me about Fishing again.");
-~chatnpc("<p,neutral>Ah, yes. Fishing! Fishing is undoubtedly one the more popular hobbies here in Runescape!");
+~chatnpc("<p,neutral>Ah, yes. Fishing! Fishing is undoubtedly one of the more popular hobbies here in RuneScape!");
 ~chatnpc("<p,neutral>Whenever you see sparkling waters, you can be sure there's probably some good fishing to be had there!");
 ~chatnpc("<p,neutral>Not only are fish absolutely delicious when cooked, there are always fighters willing to buy a well cooked fish when they're low on health.");
 ~chatnpc("<p,quiz>I would recommend everybody has a go at Fishing at least once in their lives! Was there anything else you wished to hear again?");

--- a/data/src/scripts/tutorial/scripts/tut_chatbox_steps.rs2
+++ b/data/src/scripts/tutorial/scripts/tut_chatbox_steps.rs2
@@ -124,7 +124,7 @@ hint_stop();
 tut_flash(^tab_quest_journal);
 ~update_quests;
 if_settab(questlist, ^tab_quest_journal);
-~tutorialstep("", "Open the Quest journal||Click on the flashing icon next to your inventory.");
+~tutorialstep("", "Open the Quest journal.||Click on the flashing icon next to your inventory.");
 
 [proc,tutorial_step_quest_journal]
 ~set_hint_icon_quest_guide;

--- a/data/src/scripts/tutorial/scripts/tut_doors_and_gates.rs2
+++ b/data/src/scripts/tutorial/scripts/tut_doors_and_gates.rs2
@@ -36,7 +36,7 @@ p_teleport(loc_coord);
 // Runescape guide door
 [oploc1,loc_3014]
 if (%tutorial_progress < ^runescape_guide_interact_with_scenery) {
-    ~mesbox("You need to talk to the 'Runescape Guide' before you are allowed to proceed through this door.");
+    ~mesbox("You need to talk to the 'RuneScape Guide' before you are allowed to proceed through this door.");
     return;
 }
 


### PR DESCRIPTION
Tutorial Island dialogue:
- fixed some typos and missing punctuations
- added missing recap trigger for mining instructor
- changed some instances of "Runescape" -> "RuneScape"

+slight tweaking to cat code, removed 2 wrong comments