### PR TITLE
fix(engine): exactmove not updating local player position on the client

### DIFF
--- a/src/engine/entity/Player.ts
+++ b/src/engine/entity/Player.ts
@@ -1,7 +1,7 @@
 import 'dotenv/config';
 
 import Packet from '#/io/Packet.js';
-import {fromBase37, toDisplayName} from '#/util/JString.js';
+import {toDisplayName} from '#/util/JString.js';
 
 import FontType from '#/cache/config/FontType.js';
 import Component from '#/cache/config/Component.js';
@@ -1634,6 +1634,7 @@ export default class Player extends PathingEntity {
         this.z = endZ;
         this.lastStepX = this.x - 1;
         this.lastStepZ = this.z;
+        this.tele = true;
     }
 
     setTab(com: number, tab: number) {


### PR DESCRIPTION
## Current State
When you perform an `exactmove`, the server is updated properly to know what your new position is on the world, but the client is never actually updated. The only thing the client receives is that you performed an `exactmove` but not that you actually moved positions or anything (walk, run, teleport).

https://github.com/user-attachments/assets/06c9eee6-6a73-4282-9f42-9b37050d288c

I believe there is some sort of client logic difference between the "local player" and the "array of players" when it's updating player positions and etc on the client side. Local player bits uses this property:
![image](https://github.com/user-attachments/assets/65864003-acfe-4fe2-bbb4-c4692cf7dbaf)

While update blocks use this array of players:
![image](https://github.com/user-attachments/assets/11da0397-84ae-4894-8e0c-850d97fa1b35)

From what I gather, the reason of the desync in general is because the offset from you to the other player is based on your position and the client thinks you're at than what you're actually on on the server. In this video, I would only be off by 1 tile south.

## Solution
By doing `this.tele = true;` when `exactmove` is called, this allows this block of code to execute:
![image](https://github.com/user-attachments/assets/d8b0674f-c869-43e3-b462-d9b47d23815c)

Where this sets a walk/run direction to the player which is then called in the `player_info` packet to tell the client to change the player position of the `localPlayer`.

https://github.com/user-attachments/assets/6144dff8-1efa-4516-a3fe-c34de8324eb2