### PR TITLE
fix(engine): reset spawn point for following npcs

### DIFF
--- a/src/lostcity/entity/Npc.ts
+++ b/src/lostcity/entity/Npc.ts
@@ -573,12 +573,13 @@ export default class Npc extends PathingEntity {
             this.defaultMode();
             return;
         }
-        if (player.level !== this.level || !CoordGrid.isWithinDistanceSW(this, player, 15)) {
-            this.teleport(player.x, player.z, player.level);
-        }
 
         this.pathToTarget();
         this.updateMovement();
+
+        if (player.level !== this.level || !CoordGrid.isWithinDistanceSW(this, player, 15)) {
+            this.teleport(player.x, player.z, player.level);
+        }
 
         this.startX = this.x;
         this.startZ = this.z;

--- a/src/lostcity/entity/Npc.ts
+++ b/src/lostcity/entity/Npc.ts
@@ -573,10 +573,11 @@ export default class Npc extends PathingEntity {
             this.defaultMode();
             return;
         }
+        this.startX = this.x;
+        this.startZ = this.z;
+        this.startLevel = this.level;
         if (player.level !== this.level || !CoordGrid.isWithinDistanceSW(this, player, 15)) {
             this.teleport(player.x, player.z, player.level);
-            this.startX = player.x;
-            this.startZ = player.z;
         }
 
         this.pathToTarget();

--- a/src/lostcity/entity/Npc.ts
+++ b/src/lostcity/entity/Npc.ts
@@ -573,15 +573,16 @@ export default class Npc extends PathingEntity {
             this.defaultMode();
             return;
         }
-        this.startX = this.x;
-        this.startZ = this.z;
-        this.startLevel = this.level;
         if (player.level !== this.level || !CoordGrid.isWithinDistanceSW(this, player, 15)) {
             this.teleport(player.x, player.z, player.level);
         }
 
         this.pathToTarget();
         this.updateMovement();
+
+        this.startX = this.x;
+        this.startZ = this.z;
+        this.startLevel = this.level;
     }
 
     playerFaceMode(): void {


### PR DESCRIPTION
- reset spawn coords of the npc every tick it follows. No way to confirm this in osrs, but if a following npc switches to attack you, it could get stuck if you're far away from its spawn point. Example of this for us would be the dwarf random event
- also only teleports to player after movement is processed, the old code the following npc could tele and move same tick, which didnt match osrs tests