### PR TITLE
fix(content): misc fixes

### DIFF
--- a/data/src/scripts/general_use/scripts/chests.rs2
+++ b/data/src/scripts/general_use/scripts/chests.rs2
@@ -34,7 +34,7 @@ if(map_members = true) {
         return;
     }
 }
-if (random(^findsomethingnice_chance) = 0) {
+if (random(^findsomethingnice_chance) = 0 & ~in_tutorial_island(coord) = false) {
     mes("You search the chest."); // guess
     p_delay(2);
     ~findsomethingnice;

--- a/data/src/scripts/general_use/scripts/crates.rs2
+++ b/data/src/scripts/general_use/scripts/crates.rs2
@@ -33,7 +33,7 @@ if(map_members = true) {
         return;
     }
 } 
-if (random(^findsomethingnice_chance) = 0) { // complete guess
+if (random(^findsomethingnice_chance) = 0 & ~in_tutorial_island(coord) = false) { // complete guess
     mes("You search the crate."); // https://youtu.be/YkSpV1DX1cw
     p_delay(2);
     ~findsomethingnice;
@@ -52,7 +52,7 @@ if (map_members = true) {
         return;
     }
 }
-if (random(^findsomethingnice_chance) = 0) { // complete guess
+if (random(^findsomethingnice_chance) = 0 & ~in_tutorial_island(coord) = false) { // complete guess
     mes("You search the crates."); // guess
     p_delay(2);
     ~findsomethingnice;
@@ -80,7 +80,7 @@ if(map_members = true) {
         return;
     }
 }
-if (random(^findsomethingnice_chance) = 0) { // complete guess
+if (random(^findsomethingnice_chance) = 0 & ~in_tutorial_island(coord) = false) { // complete guess
     mes("You search the boxes.");
     p_delay(2);
     ~findsomethingnice;

--- a/data/src/scripts/general_use/scripts/drawers.rs2
+++ b/data/src/scripts/general_use/scripts/drawers.rs2
@@ -57,7 +57,7 @@ if(map_members = true) {
         return;
     }
 }
-if (random(^findsomethingnice_chance) = 0) { // complete guess
+if (random(^findsomethingnice_chance) = 0 & ~in_tutorial_island(coord) = false) { // complete guess
     mes("You search the drawers."); // guess
     p_delay(2);
     ~findsomethingnice;

--- a/data/src/scripts/general_use/scripts/sacks.rs2
+++ b/data/src/scripts/general_use/scripts/sacks.rs2
@@ -3,7 +3,7 @@
 // https://web.archive.org/web/20050510163434/http://www.runehq.com/cachecities/viewcityguide00273.php
 
 // todo figure out if u can actually find swords and broken staves from these
-if (random(^findsomethingnice_chance) = 0) {
+if (random(^findsomethingnice_chance) = 0 & ~in_tutorial_island(coord) = false) {
     mes("You search the sacks."); // guess
     p_delay(2);
     ~findsomethingnice;

--- a/data/src/scripts/general_use/scripts/wardrobes.rs2
+++ b/data/src/scripts/general_use/scripts/wardrobes.rs2
@@ -13,7 +13,7 @@ if (random(21) = 0) {
 
 [oploc2,loc_389]
 p_arrivedelay;
-if (random(^findsomethingnice_chance) = 0) { // complete guess
+if (random(^findsomethingnice_chance) = 0 & ~in_tutorial_island(coord) = false) { // complete guess
     mes("You search the wardrobe."); // guess
     p_delay(2);
     ~findsomethingnice;

--- a/data/src/scripts/interface_trade/scripts/trade.rs2
+++ b/data/src/scripts/interface_trade/scripts/trade.rs2
@@ -92,6 +92,8 @@ if (.finduid(%tradepartner) = true) {
             .if_close;
             return;
         }
+        ~inv_remove_leading_empty_slots(tempinv);
+        ~.inv_remove_leading_empty_slots(tempinv);
 
         def_int $tempinvused = sub(inv_size(tempinv), inv_freespace(tempinv));
         if ($tempinvused < 1) {
@@ -178,6 +180,24 @@ while ($slot < $size) {
 }
 return(true);
 
+[proc,inv_remove_leading_empty_slots](inv $inv)
+def_int $slot = 0;
+while ($slot < inv_size($inv)) {
+    if (inv_getobj($inv, $slot) ! null) {
+        inv_movefromslot($inv, $inv, $slot);
+    }
+    $slot = add($slot, 1);
+}
+
+[proc,.inv_remove_leading_empty_slots](inv $inv)
+def_int $slot = 0;
+while ($slot < .inv_size($inv)) {
+    if (.inv_getobj($inv, $slot) ! null) {
+        .inv_movefromslot($inv, $inv, $slot);
+    }
+    $slot = add($slot, 1);
+}
+
 [if_close,trademain]
 inv_stoptransmit(trademain:inv);
 inv_stoptransmit(trademain:otherinv);
@@ -223,17 +243,13 @@ inv_stoptransmit(tradeconfirm:inv2);
 inv_stoptransmit(tradeconfirm:otherinv1);
 inv_stoptransmit(tradeconfirm:otherinv2);
 
-if (%tradestatus ! 3) {
-    ~moveallinv(tempinv, inv);
-
-    if (.finduid(%tradepartner) = true) {
-        .%tradepartner = null;
-        .if_close;
-        .mes("Other player declined trade."); // osrs
-    }
-
-    %tradepartner = null;
+~moveallinv(tempinv, inv);
+if (.finduid(%tradepartner) = true) {
+    .%tradepartner = null;
+    .if_close;
+    .mes("Other player declined trade."); // osrs
 }
+%tradepartner = null;
 
 // ----
 

--- a/data/src/scripts/macro events/configs/macro_events.constant
+++ b/data/src/scripts/macro events/configs/macro_events.constant
@@ -21,6 +21,8 @@
 ^triffid_growing = 0
 ^triffid_ready_to_attack = 1
 
+^drunken_dwarf_normal = 0
+^drunken_dwarf_angry = 1
 
 ^macro_event_cmb_14 = 1
 ^macro_event_cmb_29 = 2

--- a/data/src/scripts/macro events/scripts/general/macro_event_drunken_dwarf.rs2
+++ b/data/src/scripts/macro events/scripts/general/macro_event_drunken_dwarf.rs2
@@ -30,6 +30,7 @@ if (finduid(%npc_macro_event_target) = true) {
         // todo: figure out the message that goes here
         %aggressive_npc = npc_uid; // interupt the player if they're in combat https://youtu.be/tw66JWQzpD0?t=32
         npc_setmode(opplayer2);
+        %npc_macro_event_status = ^drunken_dwarf_angry;
         return;
     }
     npc_queue(4, add(last_int, 1), 10);
@@ -62,12 +63,16 @@ npc_queue(6, 0, 0); // say good bye
 ~chatnpc("<p,drunk>I 'new it were you matey! 'Ere, have some ob the good stuff!"); // osrs
 
 [ai_timer,macro_event_drunken_dwarf]
-if (~npc_out_of_combat = false) {
+if (%npc_macro_event_status = ^drunken_dwarf_angry) {
+    if (~macro_event_lost_hostile = true) {
+        // https://youtu.be/PhAjUCWSoOI?list=PLn23LiLYLb1bQ7Hwp77KoNBjKvpZQTfJT&t=79
+        // https://youtu.be/PhAjUCWSoOI?list=PLn23LiLYLb1bQ7Hwp77KoNBjKvpZQTfJT&t=81
+        npc_queue(5, 0, 0); // despawn
+    }
     return;
 }
-if (~macro_event_lost = true) { // https://youtu.be/PhAjUCWSoOI?list=PLn23LiLYLb1bQ7Hwp77KoNBjKvpZQTfJT&t=79
-    // https://youtu.be/PhAjUCWSoOI?list=PLn23LiLYLb1bQ7Hwp77KoNBjKvpZQTfJT&t=81
-    npc_queue(5, 0, 0); // despawn
+if (~macro_event_lost = true) {
+    npc_queue(5, 0, 0);
     return;
 }
 if (finduid(%npc_macro_event_target) = true) {

--- a/data/src/scripts/macro events/scripts/general/macro_event_swarm.rs2
+++ b/data/src/scripts/macro events/scripts/general/macro_event_swarm.rs2
@@ -11,3 +11,11 @@ if (~macro_event_lost_hostile = true) {
     npc_del;
     return;
 }
+
+// todo: confirm this
+[opnpc2,macro_event_swarm]
+if (%npc_macro_event_target ! uid) {
+    mes("They're not here for you."); // guess based on strange plant
+    return;
+}
+@player_combat_start;

--- a/data/src/scripts/macro events/scripts/mining/macro_event_rock_golem.rs2
+++ b/data/src/scripts/macro events/scripts/mining/macro_event_rock_golem.rs2
@@ -145,3 +145,10 @@ if ($random < 4) { // 4/128
 } else { // 2/128
     obj_add(npc_coord, ~randomjewel, ^lootdrop_duration);
 }
+
+[opnpc2,_macro_event_rock_golem]
+if (%npc_macro_event_target ! uid) {
+    mes("It's not here for you."); // from strange plant
+    return;
+}
+@player_combat_start;

--- a/data/src/scripts/macro events/scripts/prayer/macro_event_shade.rs2
+++ b/data/src/scripts/macro events/scripts/prayer/macro_event_shade.rs2
@@ -44,3 +44,10 @@ if ($random < 64) {
 } else {
     obj_add(npc_coord, obj_548, 1, ^lootdrop_duration);
 }
+
+[opnpc2,_macro_event_shade]
+if (%npc_macro_event_target ! uid) {
+    mes("It's not here for you."); // from strange plant
+    return;
+}
+@player_combat_start;

--- a/data/src/scripts/macro events/scripts/prayer/macro_event_zombie.rs2
+++ b/data/src/scripts/macro events/scripts/prayer/macro_event_zombie.rs2
@@ -90,3 +90,10 @@ if ($random < 36) { // 36/256
 } else {
     obj_add(npc_coord, ~randomjewel, ^lootdrop_duration);
 }
+
+[opnpc2,_macro_event_zombie]
+if (%npc_macro_event_target ! uid) {
+    mes("It's not here for you."); // from strange plant
+    return;
+}
+@player_combat_start;

--- a/data/src/scripts/macro events/scripts/thieving/macro_event_watchman.rs2
+++ b/data/src/scripts/macro events/scripts/thieving/macro_event_watchman.rs2
@@ -108,3 +108,10 @@ if ($random < 8) { // 8/128
 } else {
     obj_add(npc_coord, ~randomjewel, ^lootdrop_duration);
 }
+
+[opnpc2,_macro_event_watchman]
+if (%npc_macro_event_target ! uid) {
+    mes("It's not here for you."); // from strange plant
+    return;
+}
+@player_combat_start;

--- a/data/src/scripts/macro events/scripts/woodcutting/macro_event_dryad.rs2
+++ b/data/src/scripts/macro events/scripts/woodcutting/macro_event_dryad.rs2
@@ -58,3 +58,10 @@ if ($random < 20) {
 } else {
     obj_add(npc_coord, ~randomjewel, ^lootdrop_duration);
 }
+
+[opnpc2,_macro_event_dryad]
+if (%npc_macro_event_target ! uid) {
+    mes("It's not here for you."); // from strange plant
+    return;
+}
+@player_combat_start;

--- a/data/src/scripts/quests/quest_dragon/scripts/dragonslayer_ned.rs2
+++ b/data/src/scripts/quests/quest_dragon/scripts/dragonslayer_ned.rs2
@@ -44,15 +44,16 @@ if ((%dragon_progress = ^quest_dragon_ned_given_map | %dragon_progress = ^quest_
     // https://youtu.be/uETjjZFKWus?list=PLn23LiLYLb1aqrojPTi1_Np81LJku2Nd0&t=10
     // boat just crashed on crandor:
     def_int $choice = ~p_choice2("Is the ship ready to sail back?", 1, "So are you enjoying this exotic island vacation?", 2);
-    // MISSING DIALOGUE:
+    // https://storage.googleapis.com/tannerdino/images/crandorned2.png
+    // same as rsc
     if ($choice = 1) {
         ~chatplayer("<p,quiz>Is the ship ready to sail back?");
-        ~chatnpc("<p,sad>I'm afraid not. It looks like we're stranded."); // complete guess
+        ~chatnpc("<p,neutral>Well when we arrived, the ship took a nasty jar from those rocks.|We may be stranded.");
         return;
     }
     if ($choice = 2) {
         ~chatplayer("<p,quiz>So are you enjoying this exotic island vacation?");
-        ~chatnpc("<p,sad>Not really. I'm afraid we're stranded here."); // complete guess
+        ~chatnpc("<p,neutral>Well it would have been better if I'd brought my sun|lotion. Oh, and the skeletons which won't let me leave|the ship probably arent helping either.");
         return;
     }
 }

--- a/data/src/scripts/quests/quest_dragon/scripts/dragonslayer_ned.rs2
+++ b/data/src/scripts/quests/quest_dragon/scripts/dragonslayer_ned.rs2
@@ -53,7 +53,7 @@ if ((%dragon_progress = ^quest_dragon_ned_given_map | %dragon_progress = ^quest_
     }
     if ($choice = 2) {
         ~chatplayer("<p,quiz>So are you enjoying this exotic island vacation?");
-        ~chatnpc("<p,neutral>Well it would have been better if I'd brought my sun|lotion. Oh, and the skeletons which won't let me leave|the ship probably arent helping either.");
+        ~chatnpc("<p,neutral>Well it would have been better if I'd brought my sun|lotion. Oh, and the skeletons which won't let me leave|the ship probably aren't helping either.");
         return;
     }
 }


### PR DESCRIPTION
- macro event dwarf would still try to follow after getting angry
- "It's not here for you." message for all hostile random events (need to confirm this)
- A check to prevent searching for junk on tutorial island
- Trade window wouldnt close the other players window if you already pressed accept
- remove leading empty slots on 2nd trade window
- add authentic ned dialogue for when hes ship wrecked