### PR TITLE
fix(content): typos, level up messages

### DIFF
--- a/data/src/scripts/areas/area_gnome/scripts/gnome_restaurant.rs2
+++ b/data/src/scripts/areas/area_gnome/scripts/gnome_restaurant.rs2
@@ -208,7 +208,7 @@ if (inv_total(inv, toad_crunchies) > 0) {
     ~chatnpc("<p,quiz>If you ever want to make some money or want to improve your cooking skills, just come and see me. I'll tell you what meals I need, and if you can, you make them.");
     ~chatplayer("<p,confused>What about ingredients?");
     ~chatnpc("<p,happy>Well you know where to find toads and worms. You can buy the rest from Hudo Glenfad the grocer.");
-    ~chatnpc("<p,happy>I'll always pay you much more for the meal than you paid for the ingredients, and it's a great way to improve you cooking skills.");
+    ~chatnpc("<p,happy>I'll always pay you much more for the meal than you paid for the ingredients, and it's a great way to improve your cooking skills.");
     // Doesnt seem like he gives gianne dough in this rev
     // https://web.archive.org/web/20051210095941/http://runescape.salmoneus.net/gnome_food.html
     return;
@@ -268,7 +268,7 @@ if ($container_total < 3) {
             $cooking_utensil2 = "gnomebowl mould";
         }
     }
-    $choice = ~p_choice3("Sorry Alufy, I'm too busy.", 1, "I would be glad to help.", 2, "I'm afraid I've lost the <$cooking_utensil> you gave me.", 3);
+    $choice = ~p_choice3("Sorry Aluft, I'm too busy.", 1, "I would be glad to help.", 2, "I'm afraid I've lost the <$cooking_utensil> you gave me.", 3);
     if ($choice = 3) {
         ~chatplayer("<p,sad>I'm afraid I've lost the <$cooking_utensil2> you gave me.");
         if ($crunchy_tray_total < 1) inv_add(inv, crunchy_tray, 1);
@@ -278,10 +278,10 @@ if ($container_total < 3) {
         return;
     }
 } else {
-    $choice = ~p_choice2("Sorry Alufy, I'm too busy.", 1, "I would be glad to help.", 2);
+    $choice = ~p_choice2("Sorry Aluft, I'm too busy.", 1, "I would be glad to help.", 2);
 }
 if ($choice = 1) {
-    ~chatplayer("<p,neutral>Sorry Alufy, I'm too busy.");
+    ~chatplayer("<p,neutral>Sorry Aluft, I'm too busy.");
     ~chatnpc("<p,happy>No worries, let me know when you're free.");
     return;
 }

--- a/data/src/scripts/areas/area_white_wolf_mountain/scripts/mountain_dwarf.rs2
+++ b/data/src/scripts/areas/area_white_wolf_mountain/scripts/mountain_dwarf.rs2
@@ -18,7 +18,7 @@ if($option = 1) {
 }
 
 [label,mountain_dwarf_stairs]
-~chatnpc("<p,angry>Hoi there! halt!");
+~chatnpc("<p,angry>Hoi there! Halt!"); //imgur.com/hTWOobo
 ~chatnpc("<p,angry>You can't come in here!");
 @multi3("Why not?", mountain_dwarf_why, "Oh, sorry, I hadn't realised it was private.", mountain_dwarf_private, "I'm bigger than you. Let me by!", mountain_dwarf_bigger);
 

--- a/data/src/scripts/levelup/configs/levelup_unlocks.enum
+++ b/data/src/scripts/levelup/configs/levelup_unlocks.enum
@@ -281,6 +281,7 @@ val=31
 val=40
 val=41
 val=55
+val=60
 val=70
 val=85
 

--- a/data/src/scripts/levelup/scripts/levelup_unlocks_attack.rs2
+++ b/data/src/scripts/levelup/scripts/levelup_unlocks_attack.rs2
@@ -1,10 +1,10 @@
 [label,levelup_attack]
 //Attack level up unlock messages
 switch_int(stat_base(attack)) {
-    case 5 : ~objbox(steel_longsword,"You can now wield @dbl@Steel Weaponry@bla@!", 250, 0, 0);
-    case 10 : ~objbox(black_longsword,"You can now wield @dbl@Black Weaponry@bla@!", 250, 0, 0);
-    case 20 : ~objbox(mithril_longsword,"You can now wield @dbl@Mithril Weaponry@bla@!", 250, 0, 0);
-    case 30 : ~objbox(adamant_longsword,"You can now wield @dbl@Adamant Weaponry@bla@!", 250, 0, 0);
-    case 40 : ~objbox(rune_longsword,"You can now wield @dbl@Rune Weaponry@bla@!", 250, 0, 0);
-    case 60 : ~objbox(dragon_longsword,"Members can now wield @dbl@Dragon Weaponry@bla@!", 250, 0, 0);
+    case 5 : ~objbox(steel_longsword,"You can now wield @dbl@Steel Weaponry!", 250, 0, 0);
+    case 10 : ~objbox(black_longsword,"You can now wield @dbl@Black Weaponry!", 250, 0, 0);
+    case 20 : ~objbox(mithril_longsword,"You can now wield @dbl@Mithril Weaponry!", 250, 0, 0);
+    case 30 : ~objbox(adamant_longsword,"You can now wield @dbl@Adamant Weaponry!", 250, 0, 0);
+    case 40 : ~objbox(rune_longsword,"You can now wield @dbl@Rune Weaponry!", 250, 0, 0);
+    case 60 : ~objbox(dragon_longsword,"Members can now wield @dbl@Dragon Weaponry!", 250, 0, 0); //imgur.com/VfAYlr7
 }

--- a/data/src/scripts/levelup/scripts/levelup_unlocks_fletching.rs2
+++ b/data/src/scripts/levelup/scripts/levelup_unlocks_fletching.rs2
@@ -1,21 +1,21 @@
 [label,levelup_fletching]
 //Fletching level up unlock messages
 switch_int(stat_base(fletching)) {
-    case 5 : ~objbox(shortbow,"You can now make @dbl@Shortbows@bla@.", 250, 0, 0);
-    case 10 : ~objbox(longbow,"You can now make @dbl@Longbows@bla@.", 250, 0, 0);
-    case 15 : ~objbox(iron_arrow_5,"You can now make @dbl@Iron Arrows@bla@.", 250, 0, 0);
-    case 20 : ~objbox(oak_shortbow,"You can now make @dbl@Oak Shortbows@bla@.", 250, 0, 0);
-    case 25 : ~objbox(oak_longbow,"You can now make @dbl@Oak Longbows@bla@.", 250, 0, 0);
-    case 30 : ~objbox(steel_arrow_5,"You can now make @dbl@Steel Arrows@bla@.", 250, 0, 0);
-    case 35 : ~objbox(willow_shortbow,"You can now make @dbl@Willow Shortbows@bla@.", 250, 0, 0);
-    case 40 : ~objbox(willow_longbow,"You can now make @dbl@Willow Longbows@bla@.", 250, 0, 0);
-    case 45 : ~objbox(mithril_arrow_5,"You can now make @dbl@Mithril Arrows@bla@.", 250, 0, 0);
-    case 50 : ~objbox(maple_shortbow,"You can now make @dbl@Maple Shortbows@bla@.", 250, 0, 0);
-    case 55 : ~objbox(maple_longbow,"You can now make @dbl@Maple Longbows@bla@.", 250, 0, 0);
-    case 60 : ~objbox(adamant_arrow_5,"You can now make @dbl@Adamant Arrows@bla@.", 250, 0, 0);
-    case 65 : ~objbox(yew_shortbow,"You can now make @dbl@Yew Shortbows@bla@.", 250, 0, 0);
-    case 75 : ~objbox(rune_arrow_5,"You can now make @dbl@Rune Arrows@bla@.", 250, 0, 0);
-    case 70 : ~objbox(yew_longbow,"You can now make @dbl@Yew Longbows@bla@.", 250, 0, 0);
-    case 80 : ~objbox(magic_shortbow,"You can now make @dbl@Magic Shortbows@bla@.", 250, 0, 0);
-    case 85 : ~objbox(magic_longbow,"You can now make @dbl@Magic Longbows@bla@.", 250, 0, 0);
+    case 5 : ~objbox(shortbow,"You can now make @dbl@Shortbows.", 250, 0, 0);
+    case 10 : ~objbox(longbow,"You can now make @dbl@Longbows.", 250, 0, 0);
+    case 15 : ~objbox(iron_arrow_5,"You can now make @dbl@Iron Arrows.", 250, 0, 0);
+    case 20 : ~objbox(oak_shortbow,"You can now make @dbl@Oak Shortbows.", 250, 0, 0);
+    case 25 : ~objbox(oak_longbow,"You can now make @dbl@Oak Longbows.", 250, 0, 0);
+    case 30 : ~objbox(steel_arrow_5,"You can now make @dbl@Steel Arrows.", 250, 0, 0);
+    case 35 : ~objbox(willow_shortbow,"You can now make @dbl@Willow Shortbows.", 250, 0, 0);
+    case 40 : ~objbox(willow_longbow,"You can now make @dbl@Willow Longbows.", 250, 0, 0);
+    case 45 : ~objbox(mithril_arrow_5,"You can now make @dbl@Mithril Arrows.", 250, 0, 0);
+    case 50 : ~objbox(maple_shortbow,"You can now make @dbl@Maple Shortbows.", 250, 0, 0);
+    case 55 : ~objbox(maple_longbow,"You can now make @dbl@Maple Longbows.", 250, 0, 0);
+    case 60 : ~objbox(adamant_arrow_5,"You can now make @dbl@Adamant Arrows.", 250, 0, 0);
+    case 65 : ~objbox(yew_shortbow,"You can now make @dbl@Yew Shortbows.", 250, 0, 0);
+    case 75 : ~objbox(rune_arrow_5,"You can now make @dbl@Rune Arrows.", 250, 0, 0);
+    case 70 : ~objbox(yew_longbow,"You can now make @dbl@Yew Longbows.", 250, 0, 0); //imgur.com/3Er8U3m
+    case 80 : ~objbox(magic_shortbow,"You can now make @dbl@Magic Shortbows.", 250, 0, 0);
+    case 85 : ~objbox(magic_longbow,"You can now make @dbl@Magic Longbows.", 250, 0, 0);
 }

--- a/data/src/scripts/levelup/scripts/levelup_unlocks_herblore.rs2
+++ b/data/src/scripts/levelup/scripts/levelup_unlocks_herblore.rs2
@@ -16,7 +16,7 @@ switch_int(stat_base(herblore)) {
     case 50 : ~objbox(3dosefisherspotion,"You can now make @dbl@Fishing Potions@bla@.", 250, 0, ^objbox_height);
     case 54 : ~objbox(kwuarm,"You can now identify @dbl@Kwuarm@bla@.", 250, 0, 0);
     case 55 : ~objbox(3dose2strength,"You can now make @dbl@Super Strength Potions@bla@.", 250, 0, ^objbox_height);
-    case 60 : ~objbox(weapon_poison,"You can now make @dbl@Weapon Poisons@bla@.", 250, 0, ^objbox_height);
+    case 60 : ~objbox(weapon_poison,"You can now make @dbl@Weapon Poisons.", 250, 0, ^objbox_height); //imgur.com/dLoBair
     case 65 : ~objbox(cadantine,"You can now identify @dbl@Cadantine@bla@.", 250, 0, 0);
     case 66 : ~objbox(3dose2defense,"You can now make @dbl@Super Defence Potions@bla@.", 250, 0, ^objbox_height);
     case 67 : ~objbox(lantadyme,"You can now identify @dbl@Lantadyme@bla@.", 250, 0, 0);

--- a/data/src/scripts/levelup/scripts/levelup_unlocks_magic.rs2
+++ b/data/src/scripts/levelup/scripts/levelup_unlocks_magic.rs2
@@ -37,65 +37,11 @@ switch_int(stat_base(magic)) {
     case 62 : ~objbox(battlestaff, "Members can now cast @dbl@Wind Wave@bla@!", 250, 0, 0);
     case 63 : ~objbox(battlestaff, "Members can now @dbl@Charge Fire Orbs@bla@!", 250, 0, 0);
     case 65 : ~objbox(battlestaff, "Members can now cast @dbl@Water Wave@bla@!", 250, 0, 0);
-    case 66 : ~objbox(battlestaff, "Members can now cast @dbl@Vulnerability@bla@ and @dbl@Charge Air|@dbl@Orbs@bla@! Members can also enter the @dbl@Wizard's Guild@bla@.", 250, 0, 0);
+    case 66 : ~objbox(battlestaff, "Members can now cast @dbl@Vulnerability and Charge Air|@dbl@Orbs! Members can also enter the Wizards' Guild!", 250, 0, 0); //imgur.com/Sc4Zok3
     case 68 : ~objbox(battlestaff, "Members can now enchant @dbl@Dragonstone Jewellery@bla@!", 250, 0, 0);
     case 70 : ~objbox(battlestaff, "Members can now cast @dbl@Earth Wave@bla@!", 250, 0, 0);
     case 73 : ~objbox(battlestaff, "Members can now cast @dbl@Enfeeble@bla@!", 250, 0, 0);
     case 75 : ~objbox(battlestaff, "Members can now cast @dbl@Fire Wave@bla@!", 250, 0, 0);
     case 79 : ~objbox(battlestaff, "Members can now cast @dbl@Entangle@bla@!", 250, 0, 0);
     case 80 : ~objbox(battlestaff, "Members can now cast @dbl@Stun@bla@!", 250, 0, 0);
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 }

--- a/data/src/scripts/levelup/scripts/levelup_unlocks_mining.rs2
+++ b/data/src/scripts/levelup/scripts/levelup_unlocks_mining.rs2
@@ -10,6 +10,7 @@ switch_int(stat_base(mining)) {
     case 40 : ~doubleobjbox(gold_ore,red_topaz,"You can now mine @dbl@Gold@bla@. Members can mine @dbl@Gem|@dbl@rocks@bla@.", 150);
     case 41 : ~objbox(rune_pickaxe,"You can now mine with @dbl@Rune Pickaxes.", 250, 0, 0); //imgur.com/UvfRKuk
     case 55 : ~objbox(mithril_ore,"You can now mine @dbl@Mithril.", 250, 0, 0);
+    case 60 : ~objbox(mithril_ore,"You can now enter the world famous @dbl@Mining Guild.", 250, 0, 0); //imgur.com/BPWbfAD
     case 70 : ~objbox(adamantite_ore,"You can now mine @dbl@Adamantite.", 250, 0, 0);
-    case 85 : ~objbox(runite_ore,"You can now mine @dbl@Runite.", 250, 0, 0); //imgur.com/0bQSnX5
+    case 85 : ~objbox(runite_ore,"You can now mine @dbl@Runite.", 250, 0, 0); //imgur.com/jIwPpTa
 }

--- a/data/src/scripts/levelup/scripts/levelup_unlocks_smithing.rs2
+++ b/data/src/scripts/levelup/scripts/levelup_unlocks_smithing.rs2
@@ -54,12 +54,12 @@ switch_int(stat_base(smithing)) {
     case 58 : ~objbox(mithril_sq_shield,"You can now make @dbl@Mithril Square Shields@bla@.", 250, 0, 0);
     case 59 : ~objbox(mithril_warhammer,"You can now make @dbl@Mithril Warhammers@bla@.", 250, 0, 0);
     case 60 : ~objbox(mithril_battleaxe,"You can now make @dbl@Mithril Battleaxes@bla@.", 250, 0, 0);
-    case 61 : ~objbox(mithril_chainbody,"You can now make @dbl@Mithril Chainmail Bodies@bla@.", 250, 0, 0);
-    case 62 : ~objbox(mithril_kiteshield,"You can now make @dbl@Mithril Kite Shields@bla@.", 250, 0, 0);
-    case 64 : ~objbox(mithril_2h_sword,"You can now make @dbl@Mithril Two Handed Swords@bla@.", 250, 0, 0);
+    case 61 : ~objbox(mithril_chainbody,"You can now make @dbl@Mithril Chainmail Bodies.", 250, 0, 0); //imgur.com/J7orCyb
+    case 62 : ~objbox(mithril_kiteshield,"You can now make @dbl@Mithril Kite Shields.", 250, 0, 0); //imgur.com/2mwJUWO
+    case 64 : ~objbox(mithril_2h_sword,"You can now make @dbl@Mithril Two Handed Swords.", 250, 0, 0); //imgur.com/qMcRqiu
     case 66 : ~doubleobjbox(mithril_platelegs,mithril_plateskirt,"You can now make @dbl@Mithril Plate Legs@bla@ and @dbl@Mithril plate skirts@bla@.", 150);
     case 68 : ~objbox(mithril_platebody,"You can now make @dbl@Mithril Plate Bodies@bla@.", 250, 0, 0);
-    case 70 : ~objbox(adamant_dagger,"You can now make @dbl@Adamant Daggers@bla@.", 250, 0, 0);
+    case 70 : ~objbox(adamant_dagger,"You can now make @dbl@Adamant Daggers.", 250, 0, 0); //imgur.com/sXJ4fUC
     case 71 : ~objbox(adamant_axe,"You can now make @dbl@Adamant Axes@bla@.", 250, 0, 0);
     case 72 : ~objbox(adamant_mace,"You can now make @dbl@Adamant Maces@bla@.", 250, 0, divide(^objbox_height, 2));
     case 73 : ~objbox(adamant_med_helm,"You can now make @dbl@Adamant Medium Helms@bla@.", 250, 0, divide(^objbox_height, 2));


### PR DESCRIPTION
- Fixed typos in mountain dwarf & gnome chef dialogue
- Added mining guild level up message
- Removed black punctuation from some level up messages
  - Attack & Fletching had black punctuation entirely removed
  - Other skills had blue punctuation added to specific messages with screenshots attached