### PR TITLE
fix(engine): prevent npc pathing to target if target is outside maxrange

### DIFF
--- a/src/lostcity/entity/Npc.ts
+++ b/src/lostcity/entity/Npc.ts
@@ -181,56 +181,9 @@ export default class Npc extends PathingEntity {
 
     updateMovement(repathAllowed: boolean = true): boolean {
         const type = NpcType.get(this.type);
-        if (this.target && this.targetOp !== NpcMode.PLAYERFOLLOW && this.targetOp !== NpcMode.WANDER) {
-            const apTrigger: boolean =
-            (this.targetOp >= NpcMode.APNPC1 && this.targetOp <= NpcMode.APNPC5) ||
-            (this.targetOp >= NpcMode.APPLAYER1 && this.targetOp <= NpcMode.APPLAYER5) ||
-            (this.targetOp >= NpcMode.APLOC1 && this.targetOp <= NpcMode.APLOC5) ||
-            (this.targetOp >= NpcMode.APOBJ1 && this.targetOp <= NpcMode.APOBJ5);
-            const opTrigger: boolean = !apTrigger;
-
-            if (this.targetOp === NpcMode.PLAYERESCAPE) {
-                const distanceToEscape = CoordGrid.distanceTo(this, {
-                    x: this.startX,
-                    z: this.startZ,
-                    width: this.width,
-                    length: this.length
-                });
-                const targetDistanceFromStart = CoordGrid.distanceTo(this.target, {
-                    x: this.startX,
-                    z: this.startZ,
-                    width: this.target.width,
-                    length: this.target.length
-                });
-    
-                if (targetDistanceFromStart > type.maxrange && distanceToEscape > type.maxrange) {
-                    return false;
-                }
-            } else if (opTrigger) {
-                const distanceToX = Math.abs(this.target.x - this.startX);
-                const distanceToZ = Math.abs(this.target.z - this.startZ);
-                if (Math.max(distanceToX, distanceToZ) > type.maxrange + 1) {
-                    this.clearWaypoints();
-                    this.defaultMode();
-                    return false;
-                }
-                // remove corner
-                if (distanceToX === type.maxrange + 1 && distanceToZ === type.maxrange + 1) {
-                    this.clearWaypoints();
-                    this.defaultMode();
-                    return false; 
-                }
-            } else if (apTrigger) {
-                if (CoordGrid.distanceToSW(this.target, {x: this.startX, z: this.startZ}) > type.maxrange + type.attackrange) {
-                    this.clearWaypoints();
-                    this.defaultMode();
-                    return false; 
-                }
-            } else if (CoordGrid.distanceToSW(this.target, {x: this.startX, z: this.startZ}) > type.maxrange) {
-                this.clearWaypoints();
-                this.defaultMode();
-                return false;
-            }
+        if (!this.targetWithinMaxRange()) {
+            this.defaultMode();
+            return false;
         }
         if (type.moverestrict === MoveRestrict.NOMOVE) {
             return false;
@@ -266,6 +219,63 @@ export default class Npc extends PathingEntity {
     clearInteraction() {
         super.clearInteraction();
         this.huntTarget = null;
+    }
+
+    pathToTarget(): void {
+        if (!this.targetWithinMaxRange()) {
+            this.defaultMode();
+            return;
+        }
+        super.pathToTarget();
+    }
+
+    targetWithinMaxRange(): boolean {
+        if (!this.target) {
+            return true;
+        }
+        const type = NpcType.get(this.type);
+
+        const apTrigger: boolean =
+        (this.targetOp >= NpcMode.APNPC1 && this.targetOp <= NpcMode.APNPC5) ||
+        (this.targetOp >= NpcMode.APPLAYER1 && this.targetOp <= NpcMode.APPLAYER5) ||
+        (this.targetOp >= NpcMode.APLOC1 && this.targetOp <= NpcMode.APLOC5) ||
+        (this.targetOp >= NpcMode.APOBJ1 && this.targetOp <= NpcMode.APOBJ5);
+        const opTrigger: boolean = !apTrigger;
+        if (opTrigger) {
+            const distanceToX = Math.abs(this.target.x - this.startX);
+            const distanceToZ = Math.abs(this.target.z - this.startZ);
+            if (Math.max(distanceToX, distanceToZ) > type.maxrange + 1) {
+                return false;
+            }
+            // remove corner
+            if (distanceToX === type.maxrange + 1 && distanceToZ === type.maxrange + 1) {
+                return false; 
+            }
+        } else if (apTrigger) {
+            if (CoordGrid.distanceToSW(this.target, {x: this.startX, z: this.startZ}) > type.maxrange + type.attackrange) {
+                return false; 
+            }
+        } else if (this.targetOp === NpcMode.PLAYERESCAPE) {
+            const distanceToEscape = CoordGrid.distanceTo(this, {
+                x: this.startX,
+                z: this.startZ,
+                width: this.width,
+                length: this.length
+            });
+            const targetDistanceFromStart = CoordGrid.distanceTo(this.target, {
+                x: this.startX,
+                z: this.startZ,
+                width: this.target.width,
+                length: this.target.length
+            });
+
+            if (targetDistanceFromStart > type.maxrange && distanceToEscape > type.maxrange) {
+                return false;
+            }
+        } else if (CoordGrid.distanceToSW(this.target, {x: this.startX, z: this.startZ}) > type.maxrange) {
+            return false;
+        }
+        return true;
     }
 
     blockWalkFlag(): CollisionFlag {

--- a/src/lostcity/entity/Npc.ts
+++ b/src/lostcity/entity/Npc.ts
@@ -233,6 +233,9 @@ export default class Npc extends PathingEntity {
         if (!this.target) {
             return true;
         }
+        if (this.targetOp === NpcMode.PLAYERFOLLOW) {
+            return true;
+        }
         const type = NpcType.get(this.type);
 
         const apTrigger: boolean =

--- a/src/lostcity/entity/Npc.ts
+++ b/src/lostcity/entity/Npc.ts
@@ -596,7 +596,6 @@ export default class Npc extends PathingEntity {
         const type = NpcType.get(this.type);
 
         if (CoordGrid.distanceTo(this, this.target) > type.maxrange) {
-            this.clearWaypoints();
             this.defaultMode();
             return;
         }
@@ -626,7 +625,6 @@ export default class Npc extends PathingEntity {
         }
 
         if (CoordGrid.distanceTo(this, this.target) > 1) {
-            this.clearWaypoints();
             this.defaultMode();
             return;
         }


### PR DESCRIPTION
## To replicate this behavior:

https://github.com/user-attachments/assets/3a927def-0904-4363-ba73-22db88b1cc6a


https://github.com/user-attachments/assets/9e6e63c9-81e0-4e5e-b84b-e6267bf885f6

## Npc's still ignore the player if attacked outside of maxrange
This used to clearWaypoints, which inadvertently stopped their movement entirely

https://github.com/user-attachments/assets/e3b86169-03bd-4a27-baf0-7fd6af83425f

## Also fixes the playerface npc mode bug
Previous 'fix' was to clearWaypoints, which again inadvertently stopped their movement entirely

https://github.com/user-attachments/assets/67e9013f-f663-4055-8fdf-039a662cc927


