### PR TITLE
fix(content): add missing seaslug rewards

### DIFF
--- a/data/src/scripts/quests/quest_seaslug/scripts/quest_seaslug.rs2
+++ b/data/src/scripts/quests/quest_seaslug/scripts/quest_seaslug.rs2
@@ -122,4 +122,6 @@ while (npc_findnext = true) {
 }
 
 [queue,seaslug_quest_complete]
+stat_advance(fishing, 71750);
+inv_add(inv, oyster_perl, 1);
 ~send_quest_complete(questlist:seaslug, sea_slug, 250, ^seaslug_questpoints, "You have completed the\\nSea Slug Quest!");


### PR DESCRIPTION
The seaslug quest was missing it's rewards. As far as i could find these rewards were present in 2004.

https://web.archive.org/web/20040722192346/http://www.tip.it:80/runescape/index.php?quest_id=60
https://web.archive.org/web/20041230201616/http://www.runehq.com/cacheguides/viewquestguide00180.htm