### PR TITLE
feat(engine): pre-2006 big npc pathing

### DIFF
--- a/src/lostcity/entity/PathingEntity.ts
+++ b/src/lostcity/entity/PathingEntity.ts
@@ -483,7 +483,7 @@ export default abstract class PathingEntity extends Entity {
                 // nomove moverestrict returns as null = no walking allowed.
                 return;
             }
-            if (this.width > 1) {
+            if (this.width > 1 && !CoordGrid.intersects(this.x, this.z, this.width, this.length, this.target.x, this.target.z, this.target.width, this.target.length)) {
                 // west/east
                 let dir = CoordGrid.face(this.x, 0, this.target.x, 0);
                 const distanceToTarget = CoordGrid.distanceTo({x: this.x, z: this.z, width: this.width, length: this.length}, {x: this.target.x, z: this.target.z, width: this.target.width, length: this.target.length});

--- a/src/lostcity/entity/PathingEntity.ts
+++ b/src/lostcity/entity/PathingEntity.ts
@@ -483,21 +483,22 @@ export default abstract class PathingEntity extends Entity {
                 // nomove moverestrict returns as null = no walking allowed.
                 return;
             }
-            if (this.width > 1 && !CoordGrid.intersects(this.x, this.z, this.width, this.length, this.target.x, this.target.z, this.target.width, this.target.length)) {
-                // west/east
-                let dir = CoordGrid.face(this.x, 0, this.target.x, 0);
-                const distanceToTarget = CoordGrid.distanceTo({x: this.x, z: this.z, width: this.width, length: this.length}, {x: this.target.x, z: this.target.z, width: this.target.width, length: this.target.length});
-                if (canTravel(this.level, this.x, this.z, CoordGrid.deltaX(dir), 0, this.width, extraFlag, collisionStrategy) || distanceToTarget <= 1) {
-                    this.queueWaypoint(CoordGrid.moveX(this.x, dir), this.z);
-                    return;
+            if (this.target instanceof PathingEntity) {
+                if (this.width > 1 && !CoordGrid.intersects(this.x, this.z, this.width, this.length, this.target.x, this.target.z, this.target.width, this.target.length)) {
+                    // west/east
+                    let dir = CoordGrid.face(this.x, 0, this.target.x, 0);
+                    const distanceToTarget = CoordGrid.distanceTo({x: this.x, z: this.z, width: this.width, length: this.length}, {x: this.target.x, z: this.target.z, width: this.target.width, length: this.target.length});
+                    if (canTravel(this.level, this.x, this.z, CoordGrid.deltaX(dir), 0, this.width, extraFlag, collisionStrategy) || distanceToTarget <= 1) {
+                        this.queueWaypoint(CoordGrid.moveX(this.x, dir), this.z);
+                        return;
+                    }
+                    // north/south
+                    dir = CoordGrid.face(0, this.z, 0, this.target.z);
+                    if (canTravel(this.level, this.x, this.z, 0, CoordGrid.deltaZ(dir), this.width, extraFlag, collisionStrategy)) {
+                        this.queueWaypoint(this.x, CoordGrid.moveZ(this.z, dir));
+                        return;
+                    }
                 }
-                // north/south
-                dir = CoordGrid.face(0, this.z, 0, this.target.z);
-                if (canTravel(this.level, this.x, this.z, 0, CoordGrid.deltaZ(dir), this.width, extraFlag, collisionStrategy)) {
-                    this.queueWaypoint(this.x, CoordGrid.moveZ(this.z, dir));
-                    return;
-                }
-            } else if (this.target instanceof PathingEntity) {
                 this.queueWaypoints(findNaivePath(this.level, this.x, this.z, this.target.x, this.target.z, this.width, this.length, this.target.width, this.target.length, extraFlag, collisionStrategy));
             } else {
                 this.queueWaypoint(this.target.x, this.target.z);

--- a/src/lostcity/entity/PathingEntity.ts
+++ b/src/lostcity/entity/PathingEntity.ts
@@ -483,7 +483,21 @@ export default abstract class PathingEntity extends Entity {
                 // nomove moverestrict returns as null = no walking allowed.
                 return;
             }
-            if (this.target instanceof PathingEntity) {
+            if (this.width > 1) {
+                // west/east
+                let dir = CoordGrid.face(this.x, 0, this.target.x, 0);
+                const distanceToTarget = CoordGrid.distanceTo({x: this.x, z: this.z, width: this.width, length: this.length}, {x: this.target.x, z: this.target.z, width: this.target.width, length: this.target.length});
+                if (canTravel(this.level, this.x, this.z, CoordGrid.deltaX(dir), 0, this.width, extraFlag, collisionStrategy) || distanceToTarget <= 1) {
+                    this.queueWaypoint(CoordGrid.moveX(this.x, dir), this.z);
+                    return;
+                }
+                // north/south
+                dir = CoordGrid.face(0, this.z, 0, this.target.z);
+                if (canTravel(this.level, this.x, this.z, 0, CoordGrid.deltaZ(dir), this.width, extraFlag, collisionStrategy)) {
+                    this.queueWaypoint(this.x, CoordGrid.moveZ(this.z, dir));
+                    return;
+                }
+            } else if (this.target instanceof PathingEntity) {
                 this.queueWaypoints(findNaivePath(this.level, this.x, this.z, this.target.x, this.target.z, this.width, this.length, this.target.width, this.target.length, extraFlag, collisionStrategy));
             } else {
                 this.queueWaypoint(this.target.x, this.target.z);


### PR DESCRIPTION
fixes #997 

- 1x1 npc pathing (unchanged):

https://github.com/user-attachments/assets/cb41abcd-674b-4d80-8838-9c33558d1278

- big npc pathing:

https://github.com/user-attachments/assets/4da2c574-946b-453a-a095-2c20ae143574

- big npc pathing in zigzag pattern:

https://github.com/user-attachments/assets/e59adb91-0d3a-44ad-bfb5-532d5faefe38

- corner safespotting still exists

https://github.com/user-attachments/assets/765aa425-ce69-4ae5-bac4-8d6bfbb31aea


- npcs still dance whilst under target

https://github.com/user-attachments/assets/9aacafeb-8493-4fa2-a815-6fcdc7f36cd4

