### PR TITLE
fix(content): Big Chompy Bird Hunting fixes

### DIFF
--- a/data/src/scripts/quests/quest_chompybird/configs/quest_chompybird.npc
+++ b/data/src/scripts/quests/quest_chompybird/configs/quest_chompybird.npc
@@ -95,6 +95,9 @@ param=defend_sound,chompy_bird_hit
 param=death_sound,chompy_bird_death
 // TODO tbc + missing datas
 wanderrange=3
+// Hunt range is a guess
+// If removed, chompy won't hunt for toads during quest
+huntrange=10
 // osrs stats and Vislvl match 1:1
 
 [chompy_bird_corpse]

--- a/data/src/scripts/quests/quest_chompybird/scripts/bugs.rs2
+++ b/data/src/scripts/quests/quest_chompybird/scripts/bugs.rs2
@@ -27,11 +27,7 @@ switch_int(%chompybird_progress) {
                     return;
                 }
 
-                if (inv_freespace(inv) < 2) {
-                    // todo what to do?
-                    return;
-                }
-
+                // No inv space check - OSRS drops the feathers on the floor
                 ~doubleobjbox(chisel, coins, "You offer the 10 coins for the tools.", 150);
 
                 inv_del(inv, coins, 10);
@@ -39,10 +35,13 @@ switch_int(%chompybird_progress) {
                 inv_add(inv, knife, 1);
                 ~chatnpc("<p,happy>Ok, dat's a good 'un, I got da bright pretties and you got da scratchers!");
             case 2 :
-                // todo mesanim tbc
                 ~chatplayer("<p,neutral>Er, sorry, I can't give you that many...");
                 ~chatnpc("<p,angry>Well, you not have da scratchers den!");
         }
+
+    case ^chompybird_kids_play_with_toad, ^chompybird_removed_rock_from_chest :
+        ~chatplayer("<p,quiz>Rantz said that you play with the 'fatsy toadies', what are they?");
+        ~chatnpc("<p,neutral>Oh we sometimes use da blower on da toadies but Dad don't let us get in da locked box no more. He, he, it was good fun making da toadies fat on da swamp gas.");
 
     case ^chompybird_shown_toad :
         ~chatnpc("<p,neutral>You's better talk to Dad, he might have something for you to do.");
@@ -62,11 +61,9 @@ switch_int(%chompybird_progress) {
 
         ~chatnpc("<p,neutal>Dad say's you's making da chompy for us! Slurp! Me's|has to have <$chompy_flavour> wiv mine! Chompy is our|favourite yummms!");
 
-    case ^chompybird_chompy_cooked :
-        // todo mesanim TBC
-        ~chatnpc("<p,neutral>Have you talked to Dad, he might have something for you to do.");
+    case ^chompybird_complete :
+        ~chatnpc("<p,neutral>Thanks for da chompy, it was deloverly!");
 
     case default :
-        // todo TBC other states
-        return;
+        ~chatnpc("<p,neutral>Have you talked to Dad, he might have something for you to do.");
 }

--- a/data/src/scripts/quests/quest_chompybird/scripts/chompy_bird.rs2
+++ b/data/src/scripts/quests/quest_chompybird/scripts/chompy_bird.rs2
@@ -48,7 +48,6 @@ npc_del;
 
 [apnpc5,chompy_bird]
 def_obj $rhand = inv_getobj(worn, ^wearpos_rhand);
-
 // make the player run to the bird if they are unarmed
 if ($rhand = null)
 {
@@ -147,7 +146,7 @@ if (%damagestyle = ^style_ranged_longrange) {
 }
 
 if (($attackrange <= 1 & ~player_in_combat_check = false) | $distance > $attackrange) {
-    // p_opnpc(2);
+    p_opnpc(5);
     p_aprange($attackrange);
     return;
 }
@@ -157,7 +156,7 @@ p_stopaction;
 // facesquare(npc_coord);
 
 if (%action_delay > map_clock) {
-    p_opnpc(2);
+    p_opnpc(5);
     return;
 }
 
@@ -178,7 +177,7 @@ if (~player_npc_hit_roll(%damagetype) = true) {
     ~give_combat_experience(%damagestyle, $damage, %npc_combat_xp_multiplier);
 }
 
-def_int $delay = add(~player_ranged_use_weapon($rhand, $ammo), 30); // osrs it seems to be delayed an extra tick
+def_int $delay = add(~player_use_ogre_bow($ammo), 30); // osrs it seems to be delayed an extra tick
 anim(%com_attackanim, 0);
 sound_synth(%com_attacksound, 0, 0);
 ~npc_retaliate(calc($delay / 30));
@@ -189,8 +188,7 @@ if (npc_param(defend_sound) ! null) {
 }
 
 npc_heropoints($damage);
-
-p_opnpc(2);
+p_opnpc(5);
 if (random(5) ! 0) {
     world_delay(calc($delay / 30 - 2));
     if (map_blocked(npc_coord) = false) {
@@ -200,6 +198,12 @@ if (random(5) ! 0) {
     }
 }
 inv_clear(ranged_quiver_inv);
+
+// Ogre arrow launch spotanim is higher than other arrows by default, so we compensate for that here
+[proc,player_use_ogre_bow](obj $ammo)(int)
+spotanim_pl(oc_param($ammo, proj_launch), 46, 0);
+inv_moveitem(worn, ranged_quiver_inv, $ammo, 1);
+return(~npc_projectile(coord, npc_uid, oc_param($ammo, proj_travel), 40, 36, 41, 15, 5, 11, 5));
 
 [ai_queue3,chompy_bird]
 gosub(npc_death);

--- a/data/src/scripts/quests/quest_chompybird/scripts/fycie.rs2
+++ b/data/src/scripts/quests/quest_chompybird/scripts/fycie.rs2
@@ -27,11 +27,7 @@ switch_int(%chompybird_progress) {
                     return;
                 }
 
-                if (inv_freespace(inv) = 0 & inv_total(inv, feather) = 0) {
-                    // todo what to do?
-                    return;
-                }
-
+                // No inv space check - OSRS drops the feathers on the floor
                 ~doubleobjbox(feather, coins, "You offer the 50 coins for the 25 flufsies.", 150);
 
                 inv_del(inv, coins, 50);
@@ -42,8 +38,9 @@ switch_int(%chompybird_progress) {
                 ~chatnpc("<p,angry>Well, you not have da flufsies den!");
         }
 
-    case ^chompybird_shown_toad :
-        ~chatnpc("<p,neutral>You's better talk to Dad, him chasey sneaky chompy.");
+    case ^chompybird_kids_play_with_toad, ^chompybird_removed_rock_from_chest :
+        ~chatplayer("<p,quiz>Rantz said that you play with the 'fatsy toadies', what are they?");
+        ~chatnpc("<p,neutral>Oh we sometimes is using blower on da toadies but Dad don't let us get in da locksy bocksy no more. He, he, big chuklees when make da toadies fat on da swampy gas.");      
 
     case ^chompybird_told_to_cook_chompy :
         def_int $flavour = getbit_range(%chompybird_kills, ^chompybird_varbit_fycie_flavour_start, ^chompybird_varbit_fycie_flavour_end);
@@ -59,12 +56,10 @@ switch_int(%chompybird_progress) {
         }
 
         ~chatnpc("<p,neutal>Dad say's you's roastling da chompy for us! Slurp!|Me's wants <$chompy_flavour> wiv mine! Yummy, can't wait|to eats it.");
-        
-    case ^chompybird_chompy_cooked :
-        // todo mesanim TBC
-        ~chatnpc("<p,neutral>Go talk to Dad, him chasey sneaky chompy.");
+
+    case ^chompybird_complete :
+        ~chatnpc("<p,neutral>Thanks for da chompy, it was deloverly!");
 
     case default :
-        // todo TBC other states
-        return;
+        ~chatnpc("<p,neutral>You's better talk to Dad, him chasey sneaky chompy.");
 }

--- a/data/src/scripts/quests/quest_chompybird/scripts/rantz.rs2
+++ b/data/src/scripts/quests/quest_chompybird/scripts/rantz.rs2
@@ -11,7 +11,6 @@ switch_int(%chompybird_progress) {
         ~chatplayer("<p,quiz>I think I understand. You want me to make some arrows for you?");
         ~chatnpc("<p,neutral>Yeah, is what Rantz sayed, make da stabbers for da stabby chucker!");
 
-        // todo this dialogue isn't in OSRS, try to find an old video
         switch_int(~p_choice2("OK, I'll make you some 'stabbers'.", 1, "Er, make you're own 'stabbers'!", 2)) {
             case 1 :
                 ~chatplayer("<p,neutral>OK, I'll make you some 'stabbers'.");
@@ -19,13 +18,12 @@ switch_int(%chompybird_progress) {
                 %chompybird_progress = ^chompybird_started;
                 ~send_quest_progress(questlist:chompybird, %chompybird_progress, ^chompybird_complete);
             case 2 :
-                // todo text and mesanims TBC
                 ~chatplayer("<p,neutral>Er, make you're own 'stabbers'!");
                 ~chatnpc("<p,angry>When I make 'stabbers', I pretend you chompy and practice on you!");
         }
     case ^chompybird_started :
         @return_to_rantz;
-    case ^chompybird_given_arrows :
+    case ^chompybird_given_arrows, ^chompybird_kids_play_with_toad, ^chompybird_removed_rock_from_chest :
         ~chatnpc("<p,quiz>Hey you creature, you still here?");
         ~chatnpc("<p,neutral>Da chompy still not coming! We need da fatsy toady to get da chompy, do you got it? Do you got da fatsy toady? Then we can sneaky, sneaky stick da chompy.");
         
@@ -39,15 +37,15 @@ switch_int(%chompybird_progress) {
         }
     case ^chompybird_shown_toad :
         @where_to_put_toadies;
-    case ^chompybird_dropped_toad :
+    // Maybe chompy_ate_toad has a separate set of dialogue, but in normal circumstances the stage
+    // advances to rantz_tried_to_shoot_chompy too quickly to tell.
+    case ^chompybird_dropped_toad, ^chompybird_chompy_ate_toad :
         // todo mesanim TBC
         ~chatplayer("<p,neutral>There you go, I've placed the bait.");
         ~chatnpc("<p,neutral>Goodz, me now waits for da chompy! It shouldn't be long now. Sneaky... sneaky...");
         ~chatplayer("<p,neutral>Yes, I know... stick da chompy!");
         ~chatnpc("<p,neutral>Hey, you's creature, is da fatsy toady still dere? Go get more fatsy toadies if dey all gone!");
         ~chatplayer("<p,neutral>What? I have to get more bait if there's none there? Does this Chompy Bird even exist I wonder?");
-    case ^chompybird_chompy_ate_toad :
-        mes("[debug] currently unimplemented");
     case ^chompybird_rantz_tried_to_shoot_chompy :
         ~chatplayer("<p,neutral>Hey there, you keep missing the chompy bird.");
         ~chatnpc("<p,angry>I knows, I keeps missing... because your stabbers are|worserer at flying than a dead dog.");
@@ -86,7 +84,9 @@ switch_int(%chompybird_progress) {
         ~chatnpc("<p,angry>Well hurry up and get some, we is hungry!");
     case ^chompybird_player_killed_chompy :
         if (inv_total(inv, raw_chompy) = 0) {
-            mes("[debug] todo currently unimplemented");
+            ~chatnpc("<p,neutral>Hey You! Got da chompy yet?");
+            ~chatplayer("<p,neutral>Not yet!");
+            ~chatnpc("<p,angry>Well hurry up and get some, we is hungry!");
         } else {
             // todo mesanim TBC
             ~chatnpc("<p,neutral>Hey You! Got da chompy yet?");
@@ -99,8 +99,8 @@ switch_int(%chompybird_progress) {
         // todo what if the player no longer has the seasoned chompy? Does it still auto-hand in?
         @hand_chompy_to_rantz;
     case ^chompybird_complete :
-        // todo message tbc
-        ~chatnpc("<p,neutral>Tank's very much for da chompy...|Fycie an Bugs like very much da chompy yumms!");
+        ~chatnpc("<p,neutral>Hey deyr, t'anks for da chompy, it was scrumbly!");
+        // No chompy bird hats yet
 
     // todo dialog to buy ogre bow back from Rantz
 }
@@ -183,8 +183,8 @@ switch_obj(last_useitem) {
 
         ~chatnpc("<p,neutral>Hey you creature..you made da stabbers|Dat's good creature!");
         
-        if (%chompybird_progress = ^chompybird_started) {
-        // todo mesanim TBC
+        if (%chompybird_progress = ^chompybird_started & testbit(%chompybird_kills, ^chompybird_varbit_made_arrows) = false) {
+            // todo mesanim TBC
             ~chatnpc("<p,neutral>Hey, deese stabbers no good... did you make dem you's self? You go make dem stabbers for me creature! Don't get old ones or from other creatures.");
 
             @no_arrows_choice;
@@ -245,19 +245,16 @@ switch_int(~p_choice2("How do I make the 'stabbers' again?", 1, "Ok, I'll make t
 [label,attempt_give_rantz_arrows]
 ~chatplayer("<p,angry>Well, yes actually, as you asked so nicely. Here you go! Here's your 'stabbers'.");
 
-if (inv_total(inv, ogre_arrow) < 6) {
-    // todo mesanim tbc
+// This check runs first, then quantity
+if (testbit(%chompybird_kills, ^chompybird_varbit_made_arrows) = false) {
+    ~chatnpc("<p,angry>Hey, 'dee'se stabbers no good! Did you make dem you's self? YOU go make dem arrows for ME creature!");
+}
+else if (inv_total(inv, ogre_arrow) < 6) {
     ~chatnpc("<p,neutral>Dat's not enough, me's an good shot, but need some for practice. Bring more than fingers on hand...");
-    return;
 }
-
-if (testbit(%chompybird_kills, ^chompybird_varbit_made_arrows) = true) {
-    // todo mesanim tbc
-    ~chatnpc("<p,neutral>Hey, 'dee'se stabbers no good! Did you make dem you's self? YOU go make dem arrows for ME creature!");
-    return;
+else {
+    @give_rantz_arrows;
 }
-
-@give_rantz_arrows;
 
 [label,give_rantz_arrows]
 inv_del(inv, ogre_arrow, 6);
@@ -274,7 +271,9 @@ switch_int(~p_choice5("How do we make the chompys come?", 1, "What are 'fatsy to
     case 1 :
         ~chatplayer("<p,neutral>How do we make the chompys come?");
         ~chatnpc("<p,neutral>Chompys love da fatsy toadies. Toadies get big on der swamp gas and der chompys are licking der lips for em as me is licking lips for da chompy. Da chompys don't like da smaller toadies from nearby swampy.");
-        %chompybird_progress = ^chompybird_kids_play_with_toad;
+        if (%chompybird_progress < ^chompybird_kids_play_with_toad) {
+            %chompybird_progress = ^chompybird_kids_play_with_toad;
+        }
         ~chatnpc("<p,happy>Dey's fussie eaters just like Rantz. Fycie an' Bugs play with toadies and blower dey's all times making fatsy toadies.");
         @toadies_questions;
     case 2 :
@@ -341,21 +340,18 @@ while (.npc_findnext = true) {
         if (p_finduid(.%quest_chompybird_baiter) = true) {
             // we only run this logic for players in the right quest state
             if (%chompybird_progress = ^chompybird_chompy_ate_toad) {
-                // todo fix the delays in this section
-
                 // todo send mesbox if player is close?
                 //      not sure which one was in 04
                 mes("Rantz: Hey, dere's da chompy, I's gonna shoot it.");
                 npc_facesquare(.npc_coord);
 
-                // npc_delay(1);
+                npc_delay(1);
                 
                 npc_anim(ogre_attackbow, 0);
                 spotanim_npc(ogre_arrow_launch, 50, 0);
                 def_int $duration = ~npc_projectile(npc_coord, .npc_uid, ogre_arrow_travel, 40, 36, 41, 15, 5, 11, 5);
-                // def_int $delay = add(sub(divide($duration, 30), 1), 2);
-
-                // npc_delay($delay);
+                def_int $delay = add(sub(divide($duration, 30), 1), 2);
+                npc_delay($delay);
 
                 if (p_finduid(.%quest_chompybird_baiter) = true) {
                     %chompybird_progress = ^chompybird_rantz_tried_to_shoot_chompy;
@@ -364,6 +360,7 @@ while (.npc_findnext = true) {
                     mes("Rantz keeps missing the chompy bird...");
                     mes("Rantz: Grrr...de'ese arrows are rubbish.");
                 }
+                return;
             }
         }
     }

--- a/data/src/scripts/quests/quest_chompybird/scripts/raw_chompy.rs2
+++ b/data/src/scripts/quests/quest_chompybird/scripts/raw_chompy.rs2
@@ -18,6 +18,11 @@ if (last_useitem ! raw_chompy)
     ~displaymessage(^dm_default);
     return;
 }
+if (stat(cooking) < 30) {
+    // Guess
+    ~mesbox("You need a Cooking level of 30 to cook chompy birds.");
+    return;
+}
 
 // todo allow cooking after quest
 if (%chompybird_progress < ^chompybird_told_to_cook_chompy)
@@ -29,10 +34,9 @@ if (%chompybird_progress < ^chompybird_told_to_cook_chompy)
 
 if (%chompybird_progress = ^chompybird_told_to_cook_chompy)
 {
-    @cook_chompy_quest;
+    @cook_chompy_quest(loc_coord);
     return;
 }
-
 if (%chompybird_progress = ^chompybird_chompy_cooked)
 {
     // todo what if the player no longer has the original chompy? Does it still auto-hand in?
@@ -51,7 +55,7 @@ if (%chompybird_progress = ^chompybird_chompy_cooked)
 // todo handle non-quest cooking
 ~displaymessage(^dm_default);
 
-[label,cook_chompy_quest]
+[label,cook_chompy_quest](coord $loc_coord)
 def_int $bugs_ingredient = getbit_range(%chompybird_kills, ^chompybird_varbit_bugs_flavour_start, ^chompybird_varbit_bugs_flavour_end);
 def_int $fycie_ingredient = getbit_range(%chompybird_kills, ^chompybird_varbit_fycie_flavour_start, ^chompybird_varbit_fycie_flavour_end);
 
@@ -136,12 +140,46 @@ if ($has_rantz_ingredient = false | $has_bugs_ingredient = false | $has_fycie_in
     return;
 }
 
-// todo in OSRS this takes some time, and the spit is animated
-%chompybird_progress = ^chompybird_chompy_cooked;
-mes("You carefully place the chompy bird on the spit-roast.");
-inv_del(inv, raw_chompy, 1);
+if (loc_find($loc_coord, ogre_spitroast) = true) {
+    %chompybird_progress = ^chompybird_chompy_cooked;
+    
+    mes("You carefully place the chompy bird on the spit-roast.");
+    inv_del(inv, raw_chompy, 1);
+    loc_change(ogre_spitroast_raw_chompy, 4);
+    loc_anim(spit_anim);
+    anim(human_cooking, 0);
+    sound_synth(spit_roast, 0, 0);
+    p_delay(2);
+    
+    def_boolean $passes_roll = stat_random(stat(cooking), 200, 255);
+    if ($passes_roll = true) {
+        mes("You add the other ingredients and cook the food.");
+        ~delete_chompy_ingredients($rantz_ingredient, $bugs_ingredient, $fycie_ingredient);
+        loc_change(ogre_spitroast_cooked_chompy, 4);
+        loc_anim(spit_anim);
+        anim(human_cooking, 0);
+        p_delay(2);
+        anim(human_pickuptable, 0);
+        mes("Eventually the chompy is cooked.");
+        inv_add(inv, seasoned_chompy, 1);
+        stat_advance(cooking, 142);
+        p_delay(1);
+        ~objbox(seasoned_chompy, "You use the <$rantz_ingredient_name>, <$bugs_ingredient_name> and the <$fycie_ingredient_name>|with the chompy bird to make a seasoned chompy.", 250, 0, divide(^objbox_height, 2));
+    }
+    else {
+        mes("You accidentally burn the chompy.");
+        ~delete_chompy_ingredients($rantz_ingredient, $bugs_ingredient, $fycie_ingredient);
+        loc_change(ogre_spitroast_burnt_chompy, 4);
+        loc_anim(spit_anim);
+        anim(human_cooking, 0);
+        p_delay(2);
+        anim(human_pickuptable, 0);
+        inv_add(inv, ruined_chompy, 1);
+        p_delay(1);
+    }
+}
 
-mes("You add the other ingredients and cook the food.");
+[proc,delete_chompy_ingredients](int $rantz_ingredient, int $bugs_ingredient, int $fycie_ingredient)
 if ($rantz_ingredient = 0)
 {
     inv_del(inv, potato, 1);
@@ -168,7 +206,3 @@ else if ($fycie_ingredient = 2)
 {
     inv_del(inv, doogle_leaves, 1);
 }
-
-mes("Eventually the chompy is cooked.");
-inv_add(inv, seasoned_chompy, 1);
-~objbox(seasoned_chompy, "You use the <$rantz_ingredient_name>, <$bugs_ingredient_name> and the <$fycie_ingredient_name>|with the chompy bird to make a seasoned chompy.", 250, 0, divide(^objbox_height, 2));

--- a/data/src/scripts/skill_cooking/scripts/cooking_inv/scripts/gnome_cooking/cocktail_mixing.rs2
+++ b/data/src/scripts/skill_cooking/scripts/cooking_inv/scripts/gnome_cooking/cocktail_mixing.rs2
@@ -84,6 +84,7 @@ switch_obj(last_useitem) {
     case half_baked_gnomebowl : @add_bowl_ingredient(last_item);
     case half_baked_batta : @add_cocktail_ingredient(last_item);
     case half_baked_crunchies : @add_crunchies_ingredient(last_item);
+    case raw_chompy : @quest_chompybird_add_ingredients_to_chompy_message;
     case default : ~displaymessage(^dm_default);
 }
 

--- a/data/src/scripts/skill_cooking/scripts/cooking_inv/scripts/gnome_cooking/gnome_battas.rs2
+++ b/data/src/scripts/skill_cooking/scripts/cooking_inv/scripts/gnome_cooking/gnome_battas.rs2
@@ -49,6 +49,7 @@ if_close;
 //p_stopaction;
 switch_obj(last_useitem) {
     case half_baked_batta : @add_batta_ingredient(last_item);
+    case raw_chompy : @quest_chompybird_add_ingredients_to_chompy_message;
     case default : ~displaymessage(^dm_default);
 }
 

--- a/data/src/scripts/skill_cooking/scripts/cooking_inv/scripts/pizza/pizza.rs2
+++ b/data/src/scripts/skill_cooking/scripts/cooking_inv/scripts/pizza/pizza.rs2
@@ -15,6 +15,7 @@ switch_obj (last_useitem) {
     case incomplete_pizza : mes("I think it's already got enough tomato on.");
     case half_baked_gnomebowl : @add_bowl_ingredient(last_item);
     case half_baked_batta : @add_batta_ingredient(last_item);
+    case raw_chompy : @quest_chompybird_add_ingredients_to_chompy_message;
     case default : ~displaymessage(^dm_default);
 };
 

--- a/data/src/scripts/skill_cooking/scripts/cooking_inv/scripts/stew/stew.rs2
+++ b/data/src/scripts/skill_cooking/scripts/cooking_inv/scripts/stew/stew.rs2
@@ -3,6 +3,7 @@ switch_obj (last_useitem) {
     case bowl_water : @make_incomplete_stew(last_slot);
     case incomplete_stew_meat : @make_uncooked_stew(last_slot, last_useslot);
     case bowl_empty : @no_water_stew_message;
+    case raw_chompy : @quest_chompybird_add_ingredients_to_chompy_message;
     case default : ~displaymessage(^dm_default);
 };
 


### PR DESCRIPTION
- Add missing dialogue for `chompybird_kids_play_with_toad` and `chompybird_removed_rock_from_chest` stages
- Restore chompy hunt range
- Fix issue where players had to spam click the chompy for arrows to fire
- Add spit animation, sounds, delay, and burn chance
- Add 30 cooking requirement for cooking chompy
- Add delay for Rantz hunting the chompy
- Fix ogre arrow spotanim height for humans
- Fix "Nothing interesting happens" when using raw chompy on secondary ingredients
- Fix inverted check if the player made the ogre arrows themselves
- Handle no inv space scenario when buying feathers/tools from Rantz's kids