### PR TITLE
chore(engine): pin typescript version to 5.5.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "prisma-kysely": "^1.8.0",
     "sort-package-json": "^2.10.0",
     "tinybench": "^2.8.0",
-    "typescript": "^5.5.4",
+    "typescript": "5.5.4",
     "vitest": "^1.6.0"
   },
   "optionalDependencies": {


### PR DESCRIPTION
ts 5.6 introduced some new iterator subtypes which the EntityList code is not compatible with

https://devblogs.microsoft.com/typescript/announcing-typescript-5-6/#what%E2%80%99s-new-since-the-beta-and-rc