### PR TITLE
chore: set devcontainer default shell to /bin/bash

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -13,6 +13,9 @@
 	  		]
 	  	}
 	},
+	"containerEnv": {
+		"SHELL": "/bin/bash"
+	},
 	"remoteUser": "vscode",
 	"postStartCommand": "bash -c 'chmod +x setup.sh && ./setup.sh'"
 }


### PR DESCRIPTION
Because `/bin/sh/` is not really pleasant to work with.