### PR TITLE
feat(engine): ai_spawn triggers, 0 xp spawnhitting bug, and process order of npc hunt's

### DIFF
--- a/data/src/scripts/npc/configs/ai_spawn.varn
+++ b/data/src/scripts/npc/configs/ai_spawn.varn
@@ -1,0 +1,1 @@
+[npc_combat_xp_multiplier]

--- a/data/src/scripts/npc/scripts/ai_spawn.rs2
+++ b/data/src/scripts/npc/scripts/ai_spawn.rs2
@@ -1,0 +1,2 @@
+[ai_spawn,_]
+%npc_combat_xp_multiplier = npc_param(combat_xp_multiplier);

--- a/data/src/scripts/quests/quest_chompybird/scripts/chompy_bird.rs2
+++ b/data/src/scripts/quests/quest_chompybird/scripts/chompy_bird.rs2
@@ -175,7 +175,7 @@ def_int $damage = 0;
 if (~player_npc_hit_roll(%damagetype) = true) {
     $damage = randominc(min(%com_maxhit, npc_param(max_dealt)));
     $damage = min($damage, npc_stat(hitpoints));
-    ~give_combat_experience(%damagestyle, $damage, npc_param(combat_xp_multiplier));
+    ~give_combat_experience(%damagestyle, $damage, %npc_combat_xp_multiplier);
 }
 
 def_int $delay = add(~player_ranged_use_weapon($rhand, $ammo), 30); // osrs it seems to be delayed an extra tick

--- a/data/src/scripts/skill_combat/scripts/player/player_magic.rs2
+++ b/data/src/scripts/skill_combat/scripts/player/player_magic.rs2
@@ -239,7 +239,7 @@ if ($maxhit ! null) {
     if (npc_param(defend_sound) ! null) {
         sound_synth(npc_param(defend_sound), 0, $duration); // delay 1 client tick for the hit queue
     }
-    ~give_combat_experience(%damagestyle, $damage, npc_param(combat_xp_multiplier));
+    ~give_combat_experience(%damagestyle, $damage, %npc_combat_xp_multiplier);
 }
 // spell visual
 spotanim_npc(db_getfield($spell_data, magic_spell_table:spotanim_target, 0), $duration);

--- a/data/src/scripts/skill_combat/scripts/player/player_melee.rs2
+++ b/data/src/scripts/skill_combat/scripts/player/player_melee.rs2
@@ -38,7 +38,7 @@ if (~player_npc_hit_roll(%damagetype) = true) {
     }
     $damage = randominc(min(%com_maxhit, npc_param(max_dealt)));
     $damage = min($damage, npc_stat(hitpoints));
-    ~give_combat_experience(%damagestyle, $damage, npc_param(combat_xp_multiplier));
+    ~give_combat_experience(%damagestyle, $damage, %npc_combat_xp_multiplier);
 }
 
 def_obj $weapon = inv_getobj(worn, ^wearpos_rhand);

--- a/data/src/scripts/skill_combat/scripts/player/player_ranged.rs2
+++ b/data/src/scripts/skill_combat/scripts/player/player_ranged.rs2
@@ -61,7 +61,7 @@ if (~player_npc_hit_roll(%damagetype) = true) {
     }
     $damage = randominc(min(%com_maxhit, npc_param(max_dealt)));
     $damage = min($damage, npc_stat(hitpoints));
-    ~give_combat_experience(%damagestyle, $damage, npc_param(combat_xp_multiplier));
+    ~give_combat_experience(%damagestyle, $damage, %npc_combat_xp_multiplier);
 }
 
 def_int $poison_severity = oc_param($ammo, poison_severity);

--- a/src/lostcity/engine/script/ServerTriggerType.ts
+++ b/src/lostcity/engine/script/ServerTriggerType.ts
@@ -156,7 +156,9 @@ enum ServerTriggerType {
     MAPZONE = 161,
     MAPZONEEXIT = 162,
     ZONE = 163,
-    ZONEEXIT = 164
+    ZONEEXIT = 164,
+
+    AI_SPAWN = 166
 }
 
 namespace ServerTriggerType {

--- a/src/lostcity/entity/Npc.ts
+++ b/src/lostcity/entity/Npc.ts
@@ -51,8 +51,8 @@ export default class Npc extends PathingEntity {
     baseLevels: Uint8Array = new Uint8Array(6);
 
     // runtime variables
-    vars: Int32Array;
-    varsString: string[];
+    readonly vars: Int32Array;
+    readonly varsString: string[];
 
     // script variables
     activeScript: ScriptState | null = null;
@@ -159,8 +159,8 @@ export default class Npc extends PathingEntity {
             }
             this.resetHeroPoints();
             this.queue.clear();
-            this.vars = new Int32Array(VarNpcType.count);
-            this.varsString = new Array(VarNpcType.count);
+            this.vars.fill(0);
+            this.varsString.fill('');
             this.defaultMode();
 
             const npcType: NpcType = NpcType.get(this.type);

--- a/src/lostcity/entity/Npc.ts
+++ b/src/lostcity/entity/Npc.ts
@@ -52,7 +52,7 @@ export default class Npc extends PathingEntity {
 
     // runtime variables
     readonly vars: Int32Array;
-    readonly varsString: string[];
+    readonly varsString: (string | undefined)[];
 
     // script variables
     activeScript: ScriptState | null = null;
@@ -160,7 +160,7 @@ export default class Npc extends PathingEntity {
             this.resetHeroPoints();
             this.queue.clear();
             this.vars.fill(0);
-            this.varsString.fill('');
+            this.varsString.fill(undefined);
             this.defaultMode();
 
             const npcType: NpcType = NpcType.get(this.type);

--- a/src/lostcity/entity/Npc.ts
+++ b/src/lostcity/entity/Npc.ts
@@ -159,6 +159,8 @@ export default class Npc extends PathingEntity {
             }
             this.resetHeroPoints();
             this.queue.clear();
+            this.vars = new Int32Array(VarNpcType.count);
+            this.varsString = new Array(VarNpcType.count);
             this.defaultMode();
 
             const npcType: NpcType = NpcType.get(this.type);


### PR DESCRIPTION
0 xp spawnhitting:
- [Video](https://youtu.be/yYRSpv2AGq4) by keyboardOSRS (patched)
- Ours with proposed fixes:

https://github.com/user-attachments/assets/2d02e84e-6037-4643-8da1-3399ae20d12c

- ash tweet:

![image](https://github.com/user-attachments/assets/ae4617f1-594c-4b18-804f-14ae574a8406)

Respawn is moved to processNpcs() because:
- Npc's with hunt rates of 1, will always hunt 1 tick after *visibly* respawning (which is a total of 2 ticks after being added to the world). If respawns were processed before hunts, npc's with hunt rates of 1 would hunt the same tick it *visibly* respawns


https://github.com/user-attachments/assets/3f365058-4640-4d29-91e1-7322dcb7b4ea


https://github.com/user-attachments/assets/7ab173c3-da5e-47d2-8a84-4f0c0714ab77



- ai_spawn scripts take a tick to process in early osrs. This is the mechanism, along with pvm bonus xp handled with a varn, that allows 0 xp spawn hitting to work.


Obj/npc/loc hunting was moved to processNpcs() because:
- In osrs, npc's will only hunt *players* in the processWorld() part of the tick. This video shows that the npc will hunt the obj the same tick it is dropped (meaning its processed after processPlayerSetup()):

https://github.com/user-attachments/assets/849fec13-f5f6-4db9-91e1-366c9fddf828
- I'm pretty certain that at gwd the npc's will still hunt you if you unequip a god item in the same tick. Need a video of this though
