### PR TITLE
feat(engine): entitylist count performance for scalebyplayercount fn

### DIFF
--- a/src/lostcity/engine/World.ts
+++ b/src/lostcity/engine/World.ts
@@ -548,8 +548,8 @@ class World {
             }
 
             if (Environment.NODE_DEBUG_PROFILER) {
-                printDebug(`tick ${this.currentTick} took ${this.cycleStats[WorldStat.CYCLE]}ms: ${this.getTotalPlayers()} players`);
-                printDebug(`${this.cycleStats[WorldStat.WORLD]} ms world | ${this.cycleStats[WorldStat.CLIENT_IN]} ms client in | ${this.cycleStats[WorldStat.NPC]} ms npcs | ${this.cycleStats[WorldStat.PLAYER]} ms players | ${this.cycleStats[WorldStat.LOGOUT]} ms logout | ${this.cycleStats[WorldStat.LOGIN]} ms login | ${this.cycleStats[WorldStat.ZONE]} ms zones | ${this.cycleStats[WorldStat.CLIENT_OUT]} ms client out | ${this.cycleStats[WorldStat.CLEANUP]} ms cleanup`);
+                printDebug(`| [tick ${this.currentTick}; ${this.cycleStats[WorldStat.CYCLE]}/600ms] | ${this.getTotalPlayers()} players | ${this.getTotalNpcs()} npcs | ${this.gameMap.getTotalZones()} zones | ${this.gameMap.getTotalLocs()} locs | ${this.gameMap.getTotalObjs()} objs |`);
+                printDebug(`| ${this.cycleStats[WorldStat.WORLD]}ms world | ${this.cycleStats[WorldStat.CLIENT_IN]}ms client in | ${this.cycleStats[WorldStat.NPC]}ms npcs | ${this.cycleStats[WorldStat.PLAYER]}ms players | ${this.cycleStats[WorldStat.LOGOUT]}ms logout | ${this.cycleStats[WorldStat.LOGIN]}ms login | ${this.cycleStats[WorldStat.ZONE]}ms zones | ${this.cycleStats[WorldStat.CLIENT_OUT]}ms client out | ${this.cycleStats[WorldStat.CLEANUP]}ms cleanup |`);
                 printDebug('----');
             }
         } catch (err) {
@@ -927,13 +927,7 @@ class World {
     private processZones(): void {
         const start: number = Date.now();
         const tick: number = this.currentTick;
-        const zones: Set<Zone> | undefined = this.zonesTracking.get(tick);
-        if (typeof zones !== 'undefined') {
-            // - loc/obj despawn/respawn
-            for (const zone of zones) {
-                zone.tick(tick);
-            }
-        }
+        this.zonesTracking.get(tick)?.forEach(zone => zone.tick(tick));
         // - build list of active zones around players
         // - compute shared buffer
         this.computeSharedEvents();
@@ -947,13 +941,13 @@ class World {
         for (const player of this.players) {
             player.convertMovementDir();
 
+            const grid = this.playerGrid;
             const coord = CoordGrid.packCoord(player.level, player.x, player.z);
-            let players: Player[] | undefined = this.playerGrid.get(coord);
-            if (typeof players === 'undefined') {
-                players = [];
-                this.playerGrid.set(coord, players);
-            }
+            const players = grid.get(coord) ?? [];
             players.push(player);
+            if (!grid.has(coord)) {
+                grid.set(coord, players);
+            }
         }
 
         for (const npc of this.npcs) {
@@ -1011,16 +1005,10 @@ class World {
     // - reset invs
     private processCleanup(): void {
         const start: number = Date.now();
-
         const tick: number = this.currentTick;
 
         // - reset zones
-        const zones: Set<Zone> | undefined = this.zonesTracking.get(tick);
-        if (typeof zones !== 'undefined') {
-            for (const zone of zones) {
-                zone.reset();
-            }
-        }
+        this.zonesTracking.get(tick)?.forEach(zone => zone.reset());
         this.zonesTracking.delete(tick);
 
         // - reset players
@@ -1188,9 +1176,7 @@ class World {
                 zones.add(zone);
             }
         }
-        for (const zoneIndex of zones) {
-            this.gameMap.getZoneIndex(zoneIndex).computeShared();
-        }
+        zones.forEach(zoneIndex => this.gameMap.getZoneIndex(zoneIndex).computeShared());
     }
 
     addNpc(npc: Npc, duration: number, firstSpawn: boolean = true): void {
@@ -1255,15 +1241,11 @@ class World {
     }
 
     trackZone(tick: number, zone: Zone): void {
-        let zones: Set<Zone>;
-        const active: Set<Zone> | undefined = this.zonesTracking.get(tick);
-        if (!active) {
-            zones = new Set();
-        } else {
-            zones = active;
+        const tracking: Map<number, Set<Zone>> = this.zonesTracking;
+        const zones: Set<Zone> = (tracking.get(tick) ?? new Set()).add(zone);
+        if (!tracking.has(tick)) {
+            tracking.set(tick, zones);
         }
-        zones.add(zone);
-        this.zonesTracking.set(tick, zones);
     }
 
     addLoc(loc: Loc, duration: number): void {

--- a/src/lostcity/engine/World.ts
+++ b/src/lostcity/engine/World.ts
@@ -548,7 +548,7 @@ class World {
             }
 
             if (Environment.NODE_DEBUG_PROFILER) {
-                printDebug(`| [tick ${this.currentTick}; ${this.cycleStats[WorldStat.CYCLE]}/600ms] | ${this.getTotalPlayers()} players | ${this.getTotalNpcs()} npcs | ${this.gameMap.getTotalZones()} zones | ${this.gameMap.getTotalLocs()} locs | ${this.gameMap.getTotalObjs()} objs |`);
+                printDebug(`| [tick ${this.currentTick}; ${this.cycleStats[WorldStat.CYCLE]}/${this.tickRate}ms] | ${this.getTotalPlayers()} players | ${this.getTotalNpcs()} npcs | ${this.gameMap.getTotalZones()} zones | ${this.gameMap.getTotalLocs()} locs | ${this.gameMap.getTotalObjs()} objs |`);
                 printDebug(`| ${this.cycleStats[WorldStat.WORLD]}ms world | ${this.cycleStats[WorldStat.CLIENT_IN]}ms client in | ${this.cycleStats[WorldStat.NPC]}ms npcs | ${this.cycleStats[WorldStat.PLAYER]}ms players | ${this.cycleStats[WorldStat.LOGOUT]}ms logout | ${this.cycleStats[WorldStat.LOGIN]}ms login | ${this.cycleStats[WorldStat.ZONE]}ms zones | ${this.cycleStats[WorldStat.CLIENT_OUT]}ms client out | ${this.cycleStats[WorldStat.CLEANUP]}ms cleanup |`);
                 printDebug('----');
             }

--- a/src/lostcity/engine/World.ts
+++ b/src/lostcity/engine/World.ts
@@ -927,6 +927,7 @@ class World {
     private processZones(): void {
         const start: number = Date.now();
         const tick: number = this.currentTick;
+        // - loc/obj despawn/respawn
         this.zonesTracking.get(tick)?.forEach(zone => zone.tick(tick));
         // - build list of active zones around players
         // - compute shared buffer

--- a/src/lostcity/entity/EntityList.ts
+++ b/src/lostcity/entity/EntityList.ts
@@ -48,11 +48,7 @@ abstract class EntityList<T extends Entity> extends Array<T | undefined> {
     }
 
     get count(): number {
-        let count: number = 0;
-        for (const _ of this[Symbol.iterator]()) {
-            count++;
-        }
-        return count;
+        return Math.max(this.length - this.free.size, 0);
     }
 
     get(id: number): T | undefined {


### PR DESCRIPTION
`scaleByPlayerCount` was created which calls into `getTotalPlayers` to get the current number of players in the `World`. The way `getTotalPlayers` is implemented is by manually counting the slots every time:
```ts
    get count(): number {
        let count: number = 0;
        for (const _ of this[Symbol.iterator]()) {
            count++;
        }
        return count;
    }
```

which the `[Symbol.iterator]` is a loop itself:
```ts
    *[Symbol.iterator](): ArrayIterator<T> {
        for (const index of this.ids) {
            if (index === -1) {
                continue;
            }
            const entity: T | undefined = this[index];
            if (typeof entity === 'undefined') {
                continue;
            }
            yield entity;
        }
    }
```

Since `scaleByPlayerCount` fn in `World` is used by `removeNpc` and `removeObj`, it is performing a double loop every time an npc or obj is removed from the world.

Refactor the `count` fn as so:
```ts
    get count(): number {
        return Math.max(this.length - this.free.size, 0);
    }
```
----

`::addobj2 64` adds an obj to every tile in a 64x64 square area, effectively adding and then removing 4096 objs.
![image](https://github.com/user-attachments/assets/91143a6b-9a17-4624-a0b2-f521ad59eeeb)

The screenshots below are before & after when the 4096 objs despawn and shows the time taken.

## Before:
![image](https://github.com/user-attachments/assets/5eb89b2a-1d9f-454e-a527-03bca9c4198d)

## After:
![image](https://github.com/user-attachments/assets/1b06e9d0-9b07-401e-8780-aa192fde0518)

----

I also added some extra info into the world cycle messages & refactored some other bits of code to simplify them.