### PR TITLE
feat(engine): create a player grid to improve player_info performance

### DIFF
--- a/src/lostcity/engine/World.ts
+++ b/src/lostcity/engine/World.ts
@@ -954,6 +954,10 @@ class World {
             }
             players.push(player);
         }
+
+        for (const npc of this.npcs) {
+            npc.convertMovementDir();
+        }
     }
 
     // - map update

--- a/src/lostcity/network/225/outgoing/codec/NpcInfoEncoder.ts
+++ b/src/lostcity/network/225/outgoing/codec/NpcInfoEncoder.ts
@@ -112,7 +112,7 @@ export default class NpcInfoEncoder extends MessageEncoder<NpcInfo> {
 
     private writeNewNpcs(buf: Packet, message: NpcInfo): void {
         const buildArea: BuildArea = message.buildArea;
-        for (const npc of buildArea.getNearbyNpcs(message.x, message.z, message.originX, message.originZ)) {
+        for (const npc of buildArea.getNearbyNpcs(message.level, message.x, message.z, message.originX, message.originZ)) {
             const extendedInfoSize: number = this.calculateExtendedInfo(npc, true);
             const extendedInfo: boolean = extendedInfoSize > 0;
 

--- a/src/lostcity/network/225/outgoing/codec/PlayerInfoEncoder.ts
+++ b/src/lostcity/network/225/outgoing/codec/PlayerInfoEncoder.ts
@@ -154,7 +154,7 @@ export default class PlayerInfoEncoder extends MessageEncoder<PlayerInfo> {
 
     private writeNewPlayers(buf: Packet, message: PlayerInfo): void {
         const buildArea: BuildArea = message.buildArea;
-        for (const other of buildArea.getNearbyPlayers(message.uid, message.x, message.z, message.originX, message.originZ)) {
+        for (const other of buildArea.getNearbyPlayers(message.uid, message.level, message.x, message.z, message.originX, message.originZ)) {
             const extendedInfoSize: number = this.calculateExtendedInfo(other, message, false, true);
             const extendedInfo: boolean = extendedInfoSize > 0;
 


### PR DESCRIPTION
The screenshots show `less dense vs more dense` before & after examples on my pc.

I did not do this for npcs because it seemed too slow for 5000 npcs, and it definitely won't scale well when there are more in the world in the future.

## Before
![image](https://github.com/user-attachments/assets/4c6bd028-57c2-4799-a8fa-0f28aeeab110)
![image](https://github.com/user-attachments/assets/a9c6944e-ac91-4a06-a6f4-29b204c3bf40)

## After
![image](https://github.com/user-attachments/assets/e6f0719c-cb59-461b-956a-3b28f6ed52f9)
![image](https://github.com/user-attachments/assets/5b6857b0-78ee-41d4-822e-6cfea027fd3d)
