### PR TITLE
fix(engine): ctrl-click to run inaccuracies 

### DIFF
--- a/src/lostcity/entity/Player.ts
+++ b/src/lostcity/entity/Player.ts
@@ -575,6 +575,8 @@ export default class Player extends PathingEntity {
         this.recoverEnergy(moved);
         if (this.runenergy === 0) {
             this.setVar(VarPlayerType.PLAYER_RUN, 0);
+        }
+        if (this.runenergy < 100) {
             this.setVar(VarPlayerType.TEMP_RUN, 0);
         }
         if (moved) {

--- a/src/lostcity/network/225/incoming/handler/MoveClickHandler.ts
+++ b/src/lostcity/network/225/incoming/handler/MoveClickHandler.ts
@@ -38,14 +38,12 @@ export default class MoveClickHandler extends MessageHandler<MoveClick> {
         if (!message.opClick) {
             player.clearInteraction();
             player.closeModal();
+            if (player.runenergy < 100 && message.ctrlHeld === 1) {
+                player.setVar(VarPlayerType.TEMP_RUN, 0);
+            } else {
+                player.setVar(VarPlayerType.TEMP_RUN, message.ctrlHeld);
+            }
         }
-
-        if (player.runenergy < 100 && message.ctrlHeld === 1) {
-            player.setVar(VarPlayerType.TEMP_RUN, 0);
-        } else {
-            player.setVar(VarPlayerType.TEMP_RUN, message.ctrlHeld);
-        }
-
         return true;
     }
 }

--- a/src/lostcity/network/225/incoming/handler/MoveClickHandler.ts
+++ b/src/lostcity/network/225/incoming/handler/MoveClickHandler.ts
@@ -40,7 +40,7 @@ export default class MoveClickHandler extends MessageHandler<MoveClick> {
             player.closeModal();
         }
 
-        if (player.runenergy < 100) {
+        if (player.runenergy < 100 && message.ctrlHeld === 1) {
             player.setVar(VarPlayerType.TEMP_RUN, 0);
         } else {
             player.setVar(VarPlayerType.TEMP_RUN, message.ctrlHeld);


### PR DESCRIPTION
- fix: prevent running on ctrl-click if op click, to match this [blog post](https://oldschool.runescape.wiki/w/Update:Wilderness_Feedback_Update) from 2014 osrs `Holding CTRL to run now functions correctly when clicking on an object or NPC.` (This is actually still the case for opu clicks in osrs!)
- fix: turn off run when below 100 run energy, only if ctrl-clicked, in move click handler
- fix: turn off run when below 100 run energy, if ctrl-clicked in movement process

## Video of spamming MoveClick below 100 run energy
I run for 2 ticks. Old implementation I'd run for 1 tick

Osrs:

https://github.com/user-attachments/assets/4715a666-0b24-40bd-9e82-78e814eb11a2

2004 with fixes:

https://github.com/user-attachments/assets/58faf95b-7d77-466c-a4a7-5d2a215476e2

## Video of running at 104 run energy by ctrl-clicking
I run for 1 tick, never reaching 0 run energy.

Osrs:

https://github.com/user-attachments/assets/12022742-83e1-47ff-95f5-3596c4a392bd

2004 with fixes:

https://github.com/user-attachments/assets/1e044ed2-0150-449c-a130-beecb1c9ba2c

