### PR TITLE
fix(engine): following took an extra tick if right next to target

### DIFF
--- a/src/lostcity/engine/World.ts
+++ b/src/lostcity/engine/World.ts
@@ -832,14 +832,15 @@ class World {
                     player.mask |= Player.FACE_ENTITY;
                 }
 
-                if (player.opcalled && (player.userPath.length === 0 || !Environment.NODE_CLIENT_ROUTEFINDER)) {
-                    player.pathToTarget();
-                    continue;
-                }
-                
                 if (player.busy() || !player.opcalled) {
                     player.moveClickRequest = true;
                 }
+                
+                if (player.opcalled && (player.userPath.length === 0 || !Environment.NODE_CLIENT_ROUTEFINDER)) {
+                    player.pathToPathingTarget();
+                    continue;
+                }
+                
                 player.pathToMoveClick(player.userPath, !Environment.NODE_CLIENT_ROUTEFINDER);
             }
 

--- a/src/lostcity/entity/PathingEntity.ts
+++ b/src/lostcity/entity/PathingEntity.ts
@@ -421,7 +421,12 @@ export default abstract class PathingEntity extends Entity {
     }
 
     pathToPathingTarget(): void {
-        if (!this.target || !(this.target instanceof PathingEntity)) {
+        if (!this.target) {
+            return;
+        }
+        
+        if (!(this.target instanceof PathingEntity)) {
+            this.pathToTarget();
             return;
         }
 


### PR DESCRIPTION
## Following paths to target tile instantly if already next to player

https://github.com/user-attachments/assets/fd925b05-fa2b-4876-bdeb-a31199b90f1c

https://github.com/user-attachments/assets/d1b778f4-d516-40e3-86b9-8ebfb0d87340

## Interface + redx in the same tick behavior will now occur for all redx clicks

https://github.com/user-attachments/assets/ef240abe-92c1-4971-bcd8-d81bbf92edf3

https://github.com/user-attachments/assets/877227a6-9228-44a1-aad0-04af8b76bf24


