### PR TITLE
fix(engine): match osrs redx and yellowx mechanics

### DIFF
--- a/src/lostcity/engine/World.ts
+++ b/src/lostcity/engine/World.ts
@@ -823,7 +823,10 @@ class World {
                     player.pathToTarget();
                     continue;
                 }
-
+                
+                if (player.busy() || !player.opcalled) {
+                    player.moveClickRequest = true;
+                }
                 player.pathToMoveClick(player.userPath, !Environment.NODE_CLIENT_ROUTEFINDER);
             }
 

--- a/src/lostcity/engine/script/handlers/PlayerOps.ts
+++ b/src/lostcity/engine/script/handlers/PlayerOps.ts
@@ -392,6 +392,7 @@ const PlayerOps: CommandHandlers = {
         const coord: CoordGrid = check(state.popInt(), CoordValid);
 
         const player = state.activePlayer;
+        player.moveClickRequest = false;
         player.queueWaypoints(rsmod.findPath(player.level, player.x, player.z, coord.x, coord.z, player.width, player.width, player.length));
     }),
 

--- a/src/lostcity/entity/Player.ts
+++ b/src/lostcity/entity/Player.ts
@@ -281,6 +281,7 @@ export default class Player extends PathingEntity {
     allowDesign: boolean = false;
     afkEventReady: boolean = false;
     interactWalkTrigger: boolean = false;
+    moveClickRequest: boolean = false;
 
     highPriorityOut: Stack<OutgoingMessage> = new Stack();
     lowPriorityOut: Stack<OutgoingMessage> = new Stack();
@@ -530,9 +531,14 @@ export default class Player extends PathingEntity {
 
     // ----
 
+    clearWaypoints(): void {
+        this.moveClickRequest = false;
+        super.clearWaypoints();
+    }
+
     updateMovement(repathAllowed: boolean = true): boolean {
         // players cannot walk if they have a modal open *and* something in their queue, confirmed as far back as 2005
-        if (this.busy() && (this.queue.head() != null || this.engineQueue.head() != null)) {
+        if (this.moveClickRequest && this.busy() && (this.queue.head() != null || this.engineQueue.head() != null)) {
             this.recoverEnergy(false);
             return false;
         }
@@ -573,6 +579,9 @@ export default class Player extends PathingEntity {
         }
         if (moved) {
             this.lastMovement = World.currentTick + 1;
+        }
+        if (this.waypointIndex === -1) {
+            this.moveClickRequest = false;
         }
         return moved;
     }


### PR DESCRIPTION
## Busy + queued cases in osrs:

https://github.com/user-attachments/assets/c35ce9fa-0847-4be5-8c2b-cfa385c2934c

## Busy + queued cases with 2004 engine fixes:

https://github.com/user-attachments/assets/67000329-f10c-4079-a166-f860d93ca131


## Consequently lets you p_walk + busy + queued. Unconfirmed but this is very likely the case in osrs

https://github.com/user-attachments/assets/7a42d51c-6142-46a9-b0c7-d9c00d69d1f7

