### PR TITLE
fix(content): fix Chronozon death/regen behaviour if no hero found

### DIFF
--- a/data/src/scripts/quests/quest_crest/configs/quest_crest.npc
+++ b/data/src/scripts/quests/quest_crest/configs/quest_crest.npc
@@ -57,5 +57,6 @@ param=attack_sound,demon_attack
 param=defend_sound,demon_hit
 param=death_sound,demon_death
 param=death_drop,ashes
+param=combat_xp_multiplier,25
 huntmode=cowardly
 huntrange=3

--- a/data/src/scripts/quests/quest_crest/scripts/crest_chronozon.rs2
+++ b/data/src/scripts/quests/quest_crest/scripts/crest_chronozon.rs2
@@ -1,16 +1,22 @@
 [ai_queue3,crest_chronozon]
-if (npc_findhero = true){
+if (finduid(%npc_attacking_uid) = true) {
     if (getbit_range(%crest_spells_levers_gauntlets, ^crest_wind_blast_used, ^crest_fire_blast_used) = ^crest_all_spells_cast) {
         gosub(npc_death);
-        if (%crest_progress = ^crest_cured_johnathon) {
-            obj_add(npc_coord, crest_part_3, 1, ^lootdrop_duration);
+        if (npc_findhero = true){
+            if (%crest_progress = ^crest_cured_johnathon) {
+                obj_add(npc_coord, crest_part_3, 1, ^lootdrop_duration);
+            }
+            obj_add(npc_coord, npc_param(death_drop), 1, ^lootdrop_duration);
         }
-        obj_add(npc_coord, npc_param(death_drop), 1, ^lootdrop_duration);
     }
     else {
         @crest_chronozon_regenerate;
     }
 }
+else {
+    npc_statheal(hitpoints, npc_basestat(hitpoints), 0);
+}
+
 
 [proc,crest_chronozon_spell](int $spell) 
 switch_int ($spell) {


### PR DESCRIPTION
- Add 2.5% combat xp scaling for Chronozon
- Changed death/regen behaviour:
  - If you've cast all the spells (or have done the quest before) Chronozon will die, and if you did the most damage and are on the right quest stage it'll drop the crest piece
  - If you've cast all the spells but didn't do the most damage, it'll die with no drop for anyone
  - If you haven't cast all the spells, it regens with a message
  - If it can't find the player attacking it, it regens silently