### PR TITLE
fix(engine): walktrigger env settings and moveClickRequest changes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,6 +21,7 @@
 # NODE_STAFF=pazaz
 # NODE_CLIENT_ROUTEFINDER=true
 # NODE_SOCKET_TIMEOUT=true
+# NODE_WALKTRIGGER_SETTING=0
 
 ## login server
 # LOGIN_HOST=localhost

--- a/data/src/scripts/player/playerwalk.rs2
+++ b/data/src/scripts/player/playerwalk.rs2
@@ -1,0 +1,8 @@
+// https://x.com/JagexAsh/status/1605130887292751873
+[proc,playerwalk3](coord $coord)
+p_walk($coord);
+if (%player_run = ^player_run_off) {
+    p_delay(sub(distance(coord, $coord), 1));
+} else {
+    p_delay(sub(divide(distance(coord, $coord), 2), 1));
+}

--- a/data/src/scripts/quests/quest_mcannon/scripts/cannon.rs2
+++ b/data/src/scripts/quests/quest_mcannon/scripts/cannon.rs2
@@ -82,14 +82,16 @@ if ($setupcoord = null) {
     mes("There isn't enough space to set up here.");
     return;
 }
-~forcewalk2($setupcoord);
+~playerwalk3($setupcoord);
+
+facesquare($center);
+p_delay(0);
 
 def_coord $origin = movecoord($center, -1, 0, -1); // south-west tile
 %mcannon_coord = $origin;
 // %mcannon_world = map_world;
 %mcannon_ammo = 0;
 
-facesquare($center);
 anim(human_pickupfloor, 0);
 inv_del(inv, cannon_base, 1);
 loc_add($origin, cannon_base, 0, centrepiece_straight, ^cannon_decay_length);

--- a/src/lostcity/engine/World.ts
+++ b/src/lostcity/engine/World.ts
@@ -718,10 +718,10 @@ class World {
                             player.pathToTarget();
                             continue;
                         }
-                        if (Environment.NODE_WALKTRIGGER_SETTING === WalkTriggerSetting.PLAYERSETUP) {
+                        if (Environment.NODE_WALKTRIGGER_SETTING !== WalkTriggerSetting.PLAYERPACKET) {
                             player.pathToMoveClick(player.userPath, !Environment.NODE_CLIENT_ROUTEFINDER);
                             
-                            if (!player.opcalled && player.hasWaypoints()) {
+                            if (Environment.NODE_WALKTRIGGER_SETTING === WalkTriggerSetting.PLAYERSETUP && !player.opcalled && player.hasWaypoints()) {
                                 player.processWalktrigger();
                             }
                         }

--- a/src/lostcity/engine/World.ts
+++ b/src/lostcity/engine/World.ts
@@ -81,6 +81,7 @@ import { printDebug, printError, printInfo } from '#lostcity/util/Logger.js';
 import { createWorker } from '#lostcity/util/WorkerFactory.js';
 import HuntModeType from '#lostcity/entity/hunt/HuntModeType.js';
 import { trackCycleBandwidthInBytes, trackCycleBandwidthOutBytes, trackCycleClientInTime, trackCycleClientOutTime, trackCycleLoginTime, trackCycleLogoutTime, trackCycleNpcTime, trackCyclePlayerTime, trackCycleTime, trackCycleWorldTime, trackCycleZoneTime, trackNpcCount, trackPlayerCount } from '#lostcity/prometheus.js';
+import WalkTriggerSetting from '#lostcity/util/WalkTriggerSetting.js';
 
 class World {
     private friendThread: Worker | NodeWorker = createWorker(Environment.STANDALONE_BUNDLE ? 'FriendThread.js' : './lostcity/server/FriendThread.ts');
@@ -715,11 +716,12 @@ class World {
                             player.pathToTarget();
                             continue;
                         }
-        
-                        player.pathToMoveClick(player.userPath, !Environment.NODE_CLIENT_ROUTEFINDER);
-    
-                        if (!player.opcalled && player.hasWaypoints()) {
-                            player.processWalktrigger();
+                        if (Environment.NODE_WALKTRIGGER_SETTING === WalkTriggerSetting.PLAYERSETUP) {
+                            player.pathToMoveClick(player.userPath, !Environment.NODE_CLIENT_ROUTEFINDER);
+                            
+                            if (!player.opcalled && player.hasWaypoints()) {
+                                player.processWalktrigger();
+                            }
                         }
                     }
         

--- a/src/lostcity/engine/World.ts
+++ b/src/lostcity/engine/World.ts
@@ -708,7 +708,9 @@ class World {
                             player.masks |= InfoProt.PLAYER_FACE_ENTITY.id;
                         }
         
-                        if (player.busy() || !player.opcalled) {
+                        if (!player.busy() && player.opcalled) {
+                            player.moveClickRequest = false;
+                        } else {
                             player.moveClickRequest = true;
                         }
         
@@ -953,6 +955,7 @@ class World {
             player.pid = pid;
             player.uid = ((Number(player.username37 & 0x1fffffn) << 11) | player.pid) >>> 0;
             player.tele = true;
+            player.moveClickRequest = false;
 
             this.gameMap.getZone(player.x, player.z, player.level).enter(player);
             player.onLogin(); // todo: check response from login script?

--- a/src/lostcity/engine/World.ts
+++ b/src/lostcity/engine/World.ts
@@ -708,7 +708,7 @@ class World {
                             player.masks |= InfoProt.PLAYER_FACE_ENTITY.id;
                         }
         
-                        if (!player.busy() && player.opcalled) {
+                        if ((!player.busy() && player.opcalled) || player.opucalled) { // opu in osrs doesnt have a busy check
                             player.moveClickRequest = false;
                         } else {
                             player.moveClickRequest = true;

--- a/src/lostcity/engine/script/handlers/PlayerOps.ts
+++ b/src/lostcity/engine/script/handlers/PlayerOps.ts
@@ -404,7 +404,6 @@ const PlayerOps: CommandHandlers = {
         const coord: CoordGrid = check(state.popInt(), CoordValid);
 
         const player = state.activePlayer;
-        player.moveClickRequest = false;
         player.queueWaypoints(findPath(player.level, player.x, player.z, coord.x, coord.z));
     }),
 

--- a/src/lostcity/entity/NetworkPlayer.ts
+++ b/src/lostcity/entity/NetworkPlayer.ts
@@ -44,6 +44,7 @@ export class NetworkPlayer extends Player {
     client: ClientSocket | null = null;
     userPath: number[] = [];
     opcalled: boolean = false;
+    opucalled: boolean = false;
 
     constructor(username: string, username37: bigint, client: ClientSocket) {
         super(username, username37);
@@ -55,6 +56,7 @@ export class NetworkPlayer extends Player {
     decodeIn() {
         this.userPath = [];
         this.opcalled = false;
+        this.opucalled = false;
 
         if (this.client === null) {
             return false;

--- a/src/lostcity/entity/Player.ts
+++ b/src/lostcity/entity/Player.ts
@@ -518,10 +518,6 @@ export default class Player extends PathingEntity {
 
     // ----
 
-    clearWaypoints(): void {
-        super.clearWaypoints();
-    }
-
     updateMovement(repathAllowed: boolean = true): boolean {
         // players cannot walk if they have a modal open *and* something in their queue, confirmed as far back as 2005
         if (this.moveClickRequest && this.busy() && (this.queue.head() != null || this.engineQueue.head() != null || this.walktrigger !== -1)) {

--- a/src/lostcity/entity/Player.ts
+++ b/src/lostcity/entity/Player.ts
@@ -69,6 +69,7 @@ import ChatFilterSettings from '#lostcity/network/outgoing/model/ChatFilterSetti
 import { ChatModePrivate, ChatModePublic, ChatModeTradeDuel } from '#lostcity/util/ChatModes.js';
 import { isNetworkPlayer } from '#lostcity/entity/NetworkPlayer.js';
 import InfoProt from '#lostcity/network/225/outgoing/prot/InfoProt.js';
+import WalkTriggerSetting from '#lostcity/util/WalkTriggerSetting.js';
 
 const levelExperience = new Int32Array(99);
 
@@ -529,6 +530,9 @@ export default class Player extends PathingEntity {
             return false;
         }
 
+        if (Environment.NODE_WALKTRIGGER_SETTING === WalkTriggerSetting.PLAYERMOVEMENT && !this.target && this.hasWaypoints()) {
+            this.processWalktrigger();
+        }
         if (repathAllowed && this.target instanceof PathingEntity && !this.interacted && this.walktrigger === -1) {
             this.pathToPathingTarget();
         }

--- a/src/lostcity/entity/Player.ts
+++ b/src/lostcity/entity/Player.ts
@@ -519,7 +519,6 @@ export default class Player extends PathingEntity {
     // ----
 
     clearWaypoints(): void {
-        this.moveClickRequest = false;
         super.clearWaypoints();
     }
 
@@ -561,10 +560,6 @@ export default class Player extends PathingEntity {
         }
         if (moved) {
             this.lastMovement = World.currentTick + 1;
-        }
-        if (!this.hasWaypoints()) {
-            this.moveClickRequest = false;
-            // this.unsetMapFlag(); // should be handled client-sided
         }
         return moved;
     }

--- a/src/lostcity/network/225/incoming/handler/MoveClickHandler.ts
+++ b/src/lostcity/network/225/incoming/handler/MoveClickHandler.ts
@@ -5,6 +5,7 @@ import { CoordGrid } from '#lostcity/engine/CoordGrid.js';
 import Environment from '#lostcity/util/Environment.js';
 import VarPlayerType from '#lostcity/cache/config/VarPlayerType.js';
 import UnsetMapFlag from '#lostcity/network/outgoing/model/UnsetMapFlag.js';
+import WalkTriggerSetting from '#lostcity/util/WalkTriggerSetting.js';
 
 export default class MoveClickHandler extends MessageHandler<MoveClick> {
     handle(message: MoveClick, player: NetworkPlayer): boolean {
@@ -34,6 +35,9 @@ export default class MoveClickHandler extends MessageHandler<MoveClick> {
             const dest = message.path[message.path.length - 1];
             player.userPath = [CoordGrid.packCoord(player.level, dest.x, dest.z)];
         }
+        if (Environment.NODE_WALKTRIGGER_SETTING === WalkTriggerSetting.PLAYERPACKET) {
+            player.pathToMoveClick(player.userPath, !Environment.NODE_CLIENT_ROUTEFINDER);
+        }
         player.interactWalkTrigger = false;
         if (!message.opClick) {
             player.clearInteraction();
@@ -42,6 +46,9 @@ export default class MoveClickHandler extends MessageHandler<MoveClick> {
                 player.setVar(VarPlayerType.TEMP_RUN, 0);
             } else {
                 player.setVar(VarPlayerType.TEMP_RUN, message.ctrlHeld);
+            }
+            if (Environment.NODE_WALKTRIGGER_SETTING === WalkTriggerSetting.PLAYERPACKET && player.hasWaypoints()) {
+                player.processWalktrigger();
             }
         }
         return true;

--- a/src/lostcity/network/225/incoming/handler/OpHeldHandler.ts
+++ b/src/lostcity/network/225/incoming/handler/OpHeldHandler.ts
@@ -41,6 +41,7 @@ export default class OpHeldHandler extends MessageHandler<OpHeld> {
 
         player.clearInteraction();
         player.closeModal();
+        player.moveClickRequest = false; // uses the dueling ring op to move whilst busy & queue pending: https://youtu.be/GPfN3Isl2rM
         player.faceEntity = -1;
         player.masks |= player.entitymask;
 

--- a/src/lostcity/network/225/incoming/handler/OpHeldTHandler.ts
+++ b/src/lostcity/network/225/incoming/handler/OpHeldTHandler.ts
@@ -13,25 +13,21 @@ export default class OpHeldTHandler extends MessageHandler<OpHeldT> {
 
         const com = Component.get(comId);
         if (typeof com === 'undefined' || !player.isComponentVisible(com)) {
-            player.unsetMapFlag();
             return false;
         }
 
         const spellCom = Component.get(comId);
         if (typeof spellCom === 'undefined' || !player.isComponentVisible(spellCom)) {
-            player.unsetMapFlag();
             return false;
         }
 
         const listener = player.invListeners.find(l => l.com === comId);
         if (!listener) {
-            player.unsetMapFlag();
             return false;
         }
 
         const inv = player.getInventoryFromListener(listener);
         if (!inv || !inv.validSlot(slot) || !inv.hasAt(slot, item)) {
-            player.unsetMapFlag();
             return false;
         }
 

--- a/src/lostcity/network/225/incoming/handler/OpHeldUHandler.ts
+++ b/src/lostcity/network/225/incoming/handler/OpHeldUHandler.ts
@@ -15,26 +15,22 @@ export default class OpHeldUHandler extends MessageHandler<OpHeldU> {
 
         const com = Component.get(comId);
         if (typeof com === 'undefined' || !player.isComponentVisible(com)) {
-            player.unsetMapFlag();
             return false;
         }
 
         const useCom = Component.get(comId);
         if (typeof useCom === 'undefined' || !player.isComponentVisible(useCom)) {
-            player.unsetMapFlag();
             return false;
         }
 
         {
             const listener = player.invListeners.find(l => l.com === comId);
             if (!listener) {
-                player.unsetMapFlag();
                 return false;
             }
 
             const inv = player.getInventoryFromListener(listener);
             if (!inv || !inv.validSlot(slot) || !inv.hasAt(slot, item)) {
-                player.unsetMapFlag();
                 return false;
             }
         }
@@ -42,13 +38,11 @@ export default class OpHeldUHandler extends MessageHandler<OpHeldU> {
         {
             const listener = player.invListeners.find(l => l.com === useComId);
             if (!listener) {
-                player.unsetMapFlag();
                 return false;
             }
 
             const inv = player.getInventoryFromListener(listener);
             if (!inv || !inv.validSlot(useSlot) || !inv.hasAt(useSlot, useItem)) {
-                player.unsetMapFlag();
                 return false;
             }
         }
@@ -72,7 +66,6 @@ export default class OpHeldUHandler extends MessageHandler<OpHeldU> {
 
         if ((objType.members || useObjType.members) && !Environment.NODE_MEMBERS) {
             player.messageGame("To use this item please login to a members' server.");
-            player.unsetMapFlag();
             return false;
         }
 

--- a/src/lostcity/network/225/incoming/handler/OpHeldUHandler.ts
+++ b/src/lostcity/network/225/incoming/handler/OpHeldUHandler.ts
@@ -31,6 +31,7 @@ export default class OpHeldUHandler extends MessageHandler<OpHeldU> {
 
             const inv = player.getInventoryFromListener(listener);
             if (!inv || !inv.validSlot(slot) || !inv.hasAt(slot, item)) {
+                player.moveClickRequest = false; // removed early osrs
                 return false;
             }
         }
@@ -43,6 +44,7 @@ export default class OpHeldUHandler extends MessageHandler<OpHeldU> {
 
             const inv = player.getInventoryFromListener(listener);
             if (!inv || !inv.validSlot(useSlot) || !inv.hasAt(useSlot, useItem)) {
+                player.moveClickRequest = false; // removed early osrs
                 return false;
             }
         }

--- a/src/lostcity/network/225/incoming/handler/OpHeldUHandler.ts
+++ b/src/lostcity/network/225/incoming/handler/OpHeldUHandler.ts
@@ -12,6 +12,9 @@ import Environment from '#lostcity/util/Environment.js';
 export default class OpHeldUHandler extends MessageHandler<OpHeldU> {
     handle(message: OpHeldU, player: Player): boolean {
         const { obj: item, slot, component: comId, useObj: useItem, useSlot, useComponent: useComId } = message;
+        if (player.delayed()) {
+            return false;
+        }
 
         const com = Component.get(comId);
         if (typeof com === 'undefined' || !player.isComponentVisible(com)) {
@@ -47,10 +50,6 @@ export default class OpHeldUHandler extends MessageHandler<OpHeldU> {
                 player.moveClickRequest = false; // removed early osrs
                 return false;
             }
-        }
-
-        if (player.delayed()) {
-            return false;
         }
 
         player.lastItem = item;

--- a/src/lostcity/network/225/incoming/handler/OpLocHandler.ts
+++ b/src/lostcity/network/225/incoming/handler/OpLocHandler.ts
@@ -21,18 +21,19 @@ export default class OpLocHandler extends MessageHandler<OpLoc> {
         const absTopZ = player.originZ + 52;
         const absBottomZ = player.originZ - 52;
         if (x < absLeftX || x > absRightX || z < absBottomZ || z > absTopZ) {
+            player.write(new UnsetMapFlag());
             return false;
         }
 
         const loc = World.getLoc(x, z, player.level, locId);
         if (!loc) {
-            player.unsetMapFlag();
+            player.write(new UnsetMapFlag());
             return false;
         }
 
         const locType = LocType.get(loc.type);
         if (!locType.op || !locType.op[message.op - 1]) {
-            player.unsetMapFlag();
+            player.write(new UnsetMapFlag());
             return false;
         }
 

--- a/src/lostcity/network/225/incoming/handler/OpLocTHandler.ts
+++ b/src/lostcity/network/225/incoming/handler/OpLocTHandler.ts
@@ -18,7 +18,7 @@ export default class OpLocTHandler extends MessageHandler<OpLocT> {
 
         const spellCom = Component.get(spellComId);
         if (typeof spellCom === 'undefined' || !player.isComponentVisible(spellCom)) {
-            player.unsetMapFlag();
+            player.write(new UnsetMapFlag());
             return false;
         }
 
@@ -27,13 +27,13 @@ export default class OpLocTHandler extends MessageHandler<OpLocT> {
         const absTopZ = player.originZ + 52;
         const absBottomZ = player.originZ - 52;
         if (x < absLeftX || x > absRightX || z < absBottomZ || z > absTopZ) {
-            player.unsetMapFlag();
+            player.write(new UnsetMapFlag());
             return false;
         }
 
         const loc = World.getLoc(x, z, player.level, locId);
         if (!loc) {
-            player.unsetMapFlag();
+            player.moveClickRequest = false;
             return false;
         }
 

--- a/src/lostcity/network/225/incoming/handler/OpLocUHandler.ts
+++ b/src/lostcity/network/225/incoming/handler/OpLocUHandler.ts
@@ -63,6 +63,7 @@ export default class OpLocUHandler extends MessageHandler<OpLocU> {
 
         player.setInteraction(Interaction.ENGINE, loc, ServerTriggerType.APLOCU);
         player.opcalled = true;
+        player.opucalled = true;
         return true;
     }
 }

--- a/src/lostcity/network/225/incoming/handler/OpLocUHandler.ts
+++ b/src/lostcity/network/225/incoming/handler/OpLocUHandler.ts
@@ -20,7 +20,7 @@ export default class OpLocUHandler extends MessageHandler<OpLocU> {
 
         const com = Component.get(comId);
         if (typeof com === 'undefined' || !player.isComponentVisible(com)) {
-            player.unsetMapFlag();
+            player.write(new UnsetMapFlag());
             return false;
         }
 
@@ -29,32 +29,31 @@ export default class OpLocUHandler extends MessageHandler<OpLocU> {
         const absTopZ = player.originZ + 52;
         const absBottomZ = player.originZ - 52;
         if (x < absLeftX || x > absRightX || z < absBottomZ || z > absTopZ) {
-            player.unsetMapFlag();
             return false;
         }
 
         const listener = player.invListeners.find(l => l.com === comId);
         if (!listener) {
-            player.unsetMapFlag();
+            player.write(new UnsetMapFlag());
             return false;
         }
 
         const inv = player.getInventoryFromListener(listener);
         if (!inv || !inv.validSlot(slot) || !inv.hasAt(slot, item)) {
-            player.unsetMapFlag();
+            player.write(new UnsetMapFlag());
             return false;
         }
 
         const loc = World.getLoc(x, z, player.level, locId);
         if (!loc) {
-            player.unsetMapFlag();
+            player.write(new UnsetMapFlag());
             return false;
         }
 
         player.clearPendingAction();
         if (ObjType.get(item).members && !Environment.NODE_MEMBERS) {
             player.messageGame("To use this item please login to a members' server.");
-            player.unsetMapFlag();
+            player.write(new UnsetMapFlag());
             return false;
         }
 

--- a/src/lostcity/network/225/incoming/handler/OpNpcHandler.ts
+++ b/src/lostcity/network/225/incoming/handler/OpNpcHandler.ts
@@ -18,18 +18,18 @@ export default class OpNpcHandler extends MessageHandler<OpNpc> {
 
         const npc = World.getNpc(nid);
         if (!npc || npc.delayed()) {
-            player.unsetMapFlag();
+            player.write(new UnsetMapFlag());
             return false;
         }
 
         if (!player.buildArea.npcs.has(npc)) {
-            player.unsetMapFlag();
+            player.write(new UnsetMapFlag());
             return false;
         }
 
         const npcType = NpcType.get(npc.type);
         if (!npcType.op || !npcType.op[message.op - 1]) {
-            player.unsetMapFlag();
+            player.write(new UnsetMapFlag());
             return false;
         }
 

--- a/src/lostcity/network/225/incoming/handler/OpNpcTHandler.ts
+++ b/src/lostcity/network/225/incoming/handler/OpNpcTHandler.ts
@@ -18,18 +18,18 @@ export default class OpNpcTHandler extends MessageHandler<OpNpcT> {
 
         const spellCom = Component.get(spellComId);
         if (typeof spellCom === 'undefined' || !player.isComponentVisible(spellCom)) {
-            player.unsetMapFlag();
+            player.write(new UnsetMapFlag());
             return false;
         }
 
         const npc = World.getNpc(nid);
         if (!npc || npc.delayed()) {
-            player.unsetMapFlag();
+            player.write(new UnsetMapFlag());
             return false;
         }
 
         if (!player.buildArea.npcs.has(npc)) {
-            player.unsetMapFlag();
+            player.write(new UnsetMapFlag());
             return false;
         }
 

--- a/src/lostcity/network/225/incoming/handler/OpNpcTHandler.ts
+++ b/src/lostcity/network/225/incoming/handler/OpNpcTHandler.ts
@@ -36,6 +36,7 @@ export default class OpNpcTHandler extends MessageHandler<OpNpcT> {
         player.clearPendingAction();
         player.setInteraction(Interaction.ENGINE, npc, ServerTriggerType.APNPCT, { type: npc.type, com: spellComId });
         player.opcalled = true;
+        player.opucalled = true;
         return true;
     }
 }

--- a/src/lostcity/network/225/incoming/handler/OpNpcUHandler.ts
+++ b/src/lostcity/network/225/incoming/handler/OpNpcUHandler.ts
@@ -59,6 +59,7 @@ export default class OpNpcUHandler extends MessageHandler<OpNpcU> {
 
         player.setInteraction(Interaction.ENGINE, npc, ServerTriggerType.APNPCU, { type: npc.type, com: -1 });
         player.opcalled = true;
+        player.opucalled = true;
         return true;
     }
 }

--- a/src/lostcity/network/225/incoming/handler/OpNpcUHandler.ts
+++ b/src/lostcity/network/225/incoming/handler/OpNpcUHandler.ts
@@ -20,37 +20,37 @@ export default class OpNpcUHandler extends MessageHandler<OpNpcU> {
 
         const com = Component.get(comId);
         if (typeof com === 'undefined' || !player.isComponentVisible(com)) {
-            player.unsetMapFlag();
+            player.write(new UnsetMapFlag());
             return false;
         }
 
         const listener = player.invListeners.find(l => l.com === comId);
         if (!listener) {
-            player.unsetMapFlag();
+            player.write(new UnsetMapFlag());
             return false;
         }
 
         const inv = player.getInventoryFromListener(listener);
         if (!inv || !inv.validSlot(slot) || !inv.hasAt(slot, item)) {
-            player.unsetMapFlag();
+            player.write(new UnsetMapFlag());
             return false;
         }
 
         const npc = World.getNpc(nid);
         if (!npc || npc.delayed()) {
-            player.unsetMapFlag();
+            player.write(new UnsetMapFlag());
             return false;
         }
 
         if (!player.buildArea.npcs.has(npc)) {
-            player.unsetMapFlag();
+            player.write(new UnsetMapFlag());
             return false;
         }
 
         player.clearPendingAction();
         if (ObjType.get(item).members && !Environment.NODE_MEMBERS) {
             player.messageGame("To use this item please login to a members' server.");
-            player.unsetMapFlag();
+            player.write(new UnsetMapFlag());
             return false;
         }
 

--- a/src/lostcity/network/225/incoming/handler/OpObjHandler.ts
+++ b/src/lostcity/network/225/incoming/handler/OpObjHandler.ts
@@ -21,20 +21,20 @@ export default class OpObjHandler extends MessageHandler<OpObj> {
         const absTopZ = player.originZ + 52;
         const absBottomZ = player.originZ - 52;
         if (x < absLeftX || x > absRightX || z < absBottomZ || z > absTopZ) {
-            player.unsetMapFlag();
+            player.write(new UnsetMapFlag());
             return false;
         }
 
         const obj = World.getObj(x, z, player.level, objId, player.pid);
         if (!obj) {
-            player.unsetMapFlag();
+            player.moveClickRequest = false;
             return false;
         }
 
         const objType = ObjType.get(obj.type);
         // todo: validate all options
         if ((message.op === 1 && ((objType.op && !objType.op[0]) || !objType.op)) || (message.op === 4 && ((objType.op && !objType.op[3]) || !objType.op))) {
-            player.unsetMapFlag();
+            player.write(new UnsetMapFlag());
             return false;
         }
 

--- a/src/lostcity/network/225/incoming/handler/OpObjTHandler.ts
+++ b/src/lostcity/network/225/incoming/handler/OpObjTHandler.ts
@@ -18,7 +18,7 @@ export default class OpObjTHandler extends MessageHandler<OpObjT> {
 
         const spellCom = Component.get(spellComId);
         if (typeof spellCom === 'undefined' || !player.isComponentVisible(spellCom)) {
-            player.unsetMapFlag();
+            player.write(new UnsetMapFlag());
             return false;
         }
 
@@ -27,19 +27,20 @@ export default class OpObjTHandler extends MessageHandler<OpObjT> {
         const absTopZ = player.originZ + 52;
         const absBottomZ = player.originZ - 52;
         if (x < absLeftX || x > absRightX || z < absBottomZ || z > absTopZ) {
-            player.unsetMapFlag();
+            player.write(new UnsetMapFlag());
             return false;
         }
 
         const obj = World.getObj(x, z, player.level, objId, player.pid);
         if (!obj) {
-            player.unsetMapFlag();
+            player.write(new UnsetMapFlag());
             return false;
         }
 
         player.clearPendingAction();
         player.setInteraction(Interaction.ENGINE, obj, ServerTriggerType.APOBJT, { type: obj.type, com: spellComId });
         player.opcalled = true;
+        player.opucalled = true;
         return true;
     }
 }

--- a/src/lostcity/network/225/incoming/handler/OpObjUHandler.ts
+++ b/src/lostcity/network/225/incoming/handler/OpObjUHandler.ts
@@ -63,6 +63,7 @@ export default class OpObjUHandler extends MessageHandler<OpObjU> {
 
         player.setInteraction(Interaction.ENGINE, obj, ServerTriggerType.APOBJU);
         player.opcalled = true;
+        player.opucalled = true;
         return true;
     }
 }

--- a/src/lostcity/network/225/incoming/handler/OpObjUHandler.ts
+++ b/src/lostcity/network/225/incoming/handler/OpObjUHandler.ts
@@ -20,7 +20,7 @@ export default class OpObjUHandler extends MessageHandler<OpObjU> {
 
         const com = Component.get(comId);
         if (typeof com === 'undefined' || !player.isComponentVisible(com)) {
-            player.unsetMapFlag();
+            player.write(new UnsetMapFlag());
             return false;
         }
 
@@ -29,32 +29,32 @@ export default class OpObjUHandler extends MessageHandler<OpObjU> {
         const absTopZ = player.originZ + 52;
         const absBottomZ = player.originZ - 52;
         if (x < absLeftX || x > absRightX || z < absBottomZ || z > absTopZ) {
-            player.unsetMapFlag();
+            player.write(new UnsetMapFlag());
             return false;
         }
 
         const listener = player.invListeners.find(l => l.com === comId);
         if (!listener) {
-            player.unsetMapFlag();
+            player.write(new UnsetMapFlag());
             return false;
         }
 
         const inv = player.getInventoryFromListener(listener);
         if (!inv || !inv.validSlot(slot) || !inv.hasAt(slot, item)) {
-            player.unsetMapFlag();
+            player.write(new UnsetMapFlag());
             return false;
         }
 
         const obj = World.getObj(x, z, player.level, objId, player.pid);
         if (!obj) {
-            player.unsetMapFlag();
+            player.write(new UnsetMapFlag());
             return false;
         }
 
         player.clearPendingAction();
         if (ObjType.get(item).members && !Environment.NODE_MEMBERS) {
             player.messageGame("To use this item please login to a members' server.");
-            player.unsetMapFlag();
+            player.write(new UnsetMapFlag());
             return false;
         }
 

--- a/src/lostcity/network/225/incoming/handler/OpPlayerHandler.ts
+++ b/src/lostcity/network/225/incoming/handler/OpPlayerHandler.ts
@@ -17,12 +17,12 @@ export default class OpPlayerHandler extends MessageHandler<OpPlayer> {
 
         const other = World.getPlayer(pid);
         if (!other) {
-            player.unsetMapFlag();
+            player.write(new UnsetMapFlag());
             return false;
         }
 
         if (!player.buildArea.players.has(other)) {
-            player.unsetMapFlag();
+            player.write(new UnsetMapFlag());
             return false;
         }
 

--- a/src/lostcity/network/225/incoming/handler/OpPlayerTHandler.ts
+++ b/src/lostcity/network/225/incoming/handler/OpPlayerTHandler.ts
@@ -36,6 +36,7 @@ export default class OpPlayerTHandler extends MessageHandler<OpPlayerT> {
         player.clearPendingAction();
         player.setInteraction(Interaction.ENGINE, other, ServerTriggerType.APPLAYERT, { type: -1, com: spellComId });
         player.opcalled = true;
+        player.opucalled = true;
         return true;
     }
 }

--- a/src/lostcity/network/225/incoming/handler/OpPlayerTHandler.ts
+++ b/src/lostcity/network/225/incoming/handler/OpPlayerTHandler.ts
@@ -18,18 +18,18 @@ export default class OpPlayerTHandler extends MessageHandler<OpPlayerT> {
 
         const spellCom = Component.get(spellComId);
         if (typeof spellCom === 'undefined' || !player.isComponentVisible(spellCom)) {
-            player.unsetMapFlag();
+            player.write(new UnsetMapFlag());
             return false;
         }
 
         const other = World.getPlayer(pid);
         if (!other) {
-            player.unsetMapFlag();
+            player.write(new UnsetMapFlag());
             return false;
         }
 
         if (!player.buildArea.players.has(other)) {
-            player.unsetMapFlag();
+            player.write(new UnsetMapFlag());
             return false;
         }
 

--- a/src/lostcity/network/225/incoming/handler/OpPlayerUHandler.ts
+++ b/src/lostcity/network/225/incoming/handler/OpPlayerUHandler.ts
@@ -58,6 +58,7 @@ export default class OpPlayerUHandler extends MessageHandler<OpPlayerU> {
 
         player.setInteraction(Interaction.ENGINE, other, ServerTriggerType.APPLAYERU, { type: item, com: -1 });
         player.opcalled = true;
+        player.opucalled = true;
         return true;
     }
 }

--- a/src/lostcity/network/225/incoming/handler/OpPlayerUHandler.ts
+++ b/src/lostcity/network/225/incoming/handler/OpPlayerUHandler.ts
@@ -20,37 +20,37 @@ export default class OpPlayerUHandler extends MessageHandler<OpPlayerU> {
 
         const com = Component.get(comId);
         if (typeof com === 'undefined' || !player.isComponentVisible(com)) {
-            player.unsetMapFlag();
+            player.write(new UnsetMapFlag());
             return false;
         }
 
         const listener = player.invListeners.find(l => l.com === comId);
         if (!listener) {
-            player.unsetMapFlag();
+            player.write(new UnsetMapFlag());
             return false;
         }
 
         const inv = player.getInventoryFromListener(listener);
         if (!inv || !inv.validSlot(slot) || !inv.hasAt(slot, item)) {
-            player.unsetMapFlag();
+            player.write(new UnsetMapFlag());
             return false;
         }
 
         const other = World.getPlayer(pid);
         if (!other) {
-            player.unsetMapFlag();
+            player.write(new UnsetMapFlag());
             return false;
         }
 
         if (!player.buildArea.players.has(other)) {
-            player.unsetMapFlag();
+            player.write(new UnsetMapFlag());
             return false;
         }
 
         player.clearPendingAction();
         if (ObjType.get(item).members && !Environment.NODE_MEMBERS) {
             player.messageGame("To use this item please login to a members' server.");
-            player.unsetMapFlag();
+            player.write(new UnsetMapFlag());
             return false;
         }
 

--- a/src/lostcity/util/Environment.ts
+++ b/src/lostcity/util/Environment.ts
@@ -1,5 +1,6 @@
 import 'dotenv/config';
 import { tryParseArray, tryParseBoolean, tryParseInt, tryParseString } from './TryParse.js';
+import WalkTriggerSetting from './WalkTriggerSetting.js';
 
 export default {
     // bundler/webrtc browser mode
@@ -35,6 +36,9 @@ export default {
     NODE_CLIENT_ROUTEFINDER: tryParseBoolean(process.env.NODE_CLIENT_ROUTEFINDER, true),
     // controllable for bot testing
     NODE_SOCKET_TIMEOUT: tryParseBoolean(process.env.NODE_SOCKET_TIMEOUT, true),
+    // yellow-x walktriggers in osrs went from: in packet handler -> in player setup -> player movement
+    // 0 = processed in packet handler. 1 = processed in player setup (client input). 2 = processed in player movement
+    NODE_WALKTRIGGER_SETTING: tryParseInt(process.env.NODE_WALKTRIGGER_SETTING, WalkTriggerSetting.PLAYERPACKET),
 
     /// login server
     LOGIN_HOST: tryParseString(process.env.LOGIN_HOST, 'localhost'),

--- a/src/lostcity/util/WalkTriggerSetting.ts
+++ b/src/lostcity/util/WalkTriggerSetting.ts
@@ -1,0 +1,7 @@
+enum WalkTriggerSetting {
+    PLAYERPACKET,
+    PLAYERSETUP,
+    PLAYERMOVEMENT
+}
+
+export default WalkTriggerSetting;


### PR DESCRIPTION
- adds ~playerwalk3 proc
- adds NODE_... setting for where walktrigger is ran in the world cycle. 0 = processed in packet handler. 1 = processed in player setup (client input). 2 = processed in player movement. For setting 0, path is set in the packet handler. For settings 1 & 2, path is set in player setup.
- defaults both path to be set and walktrigger to be processed immediately in the packet handler. In the span of OSRS's lifetime, the location of where walktrigger was processed for yellowx was changed from: packet handler -> client input -> player movement. Videos: [May 4, 2013 OSRS](https://youtu.be/dKfFkEyqD8E?t=9) (before server pathing update), [Oct 17, 2016 OSRS](https://youtu.be/TnBJZD9AcJE) (after server pathing update)
- p_op and p_walk should not set moveClickRequest, and moveClickRequest is reset on login. If a queue is pending, you will not move when placing the cannon, unless moveClickRequest is false. In osrs on login, without moving, you will walk with the cannon just fine. But once you yellowx, your next cannon + queue will prevent movement for the length of the delay.

Cannon + pending queue (notice how I stop moving as soon as I turn on prayers):

https://github.com/user-attachments/assets/9baedf56-d642-4e91-92e7-f69bbf669ad4

https://github.com/user-attachments/assets/2c69dec8-0f87-4cc6-9a6b-5eb65251df34

Cannon + pending queue after logout:

https://github.com/user-attachments/assets/ff1949c1-0120-465e-bd93-d8508c60679e

https://github.com/user-attachments/assets/dbc5cd6d-dc74-4790-8c24-ce011565109e

- set moveClickRequest to false on opheld and opheldu null interactions, to match early osrs bug abuse videos such as: https://youtu.be/GPfN3Isl2rM (smuggles games room effect, which clears on engine queue). This could theoretically work with other items like books (as long as it doesnt clear movement) - todo: find proof of items that work *other than* dueling ring as shown in the linked video.

- only remove the flag on the map for op packet errors. Null obj example:

https://github.com/user-attachments/assets/787c54eb-768b-4a1e-888f-1b23fa82a43b
