### PR TITLE
feat(engine): last logged in ip address & number of days

### DIFF
--- a/data/src/scripts/login_logout/login.rs2
+++ b/data/src/scripts/login_logout/login.rs2
@@ -16,10 +16,10 @@ softtimer(stat_replenish, 100);
 softtimer(health_replenish, 100);
 // random event timer
 settimer(general_macro_events, 500);
-// chest macro gas 
+// chest macro gas
 ~check_chest_macro_gas;
 // for logout out during a general macro event, they respawn when you log back in
-// queue: 
+// queue:
 // - https://youtu.be/T0ulsgorBkY?list=PLn23LiLYLb1Y3P9S9qZbijcJihiD416jT
 // - https://youtu.be/HwGAzcmvF9k?list=PLn23LiLYLb1Y3P9S9qZbijcJihiD416jT
 // npc spawns only after interface is closed

--- a/src/engine/World.ts
+++ b/src/engine/World.ts
@@ -1622,14 +1622,14 @@ class World {
                 return;
             }
 
-            const { username, lowMemory, reconnecting, staffmodlevel, muted_until } = msg;
+            const { username, password, lowMemory, reconnecting, staffmodlevel, muted_until } = msg;
 
             let save = new Uint8Array();
             if (reply === 0 || reply === 2) {
                 save = msg.save;
             }
 
-            const player = PlayerLoading.load(username, new Packet(save), client);
+            const player = PlayerLoading.load(username, password, new Packet(save), client);
             player.reconnecting = reconnecting;
             player.staffModLevel = staffmodlevel;
             player.lowMemory = lowMemory;

--- a/src/engine/entity/NetworkPlayer.ts
+++ b/src/engine/entity/NetworkPlayer.ts
@@ -50,8 +50,8 @@ export class NetworkPlayer extends Player {
     opcalled: boolean = false;
     opucalled: boolean = false;
 
-    constructor(username: string, username37: bigint, client: ClientSocket) {
-        super(username, username37);
+    constructor(username: string, username37: bigint, password: string | null, client: ClientSocket) {
+        super(username, username37, password);
 
         this.client = client;
         this.client.player = this;

--- a/src/network/rs225/client/handler/ClientCheatHandler.ts
+++ b/src/network/rs225/client/handler/ClientCheatHandler.ts
@@ -61,13 +61,13 @@ export default class ClientCheatHandler extends MessageHandler<ClientCheat> {
             } else if (cmd === 'bots') {
                 player.messageGame('Adding bots');
                 for (let i = 0; i < 1999; i++) {
-                    const bot: Player = PlayerLoading.load(`bot${i}`, new Packet(new Uint8Array()), new NullClientSocket());
+                    const bot: Player = PlayerLoading.load(`bot${i}`, null, new Packet(new Uint8Array()), new NullClientSocket());
                     World.addPlayer(bot);
                 }
             } else if (cmd === 'lightbots') {
                 player.messageGame('Adding lightweight bots');
                 for (let i = 0; i < 1999; i++) {
-                    const bot: Player = PlayerLoading.load(`bot${i}`, new Packet(new Uint8Array()), null);
+                    const bot: Player = PlayerLoading.load(`bot${i}`, null, new Packet(new Uint8Array()), null);
                     World.addPlayer(bot);
                 }
             } else if (cmd === 'teleall') {

--- a/src/server/ClientSocket.ts
+++ b/src/server/ClientSocket.ts
@@ -6,8 +6,10 @@ import Packet from '#/io/Packet.js';
 import { NetworkPlayer } from '#/engine/entity/NetworkPlayer.js';
 
 export default abstract class ClientSocket {
+    public static readonly NO_ADDRESS: string = 'unknown';
+
     uuid = randomUUID();
-    remoteAddress = 'unknown';
+    remoteAddress = ClientSocket.NO_ADDRESS;
     totalBytesRead = 0;
     totalBytesWritten = 0;
 

--- a/src/server/login/LoginThread.ts
+++ b/src/server/login/LoginThread.ts
@@ -58,6 +58,7 @@ async function handleRequests(parentPort: ParentPort, msg: any) {
                     type: 'player_login',
                     socket,
                     username,
+                    password,
                     lowMemory,
                     reconnecting,
                     ...await client.playerLogin(username, password, uid)
@@ -75,6 +76,7 @@ async function handleRequests(parentPort: ParentPort, msg: any) {
                         type: 'player_login',
                         socket,
                         username,
+                        password,
                         lowMemory,
                         reconnecting,
                         reply: 4,
@@ -86,6 +88,7 @@ async function handleRequests(parentPort: ParentPort, msg: any) {
                         type: 'player_login',
                         socket,
                         username,
+                        password,
                         lowMemory,
                         reconnecting,
                         reply: 0,

--- a/src/util/Crypto.ts
+++ b/src/util/Crypto.ts
@@ -1,0 +1,25 @@
+import crypto from 'crypto';
+
+export function encrypt(value: string, passphrase: string): Uint8Array | null {
+    try {
+        const iv = crypto.randomBytes(16);
+        const key = crypto.createHash('sha256').update(passphrase).digest();
+        const cipher = crypto.createCipheriv('aes-256-cbc', key, iv);
+        return new Uint8Array(Buffer.concat([iv, Buffer.concat([cipher.update(value), cipher.final()])]));
+    } catch (err) {
+        console.error(err);
+    }
+    return null;
+}
+
+export function decrypt(bytes: Uint8Array, passphrase: string): string | null {
+    try {
+        const iv = bytes.subarray(0, 16);
+        const key = crypto.createHash('sha256').update(passphrase).digest();
+        const cipher = crypto.createDecipheriv('aes-256-cbc', key, iv);
+        return Buffer.concat([cipher.update(bytes.subarray(16)), cipher.final()]).toString();
+    } catch (err) {
+        console.error(err);
+    }
+    return null;
+}


### PR DESCRIPTION
## Current State
The welcome screen interface displays some details about your account when you login. Currently, this always shows that you "last logged in today" and your "current" ip address that is connected through the client. It never actually counts the number of days you actually last logged in. As well as never showing the actual last ip address that was used.
![image](https://github.com/user-attachments/assets/cbc900f5-1312-4527-b5d1-958557035e5e)

## The problem
Adding this feature technically requires 2004scape to collect ip addresses of players and save them into their saves. The reason they have to be saved is because 2004scape would have to provide to the player what the last ip address was, which means saving that state for a future purpose. I personally don't care, but it is PII and I'm sure others would care. 

## This solution
The best solution I could think of was to use the players own password as the key for encrypting and decrypting their own ip address. The only drawback is storing the password in memory for it to be used by the ciphering functions. So the password exists in memory of the server until the player is no longer online in the world.

If a players password was changed, it would fail the decryption one time for the next login only, resulting in the welcome screen not showing for that login. This is actually because it gets defaulted to `0` when sent to the client, and the client checks if it's not `0` to open the interface.

## Examples
![image](https://github.com/user-attachments/assets/444eac71-e8c1-46e3-aac2-a2d36448549b)

![image](https://github.com/user-attachments/assets/a1cfaf10-77a2-446f-aeef-8fed221ef5b8)

![image](https://github.com/user-attachments/assets/cc0b20ee-a600-415f-aeb0-9f368a872bda)
