### PR TITLE
refactor(engine): swap npc/player count metrics to gauges

### DIFF
--- a/src/lostcity/engine/World.ts
+++ b/src/lostcity/engine/World.ts
@@ -555,8 +555,8 @@ class World {
 
             // push stats to prometheus
             // todo: lock this behind a feature flag? most users may never use this feature
-            trackPlayerCount.observe(this.getTotalPlayers());
-            trackNpcCount.observe(this.getTotalNpcs());
+            trackPlayerCount.set(this.getTotalPlayers());
+            trackNpcCount.set(this.getTotalNpcs());
 
             trackCycleTime.observe(this.cycleStats[WorldStat.CYCLE]);
             trackCycleWorldTime.observe(this.cycleStats[WorldStat.WORLD]);

--- a/src/lostcity/prometheus.ts
+++ b/src/lostcity/prometheus.ts
@@ -1,16 +1,7 @@
-import { Counter, Histogram } from 'prom-client';
+import { Counter, Gauge, Histogram } from 'prom-client';
 
-export const trackPlayerCount = new Histogram({
-    name: 'lostcity_active_players',
-    help: 'Active player count.',
-    buckets: [5, 10, 25, 50, 100, 250, 500, 750, 1000, 1500, 2000]
-});
-
-export const trackNpcCount = new Histogram({
-    name: 'lostcity_active_npcs',
-    help: 'Active NPC count.',
-    buckets: [1000, 2000, 3000, 4000, 5000, 6000, 7000, 8000]
-});
+export const trackPlayerCount = new Gauge({ name: 'lostcity_active_players', help: 'Active player count.' });
+export const trackNpcCount = new Gauge({ name: 'lostcity_active_npcs', help: 'Active NPC count.' });
 
 export const trackCycleTime = new Histogram({
     name: 'lostcity_cycle_ms',


### PR DESCRIPTION
Swap prometheus player/npc count metrics from histograms to gauges. These metrics do not track any sort of duration so they're not well suited to histograms as their values are somewhat constant. A gauge is a better metric because show a 'point in time' of the player/npc count.