### PR TITLE
fix(content): Oziach should give spare key to maze during quest if lost

### DIFF
--- a/data/src/scripts/areas/area_edgeville/scripts/oziach.rs2
+++ b/data/src/scripts/areas/area_edgeville/scripts/oziach.rs2
@@ -118,11 +118,11 @@ if ($choice = 0) {
 [label,oziach_first_piece]
 ~chatplayer("<p,quiz>Where is the first piece of the map?");
 ~chatnpc("<p,neutral>Deep in a strange building known as Melzar's maze|located north west of Rimmington.");
-if (%dragon_progress < ^quest_dragon_maze_key) {
+// tipit forum post from 2006 mentioning talk/drop trick working for this. source: https://forum.tip.it/topic/42769-melzars-maze-key/
+if (inv_total(inv, maze_key) = 0 & inv_total(bank, maze_key) = 0) {
     ~chatnpc("<p,neutral>You will need this to get in|this is the key to the front entrance to the maze.");
     inv_add(inv, maze_key, 1);
     ~objbox(maze_key, "Oziach hands you a key.", 250, 0, divide(^objbox_height, 2));
-    %dragon_progress = ^quest_dragon_maze_key;
 }
 @multi4("Where can I get an antidragon shield?", oziach_dragon_shield, "Where is the second piece of the map?", oziach_second_piece, "Where is the third piece of the map?", oziach_third_piece, "Ok I'll try and get everything together.", oziach_farewell);
 

--- a/data/src/scripts/quests/quest_dragon/configs/quest_dragon.constant
+++ b/data/src/scripts/quests/quest_dragon/configs/quest_dragon.constant
@@ -1,8 +1,7 @@
 ^quest_dragon_not_started = 0
 ^quest_dragon_spoken_to_guildmaster = 1
 ^quest_dragon_spoken_to_oziach = 2
-^quest_dragon_maze_key = 3
-^quest_dragon_bought_ship = 4
+^quest_dragon_bought_ship = 3
 ^quest_dragon_repaired_ship = 7
 ^quest_dragon_ned_given_map = 8
 ^quest_dragon_sailed_to_crandor = 9


### PR DESCRIPTION
References:
- https://forum.tip.it/topic/75433-melzars-maze-not-an-option/ 
- https://forum.tip.it/topic/42769-melzars-maze-key/

While RSC Dragon Slayer had you trade other players or buy a new key from Legends Guild, with RS2, Maze key can not be traded - locking f2p out if key is lost.
This also seems to line up with known varp values for Dragon Slayer in OSRS (even though the quest was reworked in 2007): https://chisel.weirdgloop.org/varbs/display?varplayer=176

I ran a test on local server by setting dragon_progress varp to 1 and talking to Oziach, trying to do the drop trick. I found nothing obvious that had broken as result of this, but a review is appreciated in any case.