### PR TITLE
fix(content): inverted locked doors

### DIFF
--- a/data/src/scripts/skill_thieving/configs/doors/locked_door.dbrow
+++ b/data/src/scripts/skill_thieving/configs/doors/locked_door.dbrow
@@ -65,6 +65,7 @@ data=replacement,loc_2055
 data=level,39
 data=experience,350
 data=tool,lockpick,lockpick
+data=lock_inversed,true
 
 [locked_door_loc_2559]
 table=locked_door
@@ -73,3 +74,4 @@ data=replacement,loc_2070
 data=level,82
 data=experience,500
 data=tool,lockpick,lockpick
+data=lock_inversed,true

--- a/data/src/scripts/skill_thieving/configs/doors/locked_door.dbtable
+++ b/data/src/scripts/skill_thieving/configs/doors/locked_door.dbtable
@@ -6,3 +6,4 @@ column=experience,int
 column=tool,namedobj,string
 column=mirror,boolean
 column=gate,boolean
+column=lock_inversed,boolean

--- a/data/src/scripts/skill_thieving/scripts/doors/locked_door.rs2
+++ b/data/src/scripts/skill_thieving/scripts/doors/locked_door.rs2
@@ -23,10 +23,10 @@
 ~attempt_open_locked_door(loc_type, ~check_axis_locactive(coord));
 
 [oploc1,loc_2558]
-~attempt_open_locked_door(loc_type, ~not_bool(~check_axis_locactive(coord)));
+~attempt_open_locked_door(loc_type, ~check_axis_locactive(coord));
 
 [oploc1,loc_2559]
-~attempt_open_locked_door(loc_type, ~not_bool(~check_axis_locactive(coord)));
+~attempt_open_locked_door(loc_type, ~check_axis_locactive(coord));
 
 [oploc2,loc_2550]
 ~pick_locked_door(loc_type, loc_coord, ~check_axis_locactive(coord));
@@ -54,27 +54,27 @@
 
 [oplocu,loc_2557]
 if(last_useitem = lockpick) {
-    ~pick_locked_door(loc_type, loc_coord, ~not_bool(~check_axis_locactive(coord)));
+    ~pick_locked_door(loc_type, loc_coord, ~check_axis_locactive(coord));
     return;
 }
 ~displaymessage(^dm_default);
 
 [oploc2,loc_2558]
-~pick_locked_door(loc_type, loc_coord, ~not_bool(~check_axis_locactive(coord)));
+~pick_locked_door(loc_type, loc_coord, ~check_axis_locactive(coord));
 
 [oplocu,loc_2558]
 if(last_useitem = lockpick) {
-    ~pick_locked_door(loc_type, loc_coord, ~not_bool(~check_axis_locactive(coord)));
+    ~pick_locked_door(loc_type, loc_coord, ~check_axis_locactive(coord));
     return;
 }
 ~displaymessage(^dm_default);
 
 [oploc2,loc_2559]
-~pick_locked_door(loc_type, loc_coord, ~not_bool(~check_axis_locactive(coord)));
+~pick_locked_door(loc_type, loc_coord, ~check_axis_locactive(coord));
 
 [oplocu,loc_2559]
 if(last_useitem = lockpick) {
-    ~pick_locked_door(loc_type, loc_coord, ~not_bool(~check_axis_locactive(coord)));
+    ~pick_locked_door(loc_type, loc_coord, ~check_axis_locactive(coord));
     return;
 }
 ~displaymessage(^dm_default);
@@ -86,19 +86,25 @@ if (map_members = false) {
     return;
 }
 
+db_find(locked_door:loc, $loc);
+def_dbrow $data = db_findnext;
+if ($data = null) {
+    ~displaymessage(^dm_default); 
+    return;
+}
+
+def_boolean $locked = $entering;
+if (db_getfield($data, locked_door:lock_inversed, 0) = true) {
+    $locked = ~not_bool($entering);
+}
+
 // check if player is outside
-if ($entering = true) {
+if ($locked = true) {
     mes("This door is locked.");
     sound_synth(locked, 0, 0);
     return;
 }
 
-db_find(locked_door:loc, $loc);
-def_dbrow $data = db_findnext;
-if ($data = null) {
-    ~displaymessage(^dm_default);
-    return;
-}
 def_loc $replacement = db_getfield($data, locked_door:replacement, 0);
 def_boolean $gate = db_getfield($data, locked_door:gate, 0);
 def_boolean $mirror = db_getfield($data, locked_door:mirror, 0);
@@ -122,10 +128,15 @@ if ($data = null) {
     return;
 }
 
+def_boolean $locked = $entering;
+if (db_getfield($data, locked_door:lock_inversed, 0) = true) {
+    $locked = ~not_bool($entering);
+}
+
 def_loc $replacement = db_getfield($data, locked_door:replacement, 0);
 def_boolean $gate = db_getfield($data, locked_door:gate, 0);
 def_boolean $mirror = db_getfield($data, locked_door:mirror, 0);
-if ($entering = true) {
+if ($locked = true) {
     if (db_getfieldcount($data, locked_door:tool) > 0) {
         def_namedobj $tool;
         def_string $name;


### PR DESCRIPTION
A few doors have the locked side as the inverse of the entering side:
door 1 - pirate hut wildy (pos 3045, 3956)
door 2 - yanille dungeon (pos 2601, 9481)