### PR TITLE
fix(engine): Keep 'hidden' ops loaded in memory

### DIFF
--- a/src/lostcity/cache/config/LocType.ts
+++ b/src/lostcity/cache/config/LocType.ts
@@ -173,9 +173,6 @@ export default class LocType extends ConfigType {
             }
 
             this.op[code - 30] = dat.gjstr();
-            if (this.op[code - 30] === 'hidden') {
-                this.op[code - 30] = null;
-            }
         } else if (code === 40) {
             const count = dat.g1();
             this.recol_s = new Uint16Array(count);

--- a/src/lostcity/cache/config/NpcType.ts
+++ b/src/lostcity/cache/config/NpcType.ts
@@ -157,9 +157,6 @@ export default class NpcType extends ConfigType {
             }
 
             this.op[code - 30] = dat.gjstr();
-            if (this.op[code - 30] === 'hidden') {
-                this.op[code - 30] = null;
-            }
         } else if (code === 40) {
             const count = dat.g1();
             this.recol_s = new Uint16Array(count);


### PR DESCRIPTION
Interactions are checking and ignoring == null... so we need them to be valid on the server