### PR TITLE
fix(engine): reveal on untradeable objs

### DIFF
--- a/src/lostcity/engine/World.ts
+++ b/src/lostcity/engine/World.ts
@@ -1440,8 +1440,9 @@ class World {
         }
         const zone: Zone = this.gameMap.getZone(obj.x, obj.z, obj.level);
         zone.addObj(obj, receiverId);
-        if (receiverId !== -1 && objType.tradeable && (objType.members && Environment.NODE_MEMBERS || !objType.members)) {
-            // objs always reveal 100 ticks after being dropped.
+        if (receiverId !== -1) {
+            // objs with a receiver always attempt to reveal 100 ticks after being dropped.
+            // items that can't be revealed (untradable, members obj in f2p) will be skipped in revealObj
             const reveal: number = this.currentTick + Obj.REVEAL;
             obj.setLifeCycle(reveal);
             this.trackZone(reveal, zone);

--- a/src/lostcity/engine/zone/Zone.ts
+++ b/src/lostcity/engine/zone/Zone.ts
@@ -29,6 +29,8 @@ import ZoneMessageEncoder from '#lostcity/network/outgoing/codec/ZoneMessageEnco
 import ZoneMessage from '#lostcity/network/outgoing/ZoneMessage.js';
 import ZoneEntityList, {LocList, ObjList} from '#lostcity/engine/zone/ZoneEntityList.js';
 import NonPathingEntity from '#lostcity/entity/NonPathingEntity.js';
+import ObjType from '#lostcity/cache/config/ObjType.js';
+import Environment from '#lostcity/util/Environment.js';
 
 export default class Zone {
     private static readonly SIZE: number = 8 * 8;
@@ -97,7 +99,7 @@ export default class Zone {
                     continue;
                 }
                 if (obj.lifecycle === EntityLifeCycle.DESPAWN) {
-                    if (obj.receiverId !== -1) {
+                    if (obj.reveal !== -1) {
                         World.revealObj(obj);
                     } else {
                         World.removeObj(obj, 0);
@@ -302,6 +304,11 @@ export default class Zone {
     }
 
     revealObj(obj: Obj, receiverId: number): void {
+        const objType: ObjType = ObjType.get(obj.type);
+        if(!(objType.tradeable && (objType.members && Environment.NODE_MEMBERS || !objType.members))) {
+            obj.reveal = -1;
+            return;
+        }
         obj.receiverId = -1;
         obj.reveal = -1;
         obj.lastChange = -1;


### PR DESCRIPTION
- Set receiverid for all objs where applicable to prevent showing to other players
- Untradeable objs ground duration (with a receiver) will now match tradeable objs (3 minutes instead of 2)