### PR TITLE
fix(content): bronze bar superheating

### DIFF
--- a/data/src/scripts/skill_magic/scripts/spells/superheat.rs2
+++ b/data/src/scripts/skill_magic/scripts/spells/superheat.rs2
@@ -23,6 +23,8 @@ if ($ore1 = iron_ore & inv_total(inv, coal) > 1 & stat(smithing) >= 30) {
 // remove bar at end of name
 def_string $metal_name = substring(oc_name($bar), 0, calc(string_length(oc_name($bar)) - 4));
 def_struct $bar_struct = oc_param($bar, smelting_struct);
+// Ensure ore1 now refers to the primary ingredient (important for bronze)
+$ore1 = struct_param($bar_struct, ingredient);
 // if not enough level
 if (stat(smithing) < struct_param($bar_struct, levelrequired)) {
     mes("You need a smithing level of at least <tostring(struct_param($bar_struct, levelrequired))> to smelt <$metal_name>.");

--- a/data/src/scripts/skill_smithing/configs/smelting/smelting.struct
+++ b/data/src/scripts/skill_smithing/configs/smelting/smelting.struct
@@ -1,6 +1,7 @@
 [smelting_bronze_bar]
 param=levelfailure,You need a Smithing level of 1 to smelt a bronze bar.
 param=processfailure,You need at least 1 Copper ore and 1 Tin ore to smelt a bronze bar.
+param=processfailure_superheat,You need one copper ore and one tin ore to make bronze.
 param=processmessage,You smelt the copper and tin together in the furnace.
 param=productmessage,You retrieve a bar of bronze.
 param=product,bronze_bar


### PR DESCRIPTION
- Ensure both primary and secondary ore are present, fixing bug where bronze bars could be superheated with only tin ore
- Add OSRS failure message if both copper and tin not present ![image](https://github.com/user-attachments/assets/f6d95a79-0042-45b8-9f10-6caa3e23210c)
