### PR TITLE
fix(engine): actually remove the player when they logout

### DIFF
--- a/src/lostcity/engine/Login.ts
+++ b/src/lostcity/engine/Login.ts
@@ -4,7 +4,6 @@ import Isaac from '#jagex/io/Isaac.js';
 import Packet from '#jagex/io/Packet.js';
 
 import World from '#lostcity/engine/World.js';
-import {changeNpcCollision} from '#lostcity/engine/GameMap.js';
 
 import Player from '#lostcity/entity/Player.js';
 
@@ -97,6 +96,8 @@ class Login {
             save: save.data.subarray(0, save.pos)
         });
         save.release();
+
+        this.logoutRequests.delete(player.username37);
     }
 
     autosave(player: Player) {
@@ -168,21 +169,6 @@ class Login {
                 player.lowMemory = (info & 0x1) !== 0;
                 player.webClient = client.isWebSocket();
                 World.addPlayer(player);
-                break;
-            }
-            case 'logoutreply': {
-                const { username } = msg;
-
-                const player = World.getPlayerByUsername(username);
-                if (player) {
-                    World.gameMap.getZone(player.x, player.z, player.level).leave(player);
-                    World.players.remove(player.pid);
-                    changeNpcCollision(player.width, player.x, player.z, player.level, false);
-                    player.pid = -1;
-                    player.terminate();
-
-                    this.logoutRequests.delete(player.username37);
-                }
                 break;
             }
             default:

--- a/src/lostcity/server/LoginClient.ts
+++ b/src/lostcity/server/LoginClient.ts
@@ -85,21 +85,15 @@ export default class LoginClient {
         await this.connect();
 
         if (!this.ws || !this.wsr || !this.wsr.checkIfWsLive()) {
-            return -1;
+            return;
         }
 
-        const message = await this.wsr.fetchSync({
+        await this.wsr.fetchSync({
             type: 2,
             world: Environment.NODE_ID,
             username37: username37.toString(),
             save: Buffer.from(save).toString('base64')
         });
-
-        if (message.error) {
-            return -1;
-        }
-
-        return 0;
     }
 
     async reset() {

--- a/src/lostcity/server/LoginThread.ts
+++ b/src/lostcity/server/LoginThread.ts
@@ -206,25 +206,14 @@ async function handleRequests(parentPort: any, msg: any, priv: forge.pki.rsa.Pri
             break;
         }
         case 'logout': {
+            if (!Environment.LOGIN_KEY) {
+                return;
+            }
+
             const { username, save } = msg;
 
-            if (Environment.LOGIN_KEY) {
-                const reply = await login.save(toBase37(username), save);
-
-                if (reply === 0) {
-                    parentPort.postMessage({
-                        type: 'logoutreply',
-                        username
-                    });
-                }
-            } else {
-                parentPort.postMessage({
-                    type: 'logoutreply',
-                    username
-                });
-            }
-            break;
-        }
+            await login.save(toBase37(username), save);
+        } break;
         case 'autosave': {
             if (!Environment.LOGIN_KEY) {
                 return;


### PR DESCRIPTION
- The current implementation is non-blocking so when `Login.logout` is called, it doesn't actually remove the player from the world. This happens sometime later from the worker thread.
- `Environment.NODE_DEBUG_PROFILE` was reporting the next game tick instead of this current game tick.
- Renamed `processMovementDirections` to `processInfo` to more accurately describe what that function does now.