### PR TITLE
fix(engine): revert npc_arrivedelay to old timings

### DIFF
--- a/src/lostcity/engine/script/handlers/NpcOps.ts
+++ b/src/lostcity/engine/script/handlers/NpcOps.ts
@@ -480,11 +480,11 @@ const NpcOps: CommandHandlers = {
 
     // https://x.com/JagexAsh/status/1432296606376906752
     [ScriptOpcode.NPC_ARRIVEDELAY]: checkedHandler(ActiveNpc, state => {
-        if (state.activeNpc.lastMovement < World.currentTick - 2) {
+        if (state.activeNpc.lastMovement < World.currentTick - 1) {
             return;
         }
-        // If npc moved 2 ticks ago, delay for 1 tick. If npc moved 1 tick ago or current tick, delay for 2 ticks
-        if (state.activeNpc.lastMovement === World.currentTick - 2) {
+        // If npc moved 2 ticks ago, delay for 1 tick, else delay for 2 ticks
+        if (state.activeNpc.lastMovement === World.currentTick - 1) {
             state.activeNpc.delay = 1;
         } else {
             state.activeNpc.delay = 2;

--- a/src/lostcity/engine/script/handlers/NpcOps.ts
+++ b/src/lostcity/engine/script/handlers/NpcOps.ts
@@ -483,7 +483,7 @@ const NpcOps: CommandHandlers = {
         if (state.activeNpc.lastMovement < World.currentTick - 1) {
             return;
         }
-        // If npc moved 2 ticks ago, delay for 1 tick, else delay for 2 ticks
+        // If npc moved 1 tick ago, delay for 1 tick. If npc moved this tick, delay for 2 ticks
         if (state.activeNpc.lastMovement === World.currentTick - 1) {
             state.activeNpc.delay = 1;
         } else {


### PR DESCRIPTION
Note that hill giants had a shorter death delay back then. The arrivedelay should be the same though

## Move back and melee

https://github.com/user-attachments/assets/e18e0abe-bc87-40d5-b401-85b1a19d2a98



https://github.com/user-attachments/assets/b76b827e-6430-4cf1-a287-bc7738f42bea


## Range from afar
https://github.com/user-attachments/assets/ca21537c-57ee-48c4-a315-3a2ab4e8b82c



https://github.com/user-attachments/assets/3aeaadb9-901a-4d28-99c2-a26811189a47



