### PR TITLE
fix(content): Remove erroneous cooking unlock messages

### DIFF
--- a/data/src/scripts/levelup/configs/levelup_unlocks.enum
+++ b/data/src/scripts/levelup/configs/levelup_unlocks.enum
@@ -413,10 +413,7 @@ val=14
 val=15
 val=16
 val=18
-val=19
 val=20
-val=21
-val=24
 val=25
 val=26
 val=27
@@ -425,15 +422,12 @@ val=29
 val=30
 val=32
 val=33
-val=34
 val=35
 val=37
-val=39
 val=40
 val=42
 val=43
 val=45
-val=48
 val=50
 val=53
 val=55
@@ -443,7 +437,6 @@ val=65
 val=80
 val=82
 val=91
-
 
 [levelup_unlocks_firemaking]
 inputtype=autoint

--- a/data/src/scripts/levelup/scripts/levelup_unlocks_cooking.rs2
+++ b/data/src/scripts/levelup/scripts/levelup_unlocks_cooking.rs2
@@ -25,43 +25,13 @@ switch_int(stat_base(cooking)) {
     case 42 : ~objbox(chocolate_bomb,"Members can now cook @dbl@Chocolate Bombs@bla@.", 250, 0, divide(^objbox_height, 2));
     case 43 : ~objbox(bass,"Members can now cook @dbl@Bass@bla@.", 250, 0, 0);
     case 45 : ~doubleobjbox(swordfish,meat_pizza,"You can now cook @dbl@Meat Pizzas@bla@ and @dbl@Swordfish@bla@.", 150);
-    case 48 : ~objbox(cheese,"Members can now churn @dbl@Cheese@bla@.", 250, 0, divide(^objbox_height, 2));
     case 50 : ~objbox(chocolate_cake,"You can now cook @dbl@Chocolate Cakes@bla@.", 250, 0, divide(^objbox_height, 2));
     case 53 : ~objbox(lava_eel,"Members can now cook @dbl@Lava Eel@bla@.", 250, 0, 0);
     case 55 : ~objbox(anchovy_pizza,"You can now cook @dbl@Anchovy Pizza@bla@.", 250, 0, 0);
     case 58 : ~objbox(pitta_bread,"Members can now cook @dbl@Pitta Bread@bla@.", 250, 0, 0);
     case 60 : ~objbox(curry,"Members can now cook @dbl@Curry@bla@.", 250, 0, divide(^objbox_height, 2));
-    case 65 : ~doubleobjbox(pineapple_pizza,wine_of_zamorak,"Members can now cook @dbl@Pineapple Pizzas@bla@ and make @dbl@Wine|@dbl@of Zamorak@bla@", 150);
+    case 65 : ~objbox(pineapple_pizza,"Members can now cook @dbl@Pineapple Pizza@bla@.", 250, 0, 0);
     case 80 : ~objbox(raw_shark,"Members can now cook @dbl@Shark@bla@.", 250, 0, 0);
     case 82 : ~objbox(raw_sea_turtle,"Members can now cook @dbl@Sea Turtle@bla@.", 250, 0, 0);
     case 91 : ~objbox(raw_manta_ray,"Members can now cook @dbl@Manta Rays@bla@.", 250, 0, 0);
 }
-
-
-
-    
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-    
-
-


### PR DESCRIPTION
- Removed message for cheese churning which wasn't added until October 24th, 2005
- Corrected level 65 unlock message, removing reference to wine of Zamorak fermenting which wasn't added until May 20th, 2013
- Removed a few unused levels from the .enum

Used this video as a reference for the new 65 unlock message: https://youtu.be/YayjtGk5JBg?t=112