### PR TITLE
fix(content): mage arena dialogues

### DIFF
--- a/data/src/scripts/areas/area_mage_arena/scripts/kolodion.rs2
+++ b/data/src/scripts/areas/area_mage_arena/scripts/kolodion.rs2
@@ -9,7 +9,7 @@ if (%magearena < ^mage_arena_started) {
         ~chatnpc("<p,angry>Hah! A wizard of your level? Don't be absurd.");
         return;
     }
-    ~chatnpc("<p,shifty>I am the great Kolodion, master of battle magic, and|this is my battle arena. Top wizards travel from all over|Gielinor to fight here.");
+    ~chatnpc("<p,shifty>I am the great Kolodion, master of battle magic, and|this is my battle arena. Top wizards travel from all over|RuneScape to fight here.");
     @multi3("Can I fight here?", kolodion_can_i_fight_here, "What's the point of that?", kolodion_whats_the_point, "That's barbaric!", kolodion_barbaric);
 }
 if (~mage_arena_in_progress = true) {
@@ -33,7 +33,7 @@ if ($choice = 1) {
     return;
 } else if ($choice = 2) {
     ~chatplayer("<p,quiz>How can I use my new spells outside of the arena?");
-    ~chatnpc("<p,shifty>Experience, my friend, experience. Once you've used|the spell enough times in the arena, you'll be able to use|them in the rest of Gielinor.");
+    ~chatnpc("<p,shifty>Experience, my friend, experience. Once you've used|the spell enough times in the arena, you'll be able to use|them in the rest of RuneScape.");
     ~chatplayer("<p,happy>Good stuff.");
     ~chatnpc("<p,happy>Not so good for the citizens; they won't stand a chance.");
     ~chatplayer("<p,quiz>How am I doing so far?");
@@ -84,10 +84,10 @@ if ($choice = 1) {
 
 [label,kolodion_yes_indeedy]
 ~chatplayer("<p,happy>Yes indeedy.");
-~chatnpc("<p,happy>Good, good. You have a healthy sense of competition.");
-~chatnpc("<p,neutral>Remember, traveller - in my arena, hand-to-hand|combat is useless. Your strength will diminish as you|enter the arena, but the spells you can learn are|amongst the most powerful in all of Gielinor.");
+~chatnpc("<p,happy>Good, good, you have a healthy sense of competition.");
+~chatnpc("<p,neutral>Remember traveller, in my arena hand to hand combat|is useless. Your strength will diminish as you enter the|arena, but the spells you can learn are amongst the most powerful in RuneScape.");
 ~chatnpc("<p,neutral>Before I can accept you in, we must duel.|You may not take armour or weapons into the arena."); // second sentence is rsc
-@multi2("Okay, let's fight.", kolodion_lets_fight, "No thanks.", exit);
+@multi2("Ok, let's fight.", kolodion_lets_fight, "No thanks.", exit);
 
 [label,kolodion_no_i_dont]
 ~chatplayer("<p,angry>No I don't.");
@@ -101,7 +101,7 @@ if (~can_enter_mage_arena = false) {
     return;
 }
 ~chatplayer("<p,happy>You don't need to worry about that.");
-~chatnpc("<p,neutral>Not just any magician can enter - only the most|powerful and most feared. Before you can use the|power of this arena, you must prove yourself against|me.");
+~chatnpc("<p,neutral>Not just any magician can enter, only the most|powerful, the most feared. Before you can use the|power of this arena, you must prove yourself against|me.");
 %magearena = 1;
 
 @kolodion_teleport;

--- a/data/src/scripts/areas/area_mage_arena/scripts/lundail.rs2
+++ b/data/src/scripts/areas/area_mage_arena/scripts/lundail.rs2
@@ -10,7 +10,7 @@ if ($choice = 1) {
 }
 
 ~chatplayer("<p,quiz>What's that big old building above us?");
-~chatnpc("<p,happy>That, my friend, is the mage battle arena. Top mages come from all over Gielinor to compete in the arena.");
+~chatnpc("<p,happy>That, my friend, is the mage battle arena. Top mages come from all over RuneScape to compete in the arena.");
 ~chatplayer("<p,neutral>Wow.");
 ~chatnpc("<p,confused>Few return, most get fried, hence the smell.");
 ~chatplayer("<p,confused>Hmmm.. I did notice.");

--- a/data/src/scripts/engine.rs2
+++ b/data/src/scripts/engine.rs2
@@ -229,7 +229,7 @@
 // Flash a side tab icon
 [command,tut_flash](int $tab)
 // Set a component's model animation
-[command,if_setanim](component $component,seq $anim)
+[command,if_setanim](component $component, seq $anim)
 // Set a side tab to a specific interface
 [command,if_settab](interface $interface, int $tab)
 [command,.if_settab](interface $interface, int $tab)
@@ -767,7 +767,7 @@
 [command,setbit](int $value, int $bit)(int)
 // Return true if a bit is set
 [command,testbit](int $value, int $bit)(boolean)
-// Get the remainder of $n1 / $2
+// Get the remainder of $n1 / $n2
 [command,modulo](int $n1, int $n2)(int)
 // Raise $n1 to the power of $n2
 [command,pow](int $n1, int $n2)(int)


### PR DESCRIPTION
https://youtu.be/mQmeH32PdNk?t=19

This dialogue confirms they are not using "Gielinor" in their dialogue, changed other usages of the word to "RuneScape" off an assumption it is the same.

Also NPC say texts were incorrect compared to the video