### PR TITLE
fix(engine): last_coord command to use last changed coord instead of last step

### DIFF
--- a/data/src/scripts/areas/area_wilderness/configs/wilderness_levels.constant
+++ b/data/src/scripts/areas/area_wilderness/configs/wilderness_levels.constant
@@ -1,1 +1,2 @@
 ^wilderness_starting_z = 3520
+^wilderness_warning_z = 3512

--- a/data/src/scripts/areas/area_wilderness/scripts/wilderness_warning.rs2
+++ b/data/src/scripts/areas/area_wilderness/scripts/wilderness_warning.rs2
@@ -4,14 +4,10 @@
 // https://youtu.be/jdcT9ogpMwE?t=104 underground
 // all on the same z axis
 [label,wilderness_warning]
-if (coordz(last_coord) < coordz(coord)) { // if player is comin from the south
-    queue(wilderness_warning, 0);
+if (coordz(last_coord) < ^wilderness_warning_z) {
+    p_stopaction;
+    if_openmain(wilderness_warning);
 }
-
-[queue,wilderness_warning]
-// no idea if they had an area check before opening this interface
-p_stopaction;
-if_openmain(wilderness_warning);
 
 [zone,0_45_54_48_56] @wilderness_warning;
 [zone,0_45_54_56_56] @wilderness_warning;

--- a/src/lostcity/engine/script/handlers/PlayerOps.ts
+++ b/src/lostcity/engine/script/handlers/PlayerOps.ts
@@ -1063,7 +1063,7 @@ const PlayerOps: CommandHandlers = {
     }),
 
     [ScriptOpcode.LAST_COORD]: checkedHandler(ActivePlayer, state => {
-        state.pushInt(CoordGrid.packCoord(state.activePlayer.level, state.activePlayer.lastStepX, state.activePlayer.lastStepZ));
+        state.pushInt(CoordGrid.packCoord(state.activePlayer.lastCoordLevel, state.activePlayer.lastCoordX, state.activePlayer.lastCoordZ));
     }),
 };
 

--- a/src/lostcity/entity/PathingEntity.ts
+++ b/src/lostcity/entity/PathingEntity.ts
@@ -53,6 +53,9 @@ export default abstract class PathingEntity extends Entity {
     lastInt: number = -1; // resume_p_countdialog, ai_queue
     lastCrawl: boolean = false;
     lastMovement: number = 0;
+    lastCoordX: number = -1;
+    lastCoordZ: number = -1;
+    lastCoordLevel: number = -1;
 
     walktrigger: number = -1;
     walktriggerArg: number = 0; // used for npcs
@@ -112,6 +115,9 @@ export default abstract class PathingEntity extends Entity {
         this.entitymask = entitymask;
         this.lastStepX = x - 1;
         this.lastStepZ = z;
+        this.lastCoordX = x;
+        this.lastCoordZ = z;
+        this.lastCoordLevel = level;
     }
 
     /**
@@ -136,21 +142,25 @@ export default abstract class PathingEntity extends Entity {
         if (!this.hasWaypoints() || this.moveSpeed === MoveSpeed.STATIONARY || this.moveSpeed === MoveSpeed.INSTANT) {
             return false;
         }
+        const previousX = this.x;
+        const previousZ = this.z;
+        const previousLevel = this.level;
 
         if (this.moveSpeed === MoveSpeed.CRAWL) {
             this.lastCrawl = !this.lastCrawl;
             if (this.lastCrawl && this.walkDir === -1) {
                 this.walkDir = this.validateAndAdvanceStep();
             }
-            return true;
-        }
-
-        // either walk or run speed here.
-        if (this.walkDir === -1) {
+        } else if (this.walkDir === -1) { // either walk or run speed here.
             this.walkDir = this.validateAndAdvanceStep();
             if (this.moveSpeed === MoveSpeed.RUN && this.walkDir !== -1 && this.runDir === -1) {
                 this.runDir = this.validateAndAdvanceStep();
             }
+        }
+        if (previousX !== this.x || previousZ !== this.z || previousLevel !== this.level) {
+            this.lastCoordX = previousX;
+            this.lastCoordZ = previousZ;
+            this.lastCoordLevel = previousLevel;
         }
         return true;
     }
@@ -284,7 +294,13 @@ export default abstract class PathingEntity extends Entity {
         this.lastStepX = this.x - 1;
         this.lastStepZ = this.z;
         this.tele = true;
-        
+
+        if (previousX !== x || previousZ !== z || previousLevel !== level) {
+            this.lastCoordX = previousX;
+            this.lastCoordZ = previousZ;
+            this.lastCoordLevel = previousLevel;
+        }
+
         if (previousLevel != level) {
             this.moveSpeed = MoveSpeed.INSTANT;
             this.jump = true;

--- a/src/lostcity/entity/Player.ts
+++ b/src/lostcity/entity/Player.ts
@@ -442,6 +442,9 @@ export default class Player extends PathingEntity {
 
         this.lastStepX = this.x - 1;
         this.lastStepZ = this.z;
+        this.lastCoordX = this.x;
+        this.lastCoordZ = this.z;
+        this.lastCoordLevel = this.level;
     }
 
     triggerMapzone(x: number, z: number) {


### PR DESCRIPTION
also refactors wildy warning code to only show wildy warning when you pass the "wilderness line"