### PR TITLE
fix(engine): engine tweaks to match osrs firemaking edgecases

### DIFF
--- a/data/src/scripts/_test/scripts/cheats/cheat_interactions.rs2
+++ b/data/src/scripts/_test/scripts/cheats/cheat_interactions.rs2
@@ -1,0 +1,420 @@
+// [opnpc1,gnome_cheerleader]
+// p_walk(movecoord(coord, 2, 0, 0));
+// ~chatplayer("<p,neutral>Hello");
+
+// [apnpc2,savage_bird]
+// if (npc_range(coord) > 5) {
+//     p_aprange(5);
+//     return;
+// }
+// p_walk(movecoord(coord, 2, 0, 0));
+// ~chatplayer("<p,neutral>Hello");
+
+// [ai_opplayer2,savage_bird]
+// npc_walk(movecoord(npc_coord, 2, 0, 0));
+
+// [ai_applayer2,savage_bird]
+// npc_walk(movecoord(npc_coord, 2, 0, 0));
+
+[debugproc,itele]
+if (p_finduid(uid) = true) {
+    p_telejump(0_37_55_32_30);
+}
+
+[debugproc,itest](int $test)
+clearqueue(reset_itest);
+if (p_finduid(uid) = true) {
+    gosub(reset_itest);
+    switch_int ($test) {
+        case 1 : gosub(ap_to_op_switching);
+        case 2 : gosub(blocking_an_npc_and_then_unblocking);
+        case 3 : gosub(clicking_a_loc_then_clicking_away_before_reaching);
+        case 4 : gosub(clicking_a_loc_then_walking_far_away);
+        case 5 : gosub(clicking_a_loc_without_path_access);
+        case 6 : gosub(clicking_an_npc_then_clicking_away_before_reaching);
+        case 7 : gosub(clicking_an_obj_then_clicking_away_before_reaching);
+        case 8 : gosub(clicking_a_loc_then_an_npc_then_clicking_away_before_reaching);
+        case 9 : gosub(clicking_a_loc_then_an_obj_then_clicking_away_before_reaching);
+        case 10 : gosub(clicking_obj_on_the_table_in_lumbridge);
+        case 11 : gosub(firemaking_on_top_of_blockwalk_all_npc);
+        case 12, 13 : gosub(blockwalk_all_in_action);
+        case 14 : gosub(equipping_an_obj_while_in_combat);
+        case 15 : gosub(clicking_an_npc_while_underneath_it);
+        case 16 : gosub(magic_fire_bolt_while_underneath_the_npc);
+        case 17 : gosub(not_blocking_npcs_when_logged_in_without_moving);
+        case 18 : gosub(npc_modes_in_action);
+        case 19 : gosub(telegrab_on_top_of_an_obj);
+        case 20 : gosub(unequipping_an_obj_while_in_combat);
+        case 21 : gosub(walking_and_equipping_an_obj_continues_walking_while_targetting);
+        case 22 : gosub(walking_and_equipping_obj_continues_walk);
+        case 23 : gosub(walking_and_unequipping_an_obj_continues_walking_while_targeting);
+        case 24 : gosub(apnpct_on_draynor_tree_npc);
+        case 25 : gosub(pathing_to_a_loc_as_it_is_deleted_before_reaching);
+        case 26 : gosub(pathing_to_an_obj_as_it_is_deleted_before_reaching);
+        case 27 : gosub(pathing_to_an_npc_as_it_is_deleted_before_reaching);
+        case 28 : gosub(pathing_to_an_npc_as_it_does_changetype_command);
+        case 29 : gosub(repathing_to_an_npc_on_your_last_waypoint);
+        case 30 : gosub(not_repathing_to_an_npc_not_on_your_last_waypoint);
+        case 31 : gosub(npc_set_mode_to_opplayer);
+        case 32 : gosub(npc_set_mode_to_applayer);
+        case 33 : gosub(opnpc_to_p_walk);
+        case 34 : gosub(apnpc_to_p_walk);
+        case 35 : gosub(ai_opplayer_to_npc_walk);
+        case 36 : gosub(ai_applayer_to_npc_walk);
+    }
+} else {
+    mes("Command requires protected access.");
+}
+
+[proc,reset_itest]
+npc_findallany(0_37_55_32_30, 10, 0);
+while (npc_findnext = true) {
+    if (npc_type = cow_1 | npc_type = goblin_unarmed1) {
+        npc_del;
+    }
+}
+p_telejump(0_37_55_32_30);
+p_stopaction;
+inv_clear(inv);
+inv_clear(worn);
+
+[queue,reset_itest] gosub(reset_itest);
+
+[proc,ap_to_op_switching]
+mes("Test 1: AP to OP Switching");
+npc_add(movecoord(coord, 0, 0, 5), cow_1, 10);
+%npc_lastcombat = add(map_clock, 10);
+npc_setmode(none);
+queue(reset_itest, 10);
+p_delay(2);
+p_opnpc(2);
+
+[proc,blocking_an_npc_and_then_unblocking]
+mes("Test 2: Blocking an Npc and then unblocking");
+npc_add(movecoord(coord, -5, 0, -1), goblin_unarmed1, 10);
+npc_setmode(none);
+npc_walk(movecoord(npc_coord, 10, 0, 0));
+p_delay(2);
+p_walk(movecoord(coord, 0, 0, -1));
+p_delay(2);
+p_walk(movecoord(coord, 0, 0, 1));
+p_delay(5);
+~reset_itest;
+
+[proc,clicking_a_loc_then_clicking_away_before_reaching]
+mes("Test 3 (manual): Clicking a Loc then clicking away before reaching");
+loc_add(movecoord(coord, 0, 0, 5), loc_1276, 0, centrepiece_straight, 10);
+
+[proc,clicking_a_loc_then_walking_far_away]
+mes("Test 4 (manual): Clicking a Loc then walking far away");
+p_teleport(0_49_51_50_20);
+queue(reset_itest, 50);
+
+[proc,clicking_a_loc_without_path_access]
+mes("Test 5 (manual): Clicking a Loc without path access");
+p_teleport(0_50_50_17_54);
+queue(reset_itest, 15);
+
+[proc,clicking_an_npc_then_clicking_away_before_reaching]
+mes("Test 6 (manual): Clicking an Npc then clicking away before reaching");
+npc_add(movecoord(coord, 0, 0, 5), goblin_unarmed1, 10);
+npc_setmode(none);
+
+[proc,clicking_an_obj_then_clicking_away_before_reaching]
+mes("Test 7 (manual): Clicking an obj then clicking away before reaching");
+obj_addall(movecoord(coord, 0, 0, 5), rune_scimitar, 1, 10);
+
+[proc,clicking_a_loc_then_an_npc_then_clicking_away_before_reaching]
+mes("Test 8 (manual): Clicking a Loc then an Npc then clicking away before reaching");
+p_teleport(0_50_50_16_60);
+queue(reset_itest, 15);
+
+[proc,clicking_a_loc_then_an_obj_then_clicking_away_before_reaching]
+mes("Test 9 (manual): Clicking a Loc then an Obj then clicking away before reaching");
+p_teleport(0_50_50_16_60);
+queue(reset_itest, 15);
+
+[proc,clicking_obj_on_the_table_in_lumbridge]
+mes("Test 10 (manual): Clicking this Obj on the table in Lumbridge");
+p_teleport(0_50_50_10_9);
+queue(reset_itest, 10);
+
+[proc,firemaking_on_top_of_blockwalk_all_npc]
+mes("Test 11: Firemaking on top of a blockwalk=ALL Npc");
+p_teleport(0_49_52_5_32);
+inv_clear(inv);
+inv_add(inv, logs, 1);
+inv_add(inv, tinderbox, 1);
+queue(reset_itest, 10);
+@light_logs_inv(0);
+
+[proc,blockwalk_all_in_action]
+mes("Test 12 & 13 (manual): blockwalk=ALL in action");
+p_teleport(0_49_52_4_31);
+
+[proc,equipping_an_obj_while_in_combat]
+mes("Test 14 (manual): Equipping an Obj while in combat");
+p_teleport(0_50_50_43_25);
+facesquare(movecoord(coord, 1, 0, 0));
+
+inv_clear(inv);
+inv_clear(worn);
+
+inv_setslot(worn, ^wearpos_rhand, shortbow, 1);
+inv_setslot(worn, ^wearpos_quiver, bronze_arrow, 1);
+inv_delslot(worn, ^wearpos_lhand);
+~update_all(null);
+
+inv_add(inv, bronze_axe, 1);
+
+npc_add(0_50_50_40_24, man_brown, 20);
+npc_setmode(opplayer2);
+queue(reset_itest, 20);
+
+[proc,clicking_an_npc_while_underneath_it]
+mes("Test 15 (manual): Clicking an Npc while underneath it");
+p_teleport(0_51_50_2_29);
+queue(reset_itest, 10);
+
+[proc,magic_fire_bolt_while_underneath_the_npc]
+mes("Test 16 (manual): Magic Fire Bolt while underneath the Npc");
+npc_add(movecoord(coord, 0, 0, 1), goblin_unarmed1, 10);
+npc_setmode(none);
+
+inv_clear(inv);
+
+inv_add(inv, chaosrune, 1000);
+inv_add(inv, firerune, 1000);
+inv_add(inv, airrune, 1000);
+if_settabactive(^tab_magic);
+
+p_delay(1);
+p_teleport(movecoord(coord, 0, 0, 1));
+
+[proc,not_blocking_npcs_when_logged_in_without_moving]
+mes("Test 17 (manual): Not blocking Npcs when logged in without moving");
+npc_add(movecoord(coord, -5, 0, 0), goblin_unarmed1, 10);
+npc_setmode(none);
+npc_walk(movecoord(npc_coord, 10, 0, 0));
+
+queue(reset_itest, 12);
+p_delay(12);
+
+[proc,npc_modes_in_action]
+mes("Test 18 (manual): Npc Modes in action.");
+npc_add(movecoord(coord, 0, 0, 1), civilian_blonde, 30);
+npc_setmode(none);
+p_opnpc(1);
+world_delay(0);
+npc_walk(movecoord(npc_coord, 0, 0, 1));
+world_delay(0);
+
+[proc,telegrab_on_top_of_an_obj]
+mes("Test 19 (manual): Telegrab on top of an Obj");
+obj_addall(coord, garlic, 1, 100);
+inv_clear(inv);
+inv_add(inv, airrune, 5);
+inv_add(inv, lawrune, 1);
+if_settabactive(^tab_magic);
+
+[proc,unequipping_an_obj_while_in_combat]
+mes("Test 20 (manual): Unequipping an Obj while in combat");
+p_teleport(0_50_50_43_25);
+facesquare(movecoord(coord, 1, 0, 0));
+
+inv_clear(inv);
+inv_clear(worn);
+
+inv_setslot(worn, ^wearpos_rhand, shortbow, 1);
+inv_setslot(worn, ^wearpos_quiver, bronze_arrow, 100);
+inv_delslot(worn, ^wearpos_lhand);
+if_settabactive(^tab_wornitems);
+
+~update_all(null);
+
+npc_add(0_50_50_40_24, man_brown, 20);
+npc_setmode(opplayer2);
+queue(reset_itest, 20);
+
+[proc,walking_and_equipping_an_obj_continues_walking_while_targetting]
+mes("Test 21 (manual): Walking and equipping an Obj continues walking while targetting");
+npc_add(movecoord(coord, 0, 0, 7), goblin_unarmed1, 20);
+npc_setmode(none);
+
+inv_clear(inv);
+inv_add(inv, bronze_axe, 1);
+queue(reset_itest, 20);
+
+[proc,walking_and_equipping_obj_continues_walk]
+mes("Test 22 (manual): Walking and equipping an Obj continues walking");
+
+inv_clear(inv);
+inv_add(inv, bronze_axe, 1);
+if_settabactive(^tab_inventory);
+
+[proc,walking_and_unequipping_an_obj_continues_walking_while_targeting]
+mes("Test 23 (manual): Walking and unequipping an Obj continues walking while targetting");
+
+inv_clear(inv);
+inv_clear(worn);
+
+inv_setslot(worn, ^wearpos_rhand, bronze_axe, 1);
+if_settabactive(^tab_wornitems);
+
+~update_all(null);
+
+npc_add(movecoord(coord, 0, 0, 7), goblin_unarmed1, 20);
+npc_setmode(none);
+queue(reset_itest, 20);
+
+[proc,walking_and_unequipping_obj_continues_walk]
+mes("Test 23 (manual): Walking and unequipping an Obj continues walking");
+
+inv_clear(worn);
+inv_setslot(worn, ^wearpos_rhand, bronze_axe, 1);
+if_settabactive(^tab_wornitems);
+
+[proc,apnpct_on_draynor_tree_npc]
+mes("Test 24: apnpct on Draynor tree npc");
+npc_add(movecoord(coord, 0, 0, 5), nasty_tree, 10);
+inv_clear(inv);
+inv_add(inv, airrune, 1000);
+inv_add(inv, mindrune, 1000);
+p_opnpct(magic:wind_strike);
+
+[proc,pathing_to_a_loc_as_it_is_deleted_before_reaching]
+mes("Test 25: Pathing to a Loc as it is deleted before reaching");
+loc_add(movecoord(coord, 0, 0, 10), loc_1276, 0, centrepiece_straight, 5);
+p_oploc(1);
+
+[proc,pathing_to_an_obj_as_it_is_deleted_before_reaching]
+mes("Test 26: Pathing to an Obj as it is deleted before reaching");
+obj_addall(movecoord(coord, 0, 0, 10), bowl_empty, 1, 5);
+p_opobj(1);
+
+[proc,pathing_to_an_npc_as_it_is_deleted_before_reaching]
+mes("Test 27: Pathing to an Npc as it is deleted before reaching");
+npc_add(movecoord(coord, 0, 0, 10), goblin_unarmed1, 5);
+
+queue(reset_itest, 10);
+
+inv_clear(worn);
+~update_all(null);
+p_opnpc(2);
+
+
+[proc,pathing_to_an_npc_as_it_does_changetype_command]
+mes("Test 28: Pathing to an Npc as it does changetype command");
+npc_add(movecoord(coord, 0, 0, 10), goblin_unarmed1, 10);
+npc_setmode(none);
+
+queue(reset_itest, 10);
+
+inv_clear(worn);
+~update_all(null);
+p_opnpc(2);
+
+world_delay(4);
+npc_changetype(cow_1);
+
+
+[proc,repathing_to_an_npc_on_your_last_waypoint]
+mes("Test 29: Repathing to an Npc on your last waypoint");
+npc_add(movecoord(coord, 12, 0, 3), goblin_unarmed1, 20);
+npc_setmode(none);
+
+queue(reset_itest, 20);
+
+inv_clear(worn);
+~update_all(null);
+p_opnpc(2);
+
+world_delay(2);
+npc_tele(movecoord(npc_coord, -5, 0, -10));
+
+
+[proc,not_repathing_to_an_npc_not_on_your_last_waypoint]
+mes("Test 30: Not repathing to an Npc not on your last waypoint");
+p_telejump(0_50_50_39_7);
+if (loc_find(0_50_50_38_10, loc_1533) = true) {
+    def_coord $new_loc_coord = ~movecoord_loc_return(~door_open(loc_angle, loc_shape));
+    loc_del(500);
+    loc_add($new_loc_coord, loc_param(next_loc_stage), modulo(add(loc_angle, 1), 4), loc_shape, 500);
+}
+npc_add(movecoord(coord, 3, 0, 0), goblin_unarmed1, 20);
+npc_setmode(none);
+
+queue(reset_itest, 20);
+
+inv_clear(worn);
+~update_all(null);
+p_opnpc(2);
+
+world_delay(2);
+
+if (loc_find(0_50_50_37_10, loc_1534) = true) {
+    def_coord $new_loc_coord = ~movecoord_loc_return(~door_close(loc_angle, loc_shape));
+    loc_del(500);
+    loc_add($new_loc_coord, loc_param(next_loc_stage), modulo(add(loc_angle, 3), 4), loc_shape, 500);
+}
+
+world_delay(2);
+
+if (loc_find(0_50_50_38_10, loc_1533) = true) {
+    def_coord $new_loc_coord = ~movecoord_loc_return(~door_open(loc_angle, loc_shape));
+    loc_del(500);
+    loc_add($new_loc_coord, loc_param(next_loc_stage), modulo(add(loc_angle, 1), 4), loc_shape, 500);
+}
+
+[proc,npc_set_mode_to_opplayer]
+mes("Test 31: Npc_setmode to opplayer");
+npc_add(movecoord(coord, -5, 0, -1), goblin_unarmed1, 10);
+npc_setmode(opplayer2);
+
+queue(reset_itest, 10);
+
+world_delay(2);
+
+if (p_finduid(uid) = true) {
+    p_walk(movecoord(coord, 5, 0, 0));
+}
+
+[proc,npc_set_mode_to_applayer]
+mes("Test 32: Npc_setmode to applayer");
+npc_add(movecoord(coord, -5, 0, -1), dark_wizard_water, 15);
+~npc_retaliate(0);
+queue(reset_itest, 15);
+
+world_delay(2);
+
+if (p_finduid(uid) = true) {
+    p_walk(movecoord(coord, 5, 0, 0));
+}
+
+[proc,opnpc_to_p_walk]
+mes("Test 33: opnpc to p_walk");
+npc_add(movecoord(coord, -1, 0, -1), gnome_cheerleader, 10);
+npc_setmode(none);
+queue(reset_itest, 10);
+p_delay(1);
+p_opnpc(1);
+
+[proc,apnpc_to_p_walk]
+mes("Test 34: apnpc to p_walk");
+npc_add(movecoord(coord, -1, 0, -1), savage_bird, 10);
+npc_setmode(none);
+queue(reset_itest, 10);
+p_delay(1);
+p_opnpc(2);
+
+[proc,ai_opplayer_to_npc_walk]
+mes("Test 35: ai oppplayer to npc_walk");
+npc_add(movecoord(coord, -1, 0, -1), savage_bird, 10);
+npc_setmode(opplayer2);
+queue(reset_itest, 10);
+
+[proc,ai_applayer_to_npc_walk]
+mes("Test 36: ai appplayer to npc_walk");
+npc_add(movecoord(coord, -5, 0, -1), savage_bird, 10);
+npc_setmode(applayer2);
+queue(reset_itest, 10);

--- a/data/src/scripts/engine.rs2
+++ b/data/src/scripts/engine.rs2
@@ -234,6 +234,7 @@
 [command,runenergy]()(int)
 [command,weight]()(int)
 [command,last_coord]()(coord)
+[command,p_clearpendingaction]
 
 // Npc ops (2500-2999)
 [command,npc_finduid](npc_uid $uid)(boolean)

--- a/data/src/scripts/macro events/configs/antimacro.npc
+++ b/data/src/scripts/macro events/configs/antimacro.npc
@@ -171,7 +171,9 @@ recol5d=12552
 recol6s=22164
 recol6d=20678
 model1=model_3011_npc
-// TODO
+// for debug purposes
+// attackrange=2
+// maxrange=2
 param=attack_anim,terrorbird_attack
 param=defend_anim,terrorbird_block
 param=death_anim,terrorbird_death

--- a/data/src/scripts/skill_firemaking/scripts/firemaking.rs2
+++ b/data/src/scripts/skill_firemaking/scripts/firemaking.rs2
@@ -135,7 +135,7 @@ if (map_locaddunsafe($coord) = true) {
 if (map_blocked($coord) = true) {
     return(false);
 }
-if (~inzone_coord_pair_table(bank_zones, $coord) = true) {
+if (~inzone_coord_pair_table(bank_zones, coord) = true) { // zone based checks use coord instead of loc_coord
     return(false);
 }
 return(true);

--- a/data/src/scripts/skill_firemaking/scripts/firemaking.rs2
+++ b/data/src/scripts/skill_firemaking/scripts/firemaking.rs2
@@ -120,7 +120,6 @@ p_opobj(4);
 obj_del;
 stat_advance(firemaking, oc_param($log, productexp));
 sound_synth(fire_lit, 0, 0);
-anim(null, 0);
 facesquare($fire_coord);
 //mes("<tostring(map_clock)>, <tostring(%action_delay)>: The fire catches and the logs begin to burn.");
 mes("The fire catches and the logs begin to burn.");
@@ -148,6 +147,7 @@ if (p_finduid(uid) = true) {
 }
 
 [proc,push_player](coord $origin_coord)
+anim(null, 0);
 if (~in_duel_arena($origin_coord) = true) {
     p_delay(0);
     return;
@@ -160,16 +160,17 @@ if (lineofwalk(coord, movecoord(coord, 1, 0, 0)) = true & coord = $origin_coord)
     p_teleport(movecoord(coord, 1, 0, 0));
     p_delay(0);
 }
-if (lineofwalk(coord, movecoord(coord, 0, 0, 1)) = true & coord = $origin_coord) { // check south
-    p_teleport(movecoord(coord, 0, 0, 1));
+if (lineofwalk(coord, movecoord(coord, 0, 0, -1)) = true & coord = $origin_coord) { // check south
+    p_teleport(movecoord(coord, 0, 0, -1));
     p_delay(0);
 }
-if (lineofwalk(coord, movecoord(coord, 0, 0, -1)) = true & coord = $origin_coord) { // check north
-    p_teleport(movecoord(coord, 0, 0, -1));
+if (lineofwalk(coord, movecoord(coord, 0, 0, 1)) = true & coord = $origin_coord) { // check north
+    p_teleport(movecoord(coord, 0, 0, 1));
     p_delay(0);
 }
 
 [proc,push_player_from_inv](coord $origin_coord)
+anim(null, 0);
 if (~in_duel_arena($origin_coord) = true) {
     // https://youtu.be/L3OwjH-iXQU
     //  - could still fm in the duel arena. 
@@ -186,33 +187,33 @@ if (lineofwalk(coord, movecoord(coord, -1, 0, 0)) = true & coord = $origin_coord
         p_teleport(movecoord(coord, 1, 0, 0));
         p_delay(0);
     }
-    if (lineofwalk(coord, movecoord(coord, 0, 0, 1)) = true & coord = $origin_coord) { // check south
-        p_teleport(movecoord(coord, 0, 0, 1));
+    if (lineofwalk(coord, movecoord(coord, 0, 0, -1)) = true & coord = $origin_coord) { // check south
+        p_teleport(movecoord(coord, 0, 0, -1));
         p_delay(0);
     }
-    if (lineofwalk(coord, movecoord(coord, 0, 0, -1)) = true & coord = $origin_coord) { // check north
-        p_teleport(movecoord(coord, 0, 0, -1));
+    if (lineofwalk(coord, movecoord(coord, 0, 0, 1)) = true & coord = $origin_coord) { // check north
+        p_teleport(movecoord(coord, 0, 0, 1));
         p_delay(0);
     }
 } else if (lineofwalk(coord, movecoord(coord, 1, 0, 0)) = true & coord = $origin_coord) { // check east
     p_teleport(movecoord(coord, 1, 0, 0));
     p_delay(1);
-    if (lineofwalk(coord, movecoord(coord, 0, 0, 1)) = true & coord = $origin_coord) { // check south
+    if (lineofwalk(coord, movecoord(coord, 0, 0, -1)) = true & coord = $origin_coord) { // check south
+        p_teleport(movecoord(coord, 0, 0, -1));
+        p_delay(0);
+    }
+    if (lineofwalk(coord, movecoord(coord, 0, 0, 1)) = true & coord = $origin_coord) { // check north
         p_teleport(movecoord(coord, 0, 0, 1));
         p_delay(0);
     }
-    if (lineofwalk(coord, movecoord(coord, 0, 0, -1)) = true & coord = $origin_coord) { // check north
-        p_teleport(movecoord(coord, 0, 0, -1));
-        p_delay(0);
-    }
-} else if (lineofwalk(coord, movecoord(coord, 0, 0, 1)) = true & coord = $origin_coord) { // check south
-    p_teleport(movecoord(coord, 0, 0, 1));
-    p_delay(1);
-    if (lineofwalk(coord, movecoord(coord, 0, 0, -1)) = true & coord = $origin_coord) { // check north
-        p_teleport(movecoord(coord, 0, 0, -1));
-        p_delay(0);
-    }
-} else if (lineofwalk(coord, movecoord(coord, 0, 0, -1)) = true & coord = $origin_coord) { // check north
+} else if (lineofwalk(coord, movecoord(coord, 0, 0, -1)) = true & coord = $origin_coord) { // check south
     p_teleport(movecoord(coord, 0, 0, -1));
+    p_delay(1);
+    if (lineofwalk(coord, movecoord(coord, 0, 0, 1)) = true & coord = $origin_coord) { // check north
+        p_teleport(movecoord(coord, 0, 0, 1));
+        p_delay(0);
+    }
+} else if (lineofwalk(coord, movecoord(coord, 0, 0, 1)) = true & coord = $origin_coord) { // check north
+    p_teleport(movecoord(coord, 0, 0, 1));
     p_delay(1);
 }

--- a/src/lostcity/entity/Npc.ts
+++ b/src/lostcity/entity/Npc.ts
@@ -663,15 +663,15 @@ export default class Npc extends PathingEntity {
 
         const script: ScriptFile | null = this.getTrigger();
         if (script && opTrigger && this.inOperableDistance(this.target) && this.target instanceof PathingEntity) {
-            this.executeScript(ScriptRunner.init(script, this, this.target));
             this.interacted = true;
             this.clearWaypoints();
+            this.executeScript(ScriptRunner.init(script, this, this.target));
             return;
         }
         if (script && apTrigger && this.inApproachDistance(type.attackrange, this.target)) {
-            this.executeScript(ScriptRunner.init(script, this, this.target));
             this.interacted = true;
             this.clearWaypoints();
+            this.executeScript(ScriptRunner.init(script, this, this.target));
             return;
         }
         if (this.inOperableDistance(this.target) && this.target instanceof PathingEntity) {
@@ -693,13 +693,13 @@ export default class Npc extends PathingEntity {
         if (this.target && !this.interacted) {
             this.interacted = false;
             if (script && opTrigger && this.inOperableDistance(this.target) && (this.target instanceof PathingEntity || !moved)) {
-                this.executeScript(ScriptRunner.init(script, this, this.target));
                 this.interacted = true;
                 this.clearWaypoints();
+                this.executeScript(ScriptRunner.init(script, this, this.target));
             } else if (script && apTrigger && this.inApproachDistance(type.attackrange, this.target)) {
-                this.executeScript(ScriptRunner.init(script, this, this.target));
                 this.interacted = true;
                 this.clearWaypoints();
+                this.executeScript(ScriptRunner.init(script, this, this.target));
             } else if (this.inOperableDistance(this.target) && (this.target instanceof PathingEntity || !moved)) {
                 this.target = null;
                 this.interacted = true;

--- a/src/lostcity/entity/PathingEntity.ts
+++ b/src/lostcity/entity/PathingEntity.ts
@@ -19,6 +19,7 @@ import LocType from '#lostcity/cache/config/LocType.js';
 import * as rsmod from '@2004scape/rsmod-pathfinder';
 import {CollisionFlag, CollisionType} from '@2004scape/rsmod-pathfinder';
 import Environment from '#lostcity/util/Environment.js';
+import Obj from './Obj.js';
 
 type TargetSubject = {
     type: number,
@@ -443,6 +444,8 @@ export default abstract class PathingEntity extends Entity {
             } else if (this.target instanceof Loc) {
                 const forceapproach = LocType.get(this.target.type).forceapproach;
                 this.queueWaypoints(rsmod.findPath(this.level, this.x, this.z, this.target.x, this.target.z, this.width, this.target.width, this.target.length, this.target.angle, this.target.shape, true, forceapproach));
+            } else if (this.target instanceof Obj && this.x === this.target.x && this.z === this.target.z) {
+                this.queueWaypoint(this.target.x, this.target.z); // work around because our findpath() returns 0, 0 if coord and target coord are the same
             } else {
                 this.queueWaypoints(rsmod.findPath(this.level, this.x, this.z, this.target.x, this.target.z));
             }

--- a/src/lostcity/entity/PathingEntity.ts
+++ b/src/lostcity/entity/PathingEntity.ts
@@ -223,6 +223,14 @@ export default abstract class PathingEntity extends Entity {
         this.orientationZ = CoordGrid.moveZ(this.z, dir) * 2 + 1;
         this.stepsTaken++;
         this.refreshZonePresence(previousX, previousZ, this.level);
+
+        if (this.waypointIndex !== -1) {
+            const coord: CoordGrid = CoordGrid.unpackCoord(this.waypoints[this.waypointIndex]);
+            if (coord.x === this.x && coord.z === this.z) {
+                this.waypointIndex--;
+            }
+        }
+
         return dir;
     }
 

--- a/src/lostcity/entity/Player.ts
+++ b/src/lostcity/entity/Player.ts
@@ -532,7 +532,7 @@ export default class Player extends PathingEntity {
 
     updateMovement(repathAllowed: boolean = true): boolean {
         // players cannot walk if they have a modal open *and* something in their queue, confirmed as far back as 2005
-        if (this.containsModalInterface() && this.queue.head() != null) {
+        if (this.busy() && this.queue.head() != null) {
             this.recoverEnergy(false);
             return false;
         }

--- a/src/lostcity/entity/Player.ts
+++ b/src/lostcity/entity/Player.ts
@@ -918,14 +918,19 @@ export default class Player extends PathingEntity {
         } else if (apTrigger && this.inApproachDistance(this.apRange, this.target)) {
             const target = this.target;
             this.target = null;
+            const wayPoints = this.waypoints;
+            const waypointIndex = this.waypointIndex;
+            this.clearWaypoints();
 
             this.executeScript(ScriptRunner.init(apTrigger, this, target), true);
 
             // if aprange was called then we did not interact.
             if (this.apRangeCalled) {
+                this.waypoints = wayPoints;
+                this.waypointIndex = waypointIndex;
                 this.target = target;
             } else {
-                if (this.target === target) {
+                if (this.target === target) { // if p_opnpc was called
                     this.clearWaypoints(); 
                 }
                 this.interacted = true;
@@ -982,14 +987,19 @@ export default class Player extends PathingEntity {
 
                 const target = this.target;
                 this.target = null;
+                const wayPoints = this.waypoints;
+                const waypointIndex = this.waypointIndex;
+                this.clearWaypoints();
 
                 this.executeScript(ScriptRunner.init(apTrigger, this, target), true);
 
                 // if aprange was called then we did not interact.
                 if (this.apRangeCalled) {
                     this.target = target;
+                    this.waypoints = wayPoints;
+                    this.waypointIndex = waypointIndex;
                 } else {
-                    if (this.target === target) {
+                    if (this.target === target) { // if p_opnpc was called
                         this.clearWaypoints();
                     }
                     this.interacted = true;

--- a/src/lostcity/entity/Player.ts
+++ b/src/lostcity/entity/Player.ts
@@ -910,15 +910,11 @@ export default class Player extends PathingEntity {
         if (opTrigger && this.target instanceof PathingEntity && this.inOperableDistance(this.target)) {
             const target = this.target;
             this.target = null;
+            this.clearWaypoints(); 
 
             this.executeScript(ScriptRunner.init(opTrigger, this, target), true);
-
-            if (this.target === null) {
-                this.unsetMapFlag();
-            }
-
             this.interacted = true;
-            this.clearWaypoints();
+
         } else if (apTrigger && this.inApproachDistance(this.apRange, this.target)) {
             const target = this.target;
             this.target = null;
@@ -929,13 +925,12 @@ export default class Player extends PathingEntity {
             if (this.apRangeCalled) {
                 this.target = target;
             } else {
-                this.clearWaypoints();
+                if (this.target === target) {
+                    this.clearWaypoints(); 
+                }
                 this.interacted = true;
             }
 
-            if (this.target === null) {
-                this.unsetMapFlag();
-            }
         } else if (this.target instanceof PathingEntity && this.inOperableDistance(this.target)) {
             if (Environment.NODE_DEBUG && !opTrigger && !apTrigger) {
                 let debugname = '_';
@@ -977,15 +972,11 @@ export default class Player extends PathingEntity {
 
                 const target = this.target;
                 this.target = null;
+                this.clearWaypoints(); 
 
                 this.executeScript(ScriptRunner.init(opTrigger, this, target), true);
-
-                if (this.target === null) {
-                    this.unsetMapFlag();
-                }
-
                 this.interacted = true;
-                this.clearWaypoints();
+
             } else if (apTrigger && this.inApproachDistance(this.apRange, this.target)) {
                 this.apRangeCalled = false;
 
@@ -998,13 +989,12 @@ export default class Player extends PathingEntity {
                 if (this.apRangeCalled) {
                     this.target = target;
                 } else {
-                    this.clearWaypoints();
+                    if (this.target === target) {
+                        this.clearWaypoints();
+                    }
                     this.interacted = true;
                 }
 
-                if (this.target === null) {
-                    this.unsetMapFlag();
-                }
             } else if ((this.target instanceof PathingEntity || !moved) && this.inOperableDistance(this.target)) {
                 if (!Environment.NODE_PRODUCTION && !opTrigger && !apTrigger) {
                     let debugname = '_';

--- a/src/lostcity/network/225/incoming/handler/MoveClickHandler.ts
+++ b/src/lostcity/network/225/incoming/handler/MoveClickHandler.ts
@@ -4,11 +4,16 @@ import { NetworkPlayer } from '#lostcity/entity/NetworkPlayer.js';
 import { CoordGrid } from '#lostcity/engine/CoordGrid.js';
 import Environment from '#lostcity/util/Environment.js';
 import VarPlayerType from '#lostcity/cache/config/VarPlayerType.js';
+import UnsetMapFlag from '#lostcity/network/outgoing/model/UnsetMapFlag.js';
 
 export default class MoveClickHandler extends MessageHandler<MoveClick> {
     handle(message: MoveClick, player: NetworkPlayer): boolean {
+        if (player.delayed()) {
+            player.write(new UnsetMapFlag());
+            return false;
+        }
         const start = message.path[0];
-        if (player.delayed() || message.ctrlHeld < 0 || message.ctrlHeld > 1 || CoordGrid.distanceToSW(player, { x: start.x, z: start.z }) > 104) {
+        if (message.ctrlHeld < 0 || message.ctrlHeld > 1 || CoordGrid.distanceToSW(player, { x: start.x, z: start.z }) > 104) {
             player.unsetMapFlag();
             player.userPath = [];
             return false;

--- a/src/lostcity/network/225/incoming/handler/OpHeldTHandler.ts
+++ b/src/lostcity/network/225/incoming/handler/OpHeldTHandler.ts
@@ -36,7 +36,6 @@ export default class OpHeldTHandler extends MessageHandler<OpHeldT> {
         }
 
         if (player.delayed()) {
-            player.unsetMapFlag();
             return false;
         }
 

--- a/src/lostcity/network/225/incoming/handler/OpHeldUHandler.ts
+++ b/src/lostcity/network/225/incoming/handler/OpHeldUHandler.ts
@@ -54,7 +54,6 @@ export default class OpHeldUHandler extends MessageHandler<OpHeldU> {
         }
 
         if (player.delayed()) {
-            player.unsetMapFlag();
             return false;
         }
 

--- a/src/lostcity/network/225/incoming/handler/OpLocHandler.ts
+++ b/src/lostcity/network/225/incoming/handler/OpLocHandler.ts
@@ -5,13 +5,14 @@ import LocType from '#lostcity/cache/config/LocType.js';
 import ServerTriggerType from '#lostcity/engine/script/ServerTriggerType.js';
 import Interaction from '#lostcity/entity/Interaction.js';
 import { NetworkPlayer } from '#lostcity/entity/NetworkPlayer.js';
+import UnsetMapFlag from '#lostcity/network/outgoing/model/UnsetMapFlag.js';
 
 export default class OpLocHandler extends MessageHandler<OpLoc> {
     handle(message: OpLoc, player: NetworkPlayer): boolean {
         const { x, z, loc: locId } = message;
 
         if (player.delayed()) {
-            player.unsetMapFlag();
+            player.write(new UnsetMapFlag());
             return false;
         }
 

--- a/src/lostcity/network/225/incoming/handler/OpLocTHandler.ts
+++ b/src/lostcity/network/225/incoming/handler/OpLocTHandler.ts
@@ -5,13 +5,14 @@ import OpLocT from '#lostcity/network/incoming/model/OpLocT.js';
 import World from '#lostcity/engine/World.js';
 import Interaction from '#lostcity/entity/Interaction.js';
 import ServerTriggerType from '#lostcity/engine/script/ServerTriggerType.js';
+import UnsetMapFlag from '#lostcity/network/outgoing/model/UnsetMapFlag.js';
 
 export default class OpLocTHandler extends MessageHandler<OpLocT> {
     handle(message: OpLocT, player: NetworkPlayer): boolean {
         const { x, z, loc: locId, spellComponent: spellComId } = message;
 
         if (player.delayed()) {
-            player.unsetMapFlag();
+            player.write(new UnsetMapFlag());
             return false;
         }
 

--- a/src/lostcity/network/225/incoming/handler/OpLocUHandler.ts
+++ b/src/lostcity/network/225/incoming/handler/OpLocUHandler.ts
@@ -7,13 +7,14 @@ import ObjType from '#lostcity/cache/config/ObjType.js';
 import Interaction from '#lostcity/entity/Interaction.js';
 import ServerTriggerType from '#lostcity/engine/script/ServerTriggerType.js';
 import Environment from '#lostcity/util/Environment.js';
+import UnsetMapFlag from '#lostcity/network/outgoing/model/UnsetMapFlag.js';
 
 export default class OpLocUHandler extends MessageHandler<OpLocU> {
     handle(message: OpLocU, player: NetworkPlayer): boolean {
         const { x, z, loc: locId, useObj: item, useSlot: slot, useComponent: comId } = message;
 
         if (player.delayed()) {
-            player.unsetMapFlag();
+            player.write(new UnsetMapFlag());
             return false;
         }
 

--- a/src/lostcity/network/225/incoming/handler/OpNpcHandler.ts
+++ b/src/lostcity/network/225/incoming/handler/OpNpcHandler.ts
@@ -5,13 +5,14 @@ import Interaction from '#lostcity/entity/Interaction.js';
 import World from '#lostcity/engine/World.js';
 import { NetworkPlayer } from '#lostcity/entity/NetworkPlayer.js';
 import OpNpc from '#lostcity/network/incoming/model/OpNpc.js';
+import UnsetMapFlag from '#lostcity/network/outgoing/model/UnsetMapFlag.js';
 
 export default class OpNpcHandler extends MessageHandler<OpNpc> {
     handle(message: OpNpc, player: NetworkPlayer): boolean {
         const { nid } = message;
 
         if (player.delayed()) {
-            player.unsetMapFlag();
+            player.write(new UnsetMapFlag());
             return false;
         }
 

--- a/src/lostcity/network/225/incoming/handler/OpNpcTHandler.ts
+++ b/src/lostcity/network/225/incoming/handler/OpNpcTHandler.ts
@@ -5,13 +5,14 @@ import World from '#lostcity/engine/World.js';
 import Interaction from '#lostcity/entity/Interaction.js';
 import ServerTriggerType from '#lostcity/engine/script/ServerTriggerType.js';
 import { NetworkPlayer } from '#lostcity/entity/NetworkPlayer.js';
+import UnsetMapFlag from '#lostcity/network/outgoing/model/UnsetMapFlag.js';
 
 export default class OpNpcTHandler extends MessageHandler<OpNpcT> {
     handle(message: OpNpcT, player: NetworkPlayer): boolean {
         const { nid, spellComponent: spellComId } = message;
 
         if (player.delayed()) {
-            player.unsetMapFlag();
+            player.write(new UnsetMapFlag());
             return false;
         }
 

--- a/src/lostcity/network/225/incoming/handler/OpNpcUHandler.ts
+++ b/src/lostcity/network/225/incoming/handler/OpNpcUHandler.ts
@@ -7,13 +7,14 @@ import Interaction from '#lostcity/entity/Interaction.js';
 import ServerTriggerType from '#lostcity/engine/script/ServerTriggerType.js';
 import { NetworkPlayer } from '#lostcity/entity/NetworkPlayer.js';
 import Environment from '#lostcity/util/Environment.js';
+import UnsetMapFlag from '#lostcity/network/outgoing/model/UnsetMapFlag.js';
 
 export default class OpNpcUHandler extends MessageHandler<OpNpcU> {
     handle(message: OpNpcU, player: NetworkPlayer): boolean {
         const { nid, useObj: item, useSlot: slot, useComponent: comId } = message;
 
         if (player.delayed()) {
-            player.unsetMapFlag();
+            player.write(new UnsetMapFlag());
             return false;
         }
 

--- a/src/lostcity/network/225/incoming/handler/OpObjHandler.ts
+++ b/src/lostcity/network/225/incoming/handler/OpObjHandler.ts
@@ -5,13 +5,14 @@ import OpObj from '#lostcity/network/incoming/model/OpObj.js';
 import ServerTriggerType from '#lostcity/engine/script/ServerTriggerType.js';
 import Interaction from '#lostcity/entity/Interaction.js';
 import { NetworkPlayer } from '#lostcity/entity/NetworkPlayer.js';
+import UnsetMapFlag from '#lostcity/network/outgoing/model/UnsetMapFlag.js';
 
 export default class OpObjHandler extends MessageHandler<OpObj> {
     handle(message: OpObj, player: NetworkPlayer): boolean {
         const { x, z, obj: objId } = message;
 
         if (player.delayed()) {
-            player.unsetMapFlag();
+            player.write(new UnsetMapFlag());
             return false;
         }
 

--- a/src/lostcity/network/225/incoming/handler/OpObjTHandler.ts
+++ b/src/lostcity/network/225/incoming/handler/OpObjTHandler.ts
@@ -5,13 +5,14 @@ import Interaction from '#lostcity/entity/Interaction.js';
 import ServerTriggerType from '#lostcity/engine/script/ServerTriggerType.js';
 import World from '#lostcity/engine/World.js';
 import { NetworkPlayer } from '#lostcity/entity/NetworkPlayer.js';
+import UnsetMapFlag from '#lostcity/network/outgoing/model/UnsetMapFlag.js';
 
 export default class OpObjTHandler extends MessageHandler<OpObjT> {
     handle(message: OpObjT, player: NetworkPlayer): boolean {
         const { x, z, obj: objId, spellComponent: spellComId } = message;
 
         if (player.delayed()) {
-            player.unsetMapFlag();
+            player.write(new UnsetMapFlag());
             return false;
         }
 

--- a/src/lostcity/network/225/incoming/handler/OpObjUHandler.ts
+++ b/src/lostcity/network/225/incoming/handler/OpObjUHandler.ts
@@ -7,13 +7,14 @@ import Interaction from '#lostcity/entity/Interaction.js';
 import ServerTriggerType from '#lostcity/engine/script/ServerTriggerType.js';
 import { NetworkPlayer } from '#lostcity/entity/NetworkPlayer.js';
 import Environment from '#lostcity/util/Environment.js';
+import UnsetMapFlag from '#lostcity/network/outgoing/model/UnsetMapFlag.js';
 
 export default class OpObjUHandler extends MessageHandler<OpObjU> {
     handle(message: OpObjU, player: NetworkPlayer): boolean {
         const { x, z, obj: objId, useObj: item, useSlot: slot, useComponent: comId } = message;
 
         if (player.delayed()) {
-            player.unsetMapFlag();
+            player.write(new UnsetMapFlag());
             return false;
         }
 

--- a/src/lostcity/network/225/incoming/handler/OpPlayerHandler.ts
+++ b/src/lostcity/network/225/incoming/handler/OpPlayerHandler.ts
@@ -4,13 +4,14 @@ import { NetworkPlayer } from '#lostcity/entity/NetworkPlayer.js';
 import World from '#lostcity/engine/World.js';
 import ServerTriggerType from '#lostcity/engine/script/ServerTriggerType.js';
 import Interaction from '#lostcity/entity/Interaction.js';
+import UnsetMapFlag from '#lostcity/network/outgoing/model/UnsetMapFlag.js';
 
 export default class OpPlayerHandler extends MessageHandler<OpPlayer> {
     handle(message: OpPlayer, player: NetworkPlayer): boolean {
         const { pid } = message;
 
         if (player.delayed()) {
-            player.unsetMapFlag();
+            player.write(new UnsetMapFlag());
             return false;
         }
 

--- a/src/lostcity/network/225/incoming/handler/OpPlayerTHandler.ts
+++ b/src/lostcity/network/225/incoming/handler/OpPlayerTHandler.ts
@@ -5,13 +5,14 @@ import World from '#lostcity/engine/World.js';
 import Interaction from '#lostcity/entity/Interaction.js';
 import ServerTriggerType from '#lostcity/engine/script/ServerTriggerType.js';
 import { NetworkPlayer } from '#lostcity/entity/NetworkPlayer.js';
+import UnsetMapFlag from '#lostcity/network/outgoing/model/UnsetMapFlag.js';
 
 export default class OpPlayerTHandler extends MessageHandler<OpPlayerT> {
     handle(message: OpPlayerT, player: NetworkPlayer): boolean {
         const { pid, spellComponent: spellComId } = message;
 
         if (player.delayed()) {
-            player.unsetMapFlag();
+            player.write(new UnsetMapFlag());
             return false;
         }
 

--- a/src/lostcity/network/225/incoming/handler/OpPlayerUHandler.ts
+++ b/src/lostcity/network/225/incoming/handler/OpPlayerUHandler.ts
@@ -7,13 +7,14 @@ import { NetworkPlayer } from '#lostcity/entity/NetworkPlayer.js';
 import OpPlayerU from '#lostcity/network/incoming/model/OpPlayerU.js';
 import Component from '#lostcity/cache/config/Component.js';
 import Environment from '#lostcity/util/Environment.js';
+import UnsetMapFlag from '#lostcity/network/outgoing/model/UnsetMapFlag.js';
 
 export default class OpPlayerUHandler extends MessageHandler<OpPlayerU> {
     handle(message: OpPlayerU, player: NetworkPlayer): boolean {
         const { pid, useObj: item, useSlot: slot, useComponent: comId } = message;
 
         if (player.delayed()) {
-            player.unsetMapFlag();
+            player.write(new UnsetMapFlag());
             return false;
         }
 


### PR DESCRIPTION
Engine:
- extra check to decrement waypoint if player is standing on waypoint tile in . Currently our waypoints only decrement on a change of direction during the players path. P_teleports can cause this change of direction calculation to change, as p_teleport can change the player's x and z before movement is processed. So an additional check is necessary
- clearWaypoints *before* executing the script in `processInteractions()`, unless aprange is called. If a p_op command is called within the aptrigger, clearWaypoints after executing the script (Not entirely sure if this is how it should be implemented, but thats how the old code handled p_op commands in aptriggers)
- clearWaypoints *before* executing the script for npc's in `aiMode()`
- still queueWaypoint to current tile if current tile and target tile are the same (todo: update rsmod's findpath function)
- adjust moveToClick & op handler behavior to not clearWaypoints when delayed
- don't process movement if busy & have something queued, instead of just having modal interface open and something queued

Content:
- south and north directions for ~push_player were flipped
- anim(null, 0) should be called before ~push_player instead of after
- debugprocs for testing interactions


[Firemaking edgecases that are now 1:1](https://github.com/2004Scape/Server/wiki/Firemaking-Edge-Cases)

# Some Interactions that remain unaffected
## Pathing to entities as they delete
https://github.com/user-attachments/assets/8f74a2b4-5fde-4801-8bed-c5e123495104

## Pathing to npc target as npc is changing type:
https://github.com/user-attachments/assets/da823480-6f3a-4185-9114-f2c53310d722

## ai_opplayer interactions while moving
https://github.com/user-attachments/assets/3d0b94c1-d10e-423a-b294-db8bb4dbaf7d

## ai_applayer interactions while moving
https://github.com/user-attachments/assets/cc5f9ca1-5dc8-4254-bd45-f0f9a40a0190

## Repathing on last waypoint
https://github.com/user-attachments/assets/0f120541-fc81-42b1-8591-5466a0ee7751

## Not repathing
https://github.com/user-attachments/assets/84767c30-7c4c-468e-93c6-af6761d794a9

