### PR TITLE
fix(content): duel time limit, duel time out, and logout trigger changes 

### DIFF
--- a/data/src/scripts/login_logout/logout.rs2
+++ b/data/src/scripts/login_logout/logout.rs2
@@ -3,7 +3,7 @@ if (busy = true) {
     return(false);
 }
 
-if (map_clock > 17 & (add(%lastcombat, 17) > map_clock | add(%lastcombat_pvp, 17) > map_clock)) {
+if (map_clock > 17 & add(%lastcombat, 17) > map_clock) {
     return(false);
 }
 
@@ -39,7 +39,7 @@ if (p_finduid(uid) = true) {
         return;
     }
 
-    if (map_clock > 17 & (add(%lastcombat, 17) > map_clock | add(%lastcombat_pvp, 17) > map_clock)) {
+    if (map_clock > 17 & add(%lastcombat, 17) > map_clock) {
         mes("You can't logout until 10 seconds after the end of combat."); // todo: confirm this message for 2004
         return;
     }

--- a/data/src/scripts/login_logout/logout.rs2
+++ b/data/src/scripts/login_logout/logout.rs2
@@ -3,18 +3,7 @@ if (busy = true) {
     return(false);
 }
 
-if (~in_duel_arena(coord) = true) {
-    mes("You can't log out during a duel."); //https://youtu.be/xLE8au7T50Q?t=227
-    return(false);
-}
-
-if (~inzone_coord_pair_table(gnomeball_zones, coord) = true) {
-    mes("You can't log out on a gnomeball pitch."); // osrs
-    return(false);
-}
-
-if (map_clock > 17 & add(%lastcombat, 17) > map_clock) {
-    mes("You can't logout until 10 seconds after the end of combat."); // todo: confirm this message for 2004
+if (map_clock > 17 & (add(%lastcombat, 17) > map_clock | add(%lastcombat_pvp, 17) > map_clock)) {
     return(false);
 }
 
@@ -33,11 +22,26 @@ if (%tradepartner ! null) {
 ~set_cannon_vars_logout;
 ~follower_logout;
 ~rashiliyia_door_logout;
+~duel_arena_logout;
 
 return(true);
 
 [if_button,logout:try_logout]
 if_close;
 if (p_finduid(uid) = true) {
+    if (~in_duel_arena(coord) = true) {
+        mes("You can't log out during a duel."); //https://youtu.be/xLE8au7T50Q?t=227
+        return;
+    }
+
+    if (~inzone_coord_pair_table(gnomeball_zones, coord) = true) {
+        mes("You can't log out on a gnomeball pitch."); // osrs
+        return;
+    }
+
+    if (map_clock > 17 & (add(%lastcombat, 17) > map_clock | add(%lastcombat_pvp, 17) > map_clock)) {
+        mes("You can't logout until 10 seconds after the end of combat."); // todo: confirm this message for 2004
+        return;
+    }
     p_logout;
 }

--- a/data/src/scripts/minigames/game_duelarena/scripts/duel_arena.rs2
+++ b/data/src/scripts/minigames/game_duelarena/scripts/duel_arena.rs2
@@ -399,6 +399,26 @@ if (~.inzone_coord_pair_table(duel_arena_fight_zones, $coord) = true | ~.inzone_
 return(false);
 
 [proc,duel_arena_login]
-if (~in_duel_arena(coord) = true) {
-    p_telejump(~duel_arena_finish_coord(coord));
+if (~in_duel_arena(coord) = false) {
+    return;
 }
+~duel_reset_all;
+
+[proc,duel_arena_logout]
+if (~in_duel_arena(coord) = false) {
+    return;
+}
+if (.finduid(%duelpartner) = true) {
+    .%duelstatus = 0;
+    .%duelpartner = null;
+    .if_close;
+    .queue(duel_arena_disconnect, 0);
+}
+%duelstatus = 0;
+%duelpartner = null;
+~duel_give_stake_back;
+
+[queue,duel_arena_disconnect]
+~duel_give_stake_back;
+~duel_reset_all;
+~mesbox("Your opponent timed out, there was no winner!"); // https://youtu.be/LZzhIWbSKpY?t=127

--- a/data/src/scripts/minigames/game_duelarena/scripts/duel_arena.rs2
+++ b/data/src/scripts/minigames/game_duelarena/scripts/duel_arena.rs2
@@ -125,6 +125,9 @@ if (.finduid(%duelpartner) = true & ~enough_duel_space = true) { // https://yout
         cam_reset;
         .cam_reset;
 
+        ~inv_remove_leading_empty_slots(tempinv);
+        ~.inv_remove_leading_empty_slots(tempinv);
+
         def_int $tempinvused = sub(inv_size(tempinv), inv_freespace(tempinv));
         if ($tempinvused < 1) {
             if_settext(duel_confirm:com_91, "Absolutely nothing!");

--- a/data/src/scripts/minigames/game_duelarena/scripts/duel_arena_finish.rs2
+++ b/data/src/scripts/minigames/game_duelarena/scripts/duel_arena_finish.rs2
@@ -7,6 +7,35 @@ if (~in_duel_arena(coord) = false) {
     %duelpartner = null;
     return;
 }
+~duel_reset_all;
+
+if (.finduid(%duelpartner) = true & (%duelstatus = ^duelstatus_victory | %duelstatus = ^duelstatus_opponent_resigned)) {
+    if (%duelstatus = ^duelstatus_opponent_resigned) {
+        if_settext(duel_win:com_99, "You are victorious! Your opponent resigned!"); // 2006
+        mes("Well done! <.displayname> resigned!"); // 2006
+    } else {
+        if_settext(duel_win:com_99, "You are victorious!");
+        mes("Well done! You have defeated <.displayname>!");
+    }
+    midi_jingle(^duel_win_2_jingle, ^duel_win_2_jingle_millis);
+    if_openmain(duel_win);
+    ~duel_adjust_scoreboard(displayname, ~player_combat_level, .displayname, ~.player_combat_level);
+    if_settext(duel_win:displayname, .displayname);
+    if_settext(duel_win:combat_level, tostring(~.player_combat_level));
+
+    ~duel_give_stake_back;
+
+    // take stuff from other player's stakeinv
+    .both_moveinv(stakeinv, stakeinv);
+    // .%duelpartner = null;
+    // display spoils
+    inv_transmit(stakeinv, duel_win:spoils);
+}
+
+%duelstatus = 0;
+%duelpartner = null;
+
+[proc,duel_reset_all]
 // get arrows back
 def_int $i = 0;
 while ($i < inv_size(tempinv)) {
@@ -32,48 +61,18 @@ clearqueue(player_death);
 ~update_all(inv_getobj(worn, ^wearpos_rhand));
 hint_stop;
 
-if (.finduid(%duelpartner) = true & (%duelstatus = ^duelstatus_victory | %duelstatus = ^duelstatus_opponent_resigned)) {
-    if (%duelstatus = ^duelstatus_opponent_resigned) {
-        if_settext(duel_win:com_99, "You are victorious! Your opponent resigned!"); // 2006
-        mes("Well done! <.displayname> resigned!"); // 2006
-    } else {
-        if_settext(duel_win:com_99, "You are victorious!");
-        mes("Well done! You have defeated <.displayname>!");
-    }
-    midi_jingle(^duel_win_2_jingle, ^duel_win_2_jingle_millis);
-    if_openmain(duel_win);
-    ~duel_adjust_scoreboard(displayname, ~player_combat_level, .displayname, ~.player_combat_level);
-    if_settext(duel_win:displayname, .displayname);
-    if_settext(duel_win:combat_level, tostring(~.player_combat_level));
-
-    $i = 0;
-    while ($i < inv_size(stakeinv)) {
-        if (inv_getobj(stakeinv, $i) ! null) {
-            //mes("<oc_debugname(inv_getobj(stakeinv, $i))>: <tostring(inv_getnum(tempinv, $i))>");
-            inv_movefromslot(stakeinv, inv, $i);
-        }
-        $i = calc($i + 1);
-    }
-    inv_clear(stakeinv);
-    // take stuff from other player's stakeinv
-    .both_moveinv(stakeinv, stakeinv);
-    // .%duelpartner = null;
-    // display spoils
-    inv_transmit(stakeinv, duel_win:spoils);
-}
-
-%duelstatus = 0;
-%duelpartner = null;
-
-[if_close,duel_win]
+[proc,duel_give_stake_back]
 def_int $i = 0;
 while ($i < inv_size(stakeinv)) {
     if (inv_getobj(stakeinv, $i) ! null) {
+        //mes("<oc_debugname(inv_getobj(stakeinv, $i))>: <tostring(inv_getnum(tempinv, $i))>");
         inv_movefromslot(stakeinv, inv, $i);
     }
     $i = calc($i + 1);
 }
-inv_clear(stakeinv);
+
+[if_close,duel_win]
+~duel_give_stake_back;
 inv_stoptransmit(duel_win:spoils);
 
 // https://youtu.be/QggKGBAl_X8?t=111

--- a/data/src/scripts/minigames/game_duelarena/scripts/duel_arena_start.rs2
+++ b/data/src/scripts/minigames/game_duelarena/scripts/duel_arena_start.rs2
@@ -54,6 +54,7 @@ if (.finduid(%duelpartner) = true) {
     hint_player(.uid);
 
     softtimer(duel_arena_start_3, 3); // todo: confirm these timings
+    softtimer(duel_arena_time_limit, 6000); // 60 minute time limit https://runescape.wiki/w/Update:Assist_System
 
     midi_jingle(^duel_start_jingle, ^duel_start_jingle_millis);
 }
@@ -152,6 +153,18 @@ if (~duel_arena_movement_check = true & ~in_duel_arena(coord) = true) {
     walktrigger(duel_arena_no_move);
 }
 
+[softtimer,duel_arena_time_limit]
+if (~in_duel_arena(coord) = false) {
+    clearsofttimer(duel_arena_time_limit);
+    return;
+}
+%duelstatus = 0;
+%duelpartner = null;
+if_close;
+queue(duel_arena_time_limit, 0);
 
-[queue,duel_arena_full]
-~mesbox("All arenas of this type are full! Select another type of arena, try|again in a few minutes or try a different server."); // https://youtu.be/TcrIr9O92sw?t=89
+
+[queue,duel_arena_time_limit]
+~duel_give_stake_back;
+~duel_reset_all;
+~mesbox("Time is up, there was no winner!"); // complete guess


### PR DESCRIPTION
- duel time limit from this [blog](https://runescape.wiki/w/Update:Assist_System). `The time-out in the Duel Arena has been reduced to 30 minutes from the previous 60 minutes.`
- duel time out from opponent disconnecting from this [video](https://youtu.be/LZzhIWbSKpY?t=126).
- In the video above, the opponent logs out after not being attacked for 17 ticks. This means the duel arena check is only in the logout if_button. Same goes with gnomeball, current osrs you can afk log within gnomeball
- also applies the ~inv_remove_leading_empty_slots proc from trading to duel stakes