### PR TITLE
fix(engine): players now naive path if target is ontop of them

### DIFF
--- a/src/lostcity/entity/PathingEntity.ts
+++ b/src/lostcity/entity/PathingEntity.ts
@@ -402,6 +402,10 @@ export default abstract class PathingEntity extends Entity {
 
     pathToMoveClick(input: number[], needsfinding: boolean): void {
         if (this.moveStrategy === MoveStrategy.SMART) {
+            if (this.target && this.target instanceof PathingEntity && Environment.NODE_CLIENT_ROUTEFINDER && CoordGrid.intersects(this.x, this.z, this.width, this.length, this.target.x, this.target.z, this.target.width, this.target.length)) {
+                this.queueWaypoints(findNaivePath(this.level, this.x, this.z, this.target.x, this.target.z, this.width, this.length, this.target.width, this.target.length, 0, CollisionType.NORMAL));
+                return;
+            }
             if (needsfinding) {
                 const { x, z } = CoordGrid.unpackCoord(input[0]);
                 this.queueWaypoints(findPath(this.level, this.x, this.z, x, z));

--- a/src/lostcity/entity/PathingEntity.ts
+++ b/src/lostcity/entity/PathingEntity.ts
@@ -455,7 +455,11 @@ export default abstract class PathingEntity extends Entity {
 
         if (this.moveStrategy === MoveStrategy.SMART) {
             if (this.target instanceof PathingEntity) {
-                this.queueWaypoints(findPathToEntity(this.level, this.x, this.z, this.target.x, this.target.z, this.width, this.target.width, this.target.length));
+                if (Environment.NODE_CLIENT_ROUTEFINDER && CoordGrid.intersects(this.x, this.z, this.width, this.length, this.target.x, this.target.z, this.target.width, this.target.length)) {
+                    this.queueWaypoints(findNaivePath(this.level, this.x, this.z, this.target.x, this.target.z, this.width, this.length, this.target.width, this.target.length, 0, CollisionType.NORMAL));
+                } else {
+                    this.queueWaypoints(findPathToEntity(this.level, this.x, this.z, this.target.x, this.target.z, this.width, this.target.width, this.target.length));
+                }
             } else if (this.target instanceof Loc) {
                 const forceapproach = LocType.get(this.target.type).forceapproach;
                 this.queueWaypoints(findPathToLoc(this.level, this.x, this.z, this.target.x, this.target.z, this.width, this.target.width, this.target.length, this.target.angle, this.target.shape, forceapproach));


### PR DESCRIPTION
Fixes https://github.com/2004Scape/Server/issues/982
Thanks to https://github.com/2004Scape/Server/issues/982#issuecomment-2455896662


However a new issue arises:

https://github.com/user-attachments/assets/9ce12f1c-50e3-40b9-84bf-1f9d4ed4baef

In order to fix this I added the same work around to pathToMoveClick():

https://github.com/tannerdino/Server/blob/72cbca79c438eb37097d9cf6fe0037247a90604e/src/lostcity/entity/PathingEntity.ts#L403-L408