### PR TITLE
fix(content): Mark counters at giants as a usable table

### DIFF
--- a/data/src/scripts/_unpack/all.loc
+++ b/data/src/scripts/_unpack/all.loc
@@ -13425,13 +13425,6 @@ active=yes
 op1=Open
 forceapproach=north
 
-[loc_2791]
-name=Counter
-desc=A counter made from a stone block.
-model=model_loc_2791
-width=2
-active=yes
-
 [loc_2792]
 name=Counter
 desc=A counter made from a stone block.

--- a/data/src/scripts/general_use/configs/tables.loc
+++ b/data/src/scripts/general_use/configs/tables.loc
@@ -297,3 +297,11 @@ retex1d=wood2
 retex2s=elfwood
 retex2d=wood2
 category=usable_table
+
+[loc_2791]
+name=Counter
+desc=A counter made from a stone block.
+model=model_loc_2791
+width=2
+active=yes
+category=usable_table


### PR DESCRIPTION
Before: "Nothing interesting happens." when attempting to place item on it.

How it looks with items on the counters:
![image](https://github.com/user-attachments/assets/b54718ad-1210-4e40-8d0c-c7d83d2f5ed3)
![image](https://github.com/user-attachments/assets/6b642fef-b780-4ed2-9552-40ac7b9a5b3c)

On OSRS, the counters at giants also allow to place items on them.