### PR TITLE
fix(content): misc fixes

### DIFF
--- a/data/src/pack/varp.pack
+++ b/data/src/pack/varp.pack
@@ -121,7 +121,7 @@
 120=pk_predator2
 121=pk_predator3
 122=squire_progress
-123=varp_123
+123=pk_binder
 124=skill_anim
 125=skill_sound
 126=shop

--- a/data/src/scripts/_unpack/all.varp
+++ b/data/src/scripts/_unpack/all.varp
@@ -146,7 +146,9 @@ type=player_uid
 protect=no
 type=player_uid
 
-[varp_123]
+[pk_binder]
+protect=no
+type=player_uid
 
 [skill_anim]
 

--- a/data/src/scripts/player/scripts/drop.rs2
+++ b/data/src/scripts/player/scripts/drop.rs2
@@ -10,4 +10,5 @@ if (~inzone_coord_pair_table(trawler_wreck_zones, coord) = true) {
     return;
 }
 inv_dropslot(inv, coord, $last, 200);
+anim(null, 0); // https://youtu.be/QvDYolBZNjY?t=164, https://youtu.be/DVHCP2JhQE0?t=142
 sound_synth(put_down, 0, 0);

--- a/data/src/scripts/quests/quest_mcannon/scripts/cannon.rs2
+++ b/data/src/scripts/quests/quest_mcannon/scripts/cannon.rs2
@@ -196,6 +196,10 @@ if (~cannon_belongs_to_player = false) {
     mes("This is not your cannon."); // osrs
     return;
 }
+if (inv_freespace(inv) < 4) {
+    mes("You need 4 free inventory spaces to pick that up."); // osrs
+    return;
+}
 mes("You pick up the cannon,"); // https://youtu.be/TeQXQDaawO0?t=518
 mes("It's really heavy.");
 sound_synth(pick, 0, 0);
@@ -203,10 +207,6 @@ sound_synth(pick, 0, 0);
 %mcannon_decay_clock = null;
 cleartimer(cannon_rotate);
 cleartimer(cannon_decay);
-if (inv_freespace(inv) < 4) {
-    mes("You need 4 free inventory spaces to pick that up."); // osrs
-    return;
-}
 inv_add(inv, cannon_base, 1);
 inv_add(inv, cannon_stand, 1);
 inv_add(inv, cannon_barrels, 1);

--- a/data/src/scripts/quests/quest_mcannon/scripts/cannon.rs2
+++ b/data/src/scripts/quests/quest_mcannon/scripts/cannon.rs2
@@ -247,7 +247,8 @@ if (last_useitem = mcannonball) {
         return;
     }
     def_int $count = min(sub(30, max(%mcannon_ammo, 0)), inv_total(inv, mcannonball));
-    mes("You load the cannon with <~pluralise($count, "cannonball")>."); // https://youtu.be/TeQXQDaawO0?t=239
+    // with one cannon ball, it'd still be plural: https://youtu.be/5itKFWuomiM&t=132
+    mes("You load the cannon with <tostring($count)> cannonballs."); // https://youtu.be/TeQXQDaawO0?t=239
     %mcannon_ammo = add(%mcannon_ammo, $count);
     inv_del(inv, mcannonball, $count);
 } else {

--- a/data/src/scripts/skill_combat/scripts/player/auto_retaliate.rs2
+++ b/data/src/scripts/skill_combat/scripts/player/auto_retaliate.rs2
@@ -1,5 +1,5 @@
 [queue,playerhit_n_retaliate](npc_uid $nid)
-if (%auto_retaliate = ^player_auto_retaliate_on & npc_finduid($nid) = true & ~npc_is_attackable() = true & busy2 = false) {
+if (%auto_retaliate = ^player_auto_retaliate_on & npc_finduid($nid) = true & busy2 = false) {
     // npc flinches player
     if (%action_delay < map_clock) {
         def_obj $weapon = inv_getobj(worn, ^wearpos_rhand);

--- a/data/src/scripts/skill_combat/scripts/pvp/pvp_magic.rs2
+++ b/data/src/scripts/skill_combat/scripts/pvp/pvp_magic.rs2
@@ -179,6 +179,7 @@ if ($freeze_time > 0) {
     if (~.check_protect_prayer(^magic_style) = true) {
         $freeze_time = divide($freeze_time, 2); // 50% reduction https://oldschool.runescape.wiki/w/Update:RS2_bugfixes_-_part_4
     }
+    .%pk_binder = uid;
     .queue(pvp_freeze_player, 0, $freeze_time);
 }
 
@@ -259,7 +260,7 @@ walktrigger(pvp_frozen);
 
 
 [walktrigger,pvp_frozen]
-if (.finduid(%pk_predator1) = true) { // todo: check in osrs if this is a separate varp? %pk_predator1 can be reset before the freeze is over?
+if (.finduid(%pk_binder) = true) {
     if (distance(coord, .coord) > 10) { // https://youtu.be/SC4KF1JWVl8&t=76
         return;
     }

--- a/data/src/scripts/skill_combat/scripts/pvp/pvp_magic.rs2
+++ b/data/src/scripts/skill_combat/scripts/pvp/pvp_magic.rs2
@@ -255,4 +255,17 @@ return($maxhit);
 [queue,pvp_freeze_player](int $duration)
 mes("You've been frozen!");
 %frozen = calc(map_clock + $duration + 1);
-walktrigger(frozen);
+walktrigger(pvp_frozen);
+
+
+[walktrigger,pvp_frozen]
+if (.finduid(%pk_predator1) = true) { // todo: check in osrs if this is a separate varp? %pk_predator1 can be reset before the freeze is over?
+    if (distance(coord, .coord) > 10) { // https://youtu.be/SC4KF1JWVl8&t=76
+        return;
+    }
+    if (map_clock < %frozen) {
+        mes("A magical force stops you from moving.");
+        p_walk(coord);
+        walktrigger(pvp_frozen);
+    }
+}

--- a/src/lostcity/engine/script/handlers/PlayerOps.ts
+++ b/src/lostcity/engine/script/handlers/PlayerOps.ts
@@ -57,6 +57,9 @@ import {
     GenderValid,
     SkinColourValid
 } from '#lostcity/engine/script/ScriptValidators.js';
+import NpcType from '#lostcity/cache/config/NpcType.js';
+import LocType from '#lostcity/cache/config/LocType.js';
+import ObjType from '#lostcity/cache/config/ObjType.js';
 
 const PlayerOps: CommandHandlers = {
     [ScriptOpcode.FINDUID]: state => {
@@ -335,6 +338,10 @@ const PlayerOps: CommandHandlers = {
         if (type < 0 || type >= 5) {
             throw new Error(`Invalid oploc: ${type + 1}`);
         }
+        const locType: LocType = LocType.get(state.activeLoc.type);
+        if (!locType.op || !locType.op[type]) {
+            return;
+        }
         state.activePlayer.stopAction();
         state.activePlayer.setInteraction(Interaction.SCRIPT, state.activeLoc, ServerTriggerType.APLOC1 + type);
     }),
@@ -344,6 +351,10 @@ const PlayerOps: CommandHandlers = {
         const type = check(state.popInt(), NumberNotNull) - 1;
         if (type < 0 || type >= 5) {
             throw new Error(`Invalid opnpc: ${type + 1}`);
+        }
+        const npcType: NpcType = NpcType.get(state.activeNpc.type);
+        if (!npcType.op || !npcType.op[type]) {
+            return;
         }
         state.activePlayer.stopAction();
         state.activePlayer.setInteraction(Interaction.SCRIPT, state.activeNpc, ServerTriggerType.APNPC1 + type, {type: state.activeNpc.type, com: -1});
@@ -857,6 +868,10 @@ const PlayerOps: CommandHandlers = {
         const type = check(state.popInt(), NumberNotNull) - 1;
         if (type < 0 || type >= 5) {
             throw new Error(`Invalid opobj: ${type + 1}`);
+        }
+        const objType: ObjType = ObjType.get(state.activeObj.type);
+        if (!objType.op || !objType.op[type]) {
+            return;
         }
         state.activePlayer.stopAction();
         state.activePlayer.setInteraction(Interaction.SCRIPT, state.activeObj, ServerTriggerType.APOBJ1 + type);


### PR DESCRIPTION
- fix: stop animations when dropping items to match early osrs.  https://youtu.be/QvDYolBZNjY?t=164, https://youtu.be/DVHCP2JhQE0?t=142
- fix: load cannonballs mes to never singularize 
![image](https://github.com/user-attachments/assets/c924ceed-4007-4e00-99ba-737c34f9e581)
- fix: remove npc attackable check from player retaliation, and check if the op exists in the p_op commands. If the npc does have an op2, when it runs there will already an npc attackable check in there. %action_delay is still set in this clip, causing me to firemake in 2 ticks:

https://github.com/user-attachments/assets/0d92f2d0-d46b-470b-a2a8-ab8b983eaac9
- fix: 10 tile check for pvp freezes to match: https://youtu.be/SC4KF1JWVl8&t=76. This is how it works in osrs currently, theres no indication in any blog posts that this was added post rs2 release
- fix: inv space check for the cannon is placed earlier in the tick