### PR TITLE
fix(engine): p_walk should move the player when movement is processed

### DIFF
--- a/src/lostcity/engine/script/handlers/PlayerOps.ts
+++ b/src/lostcity/engine/script/handlers/PlayerOps.ts
@@ -393,7 +393,6 @@ const PlayerOps: CommandHandlers = {
 
         const player = state.activePlayer;
         player.queueWaypoints(rsmod.findPath(player.level, player.x, player.z, coord.x, coord.z, player.width, player.width, player.length));
-        player.updateMovement(false); // try to walk immediately
     }),
 
     [ScriptOpcode.SAY]: checkedHandler(ActivePlayer, state => {

--- a/src/lostcity/entity/Player.ts
+++ b/src/lostcity/entity/Player.ts
@@ -963,16 +963,15 @@ export default class Player extends PathingEntity {
             this.interacted = true;
             this.clearWaypoints();
         }
-
-        const moved: boolean = this.updateMovement();
-        if (moved) {
-            // we need to keep the mask if the player had to move.
-            this.alreadyFacedEntity = false;
-        }
+        let moved = false;
 
         if (this.target && (!this.interacted || this.apRangeCalled)) {
             this.interacted = false;
-
+            moved = this.updateMovement();
+            if (moved) {
+                // we need to keep the mask if the player had to move.
+                this.alreadyFacedEntity = false;
+            }
             if (opTrigger && (this.target instanceof PathingEntity || !moved) && this.inOperableDistance(this.target)) {
 
                 const target = this.target;


### PR DESCRIPTION
Only updateMovement if first interaction failed, or aprange called to match:

https://github.com/user-attachments/assets/3a4b9182-7eb7-4330-bd22-590a12d7beba


https://github.com/user-attachments/assets/1b1f705a-09fd-4b88-8212-1366cf4523ca

