### PR TITLE
fix(content): tweak mcannon projectile parameters

### DIFF
--- a/data/src/scripts/quests/quest_mcannon/scripts/cannon.rs2
+++ b/data/src/scripts/quests/quest_mcannon/scripts/cannon.rs2
@@ -360,7 +360,7 @@ if (~player_in_combat_check = false) { // https://youtu.be/TeQXQDaawO0?t=247
 }
 // map_projanim	id=53, starttime=0, endtime=40, angle=2, progress=11, startheight=36, endheight=35
 // (coord $coord, npc_uid $uid, spotanim $spotanim, int $startheight, int $endheight, int $delay, int $angle, int $length, int $offset, int $step)(int)
-def_int $duration = ~npc_projectile(movecoord(%mcannon_coord, 1, 0, 1), npc_uid, spotanim_53, 36, 35, 0, 2, 40, 0, 13);
+def_int $duration = ~npc_projectile(movecoord(%mcannon_coord, 1, 0, 1), npc_uid, spotanim_53, 36, 35, 0, 2, 35, 0, 5);
 %mcannon_ammo = sub(%mcannon_ammo, 1);
 sound_synth(mcannon_fire, 0, 0);
 def_int $damage = 0;


### PR DESCRIPTION
Updates the cannonball projectile length and step to match osrs.

Current args:

https://github.com/user-attachments/assets/8d6c6775-9671-4b8d-ae8d-2ccc00d84f5a



Modified args:


https://github.com/user-attachments/assets/9a671880-5686-4077-9bf6-d4b05e411f77

I do not have a rsprox log to back it up but i have some old notes from back 2017 where i logged a bunch of osrs projectiles:


```
{gfxId=53, sourceX=6976, sourceY=7360, targetX=6848, targetY=7488, startHeight=144, endHeight=140, delay=0, duration=30, slope=2, centerOffset=11}
{gfxId=53, sourceX=5952, sourceY=6080, targetX=5696, targetY=5952, startHeight=144, endHeight=140, delay=0, duration=35, slope=2, centerOffset=11}
{gfxId=53, sourceX=5952, sourceY=6080, targetX=5568, targetY=5952, startHeight=144, endHeight=140, delay=0, duration=40, slope=2, centerOffset=11}
{gfxId=53, sourceX=5952, sourceY=6080, targetX=5568, targetY=5568, startHeight=144, endHeight=140, delay=0, duration=45, slope=2, centerOffset=11}
{gfxId=53, sourceX=5952, sourceY=6080, targetX=5312, targetY=6592, startHeight=144, endHeight=140, delay=0, duration=50, slope=2, centerOffset=11}
{gfxId=53, sourceX=6976, sourceY=7360, targetX=7744, targetY=7360, startHeight=144, endHeight=140, delay=0, duration=55, slope=2, centerOffset=11}
{gfxId=53, sourceX=5952, sourceY=6080, targetX=5056, targetY=6848, startHeight=144, endHeight=140, delay=0, duration=60, slope=2, centerOffset=11}
{gfxId=53, sourceX=5952, sourceY=6080, targetX=4800, targetY=6080, startHeight=144, endHeight=140, delay=0, duration=70, slope=2, centerOffset=11}
```