### PR TITLE
fix(engine): Change delay behaviour to match osrs

### DIFF
--- a/src/engine/entity/Npc.ts
+++ b/src/engine/entity/Npc.ts
@@ -339,11 +339,11 @@ export default class Npc extends PathingEntity {
     processQueue() {
         for (let request = this.queue.head(); request !== null; request = this.queue.next()) {
             // purposely only decrements the delay when the npc is not delayed
-            if (!this.delayed()) {
+            if (!this.delayed) {
                 request.delay--;
             }
 
-            if (!this.delayed() && request.delay <= 0) {
+            if (!this.delayed && request.delay <= 0) {
                 request.unlink();
 
                 const state = ScriptRunner.init(request.script, this, null, request.args);
@@ -608,7 +608,7 @@ export default class Npc extends PathingEntity {
     }
 
     aiMode(): void {
-        if (this.delayed() || !this.target) {
+        if (this.delayed || !this.target) {
             this.defaultMode();
             return;
         }
@@ -618,7 +618,7 @@ export default class Npc extends PathingEntity {
             return;
         }
 
-        if (this.target instanceof Npc && (typeof World.getNpc(this.target.nid) === 'undefined' || this.target.delayed())) {
+        if (this.target instanceof Npc && (typeof World.getNpc(this.target.nid) === 'undefined' || this.target.delayed)) {
             this.defaultMode();
             return;
         }

--- a/src/engine/entity/PathingEntity.ts
+++ b/src/engine/entity/PathingEntity.ts
@@ -72,7 +72,8 @@ export default abstract class PathingEntity extends Entity {
     walktrigger: number = -1;
     walktriggerArg: number = 0; // used for npcs
 
-    delay: number = -1;
+    delayed: boolean = false;
+    delayedUntil: number = -1;
     interacted: boolean = false;
     repathed: boolean = false;
     target: Entity | null = null;
@@ -571,10 +572,6 @@ export default abstract class PathingEntity extends Entity {
         this.targetZ = -1;
         this.apRange = 10;
         this.apRangeCalled = false;
-    }
-
-    delayed() {
-        return this.delay > 0;
     }
 
     protected getCollisionStrategy(): CollisionType | null {

--- a/src/engine/entity/Player.ts
+++ b/src/engine/entity/Player.ts
@@ -496,7 +496,7 @@ export default class Player extends PathingEntity {
         if (!moved || this.stepsTaken === 0) {
             return;
         }
-        if (!this.delayed() && this.moveSpeed === MoveSpeed.RUN && this.stepsTaken > 1) {
+        if (!this.delayed && this.moveSpeed === MoveSpeed.RUN && this.stepsTaken > 1) {
             const weightKg = Math.floor(this.runweight / 1000);
             const clampWeight = Math.min(Math.max(weightKg, 0), 64);
             const loss = (67 + (67 * clampWeight) / 64) | 0;
@@ -505,7 +505,7 @@ export default class Player extends PathingEntity {
     }
 
     private recoverEnergy(moved: boolean): void {
-        if (!this.delayed() && (!moved || this.moveSpeed !== MoveSpeed.RUN) && this.runenergy < 10000) {
+        if (!this.delayed && (!moved || this.moveSpeed !== MoveSpeed.RUN) && this.runenergy < 10000) {
             const recovered = (this.baseLevels[PlayerStat.AGILITY] / 9 | 0) + 8;
             this.runenergy = Math.min(this.runenergy + recovered, 10000);
         }
@@ -536,7 +536,7 @@ export default class Player extends PathingEntity {
     closeModal() {
         this.weakQueue.clear();
 
-        if (!this.delayed()) {
+        if (!this.delayed) {
             this.protect = false;
         }
 
@@ -581,7 +581,7 @@ export default class Player extends PathingEntity {
     }
 
     busy() {
-        return this.delayed() || this.containsModalInterface();
+        return this.delayed || this.containsModalInterface();
     }
 
     canAccess() {
@@ -780,7 +780,7 @@ export default class Player extends PathingEntity {
     // we process walktriggers from regular movement in client input, 
     // and for each interaction.
     processWalktrigger() {
-        if (this.walktrigger !== -1 && (!this.protect && !this.delayed())) {
+        if (this.walktrigger !== -1 && (!this.protect && !this.delayed)) {
             const trigger = ScriptProvider.get(this.walktrigger);
             this.walktrigger = -1;
             if (trigger) {
@@ -802,7 +802,7 @@ export default class Player extends PathingEntity {
             return;
         }
 
-        if (this.target instanceof Npc && (typeof World.getNpc(this.target.nid) === 'undefined' || this.target.delayed())) {
+        if (this.target instanceof Npc && (typeof World.getNpc(this.target.nid) === 'undefined' || this.target.delayed)) {
             this.clearInteraction();
             this.unsetMapFlag();
             return;
@@ -1708,7 +1708,7 @@ export default class Player extends PathingEntity {
     // ----
 
     runScript(script: ScriptState, protect: boolean = false, force: boolean = false) {
-        if (!force && protect && (this.protect || this.delayed())) {
+        if (!force && protect && (this.protect || this.delayed)) {
             // can't get protected access, bye-bye
             // printDebug('No protected access:', script.script.name, protect, this.protect);
             return -1;

--- a/src/engine/script/handlers/NpcOps.ts
+++ b/src/engine/script/handlers/NpcOps.ts
@@ -98,7 +98,8 @@ const NpcOps: CommandHandlers = {
     }),
 
     [ScriptOpcode.NPC_DELAY]: checkedHandler(ActiveNpc, state => {
-        state.activeNpc.delay = check(state.popInt(), NumberNotNull) + 1;
+        state.activeNpc.delayed = true;
+        state.activeNpc.delayedUntil = World.currentTick + 1 + check(state.popInt(), NumberNotNull);
         state.execution = ScriptState.NPC_SUSPENDED;
     }),
 
@@ -484,10 +485,11 @@ const NpcOps: CommandHandlers = {
             return;
         }
         // If npc moved 1 tick ago, delay for 1 tick. If npc moved this tick, delay for 2 ticks
+        state.activeNpc.delayed = true;
         if (state.activeNpc.lastMovement === World.currentTick - 1) {
-            state.activeNpc.delay = 1;
+            state.activeNpc.delayedUntil = World.currentTick + 1;
         } else {
-            state.activeNpc.delay = 2;
+            state.activeNpc.delayedUntil = World.currentTick + 2;
         }
         
         state.execution = ScriptState.NPC_SUSPENDED;

--- a/src/engine/script/handlers/PlayerOps.ts
+++ b/src/engine/script/handlers/PlayerOps.ts
@@ -326,7 +326,8 @@ const PlayerOps: CommandHandlers = {
             return;
         }
 
-        state.activePlayer.delay = 1;
+        state.activePlayer.delayed = true;
+        state.activePlayer.delayedUntil = World.currentTick + 1;
         state.execution = ScriptState.SUSPENDED;
     }),
 
@@ -338,7 +339,8 @@ const PlayerOps: CommandHandlers = {
     // https://x.com/JagexAsh/status/1684478874703343616
     // https://x.com/JagexAsh/status/1780932943038345562
     [ScriptOpcode.P_DELAY]: checkedHandler(ProtectedActivePlayer, state => {
-        state.activePlayer.delay = check(state.popInt(), NumberNotNull) + 1;
+        state.activePlayer.delayed = true;
+        state.activePlayer.delayedUntil = World.currentTick + 1 + check(state.popInt(), NumberNotNull);
         state.execution = ScriptState.SUSPENDED;
     }),
 

--- a/src/network/rs225/client/handler/InvButtonDHandler.ts
+++ b/src/network/rs225/client/handler/InvButtonDHandler.ts
@@ -28,7 +28,7 @@ export default class InvButtonDHandler extends MessageHandler<InvButtonD> {
             return false;
         }
 
-        if (player.delayed()) {
+        if (player.delayed) {
             // do nothing; revert the client visual
             player.write(new UpdateInvPartial(comId, inv, slot, targetSlot));
             return false;

--- a/src/network/rs225/client/handler/InvButtonHandler.ts
+++ b/src/network/rs225/client/handler/InvButtonHandler.ts
@@ -31,7 +31,7 @@ export default class InvButtonHandler extends MessageHandler<InvButton> {
             return false;
         }
 
-        if (player.delayed()) {
+        if (player.delayed) {
             return false;
         }
 

--- a/src/network/rs225/client/handler/MoveClickHandler.ts
+++ b/src/network/rs225/client/handler/MoveClickHandler.ts
@@ -9,7 +9,7 @@ import WalkTriggerSetting from '#/util/WalkTriggerSetting.js';
 
 export default class MoveClickHandler extends MessageHandler<MoveClick> {
     handle(message: MoveClick, player: NetworkPlayer): boolean {
-        if (player.delayed()) {
+        if (player.delayed) {
             player.write(new UnsetMapFlag());
             return false;
         }

--- a/src/network/rs225/client/handler/OpHeldHandler.ts
+++ b/src/network/rs225/client/handler/OpHeldHandler.ts
@@ -33,7 +33,7 @@ export default class OpHeldHandler extends MessageHandler<OpHeld> {
             return false;
         }
 
-        if (player.delayed()) {
+        if (player.delayed) {
             return false;
         }
 

--- a/src/network/rs225/client/handler/OpHeldTHandler.ts
+++ b/src/network/rs225/client/handler/OpHeldTHandler.ts
@@ -33,7 +33,7 @@ export default class OpHeldTHandler extends MessageHandler<OpHeldT> {
             return false;
         }
 
-        if (player.delayed()) {
+        if (player.delayed) {
             return false;
         }
 

--- a/src/network/rs225/client/handler/OpHeldUHandler.ts
+++ b/src/network/rs225/client/handler/OpHeldUHandler.ts
@@ -13,7 +13,7 @@ import LoggerEventType from '#/server/logger/LoggerEventType.js';
 export default class OpHeldUHandler extends MessageHandler<OpHeldU> {
     handle(message: OpHeldU, player: Player): boolean {
         const { obj: item, slot, component: comId, useObj: useItem, useSlot, useComponent: useComId } = message;
-        if (player.delayed()) {
+        if (player.delayed) {
             return false;
         }
 

--- a/src/network/rs225/client/handler/OpLocHandler.ts
+++ b/src/network/rs225/client/handler/OpLocHandler.ts
@@ -11,7 +11,7 @@ export default class OpLocHandler extends MessageHandler<OpLoc> {
     handle(message: OpLoc, player: NetworkPlayer): boolean {
         const { x, z, loc: locId } = message;
 
-        if (player.delayed()) {
+        if (player.delayed) {
             player.write(new UnsetMapFlag());
             return false;
         }

--- a/src/network/rs225/client/handler/OpLocTHandler.ts
+++ b/src/network/rs225/client/handler/OpLocTHandler.ts
@@ -11,7 +11,7 @@ export default class OpLocTHandler extends MessageHandler<OpLocT> {
     handle(message: OpLocT, player: NetworkPlayer): boolean {
         const { x, z, loc: locId, spellComponent: spellComId } = message;
 
-        if (player.delayed()) {
+        if (player.delayed) {
             player.write(new UnsetMapFlag());
             return false;
         }

--- a/src/network/rs225/client/handler/OpLocUHandler.ts
+++ b/src/network/rs225/client/handler/OpLocUHandler.ts
@@ -13,7 +13,7 @@ export default class OpLocUHandler extends MessageHandler<OpLocU> {
     handle(message: OpLocU, player: NetworkPlayer): boolean {
         const { x, z, loc: locId, useObj: item, useSlot: slot, useComponent: comId } = message;
 
-        if (player.delayed()) {
+        if (player.delayed) {
             player.write(new UnsetMapFlag());
             return false;
         }

--- a/src/network/rs225/client/handler/OpNpcHandler.ts
+++ b/src/network/rs225/client/handler/OpNpcHandler.ts
@@ -11,13 +11,13 @@ export default class OpNpcHandler extends MessageHandler<OpNpc> {
     handle(message: OpNpc, player: NetworkPlayer): boolean {
         const { nid } = message;
 
-        if (player.delayed()) {
+        if (player.delayed) {
             player.write(new UnsetMapFlag());
             return false;
         }
 
         const npc = World.getNpc(nid);
-        if (!npc || npc.delayed()) {
+        if (!npc || npc.delayed) {
             player.write(new UnsetMapFlag());
             return false;
         }

--- a/src/network/rs225/client/handler/OpNpcTHandler.ts
+++ b/src/network/rs225/client/handler/OpNpcTHandler.ts
@@ -11,7 +11,7 @@ export default class OpNpcTHandler extends MessageHandler<OpNpcT> {
     handle(message: OpNpcT, player: NetworkPlayer): boolean {
         const { nid, spellComponent: spellComId } = message;
 
-        if (player.delayed()) {
+        if (player.delayed) {
             player.write(new UnsetMapFlag());
             return false;
         }
@@ -23,7 +23,7 @@ export default class OpNpcTHandler extends MessageHandler<OpNpcT> {
         }
 
         const npc = World.getNpc(nid);
-        if (!npc || npc.delayed()) {
+        if (!npc || npc.delayed) {
             player.write(new UnsetMapFlag());
             return false;
         }

--- a/src/network/rs225/client/handler/OpNpcUHandler.ts
+++ b/src/network/rs225/client/handler/OpNpcUHandler.ts
@@ -13,7 +13,7 @@ export default class OpNpcUHandler extends MessageHandler<OpNpcU> {
     handle(message: OpNpcU, player: NetworkPlayer): boolean {
         const { nid, useObj: item, useSlot: slot, useComponent: comId } = message;
 
-        if (player.delayed()) {
+        if (player.delayed) {
             player.write(new UnsetMapFlag());
             return false;
         }
@@ -37,7 +37,7 @@ export default class OpNpcUHandler extends MessageHandler<OpNpcU> {
         }
 
         const npc = World.getNpc(nid);
-        if (!npc || npc.delayed()) {
+        if (!npc || npc.delayed) {
             player.write(new UnsetMapFlag());
             return false;
         }

--- a/src/network/rs225/client/handler/OpObjHandler.ts
+++ b/src/network/rs225/client/handler/OpObjHandler.ts
@@ -11,7 +11,7 @@ export default class OpObjHandler extends MessageHandler<OpObj> {
     handle(message: OpObj, player: NetworkPlayer): boolean {
         const { x, z, obj: objId } = message;
 
-        if (player.delayed()) {
+        if (player.delayed) {
             player.write(new UnsetMapFlag());
             return false;
         }

--- a/src/network/rs225/client/handler/OpObjTHandler.ts
+++ b/src/network/rs225/client/handler/OpObjTHandler.ts
@@ -11,7 +11,7 @@ export default class OpObjTHandler extends MessageHandler<OpObjT> {
     handle(message: OpObjT, player: NetworkPlayer): boolean {
         const { x, z, obj: objId, spellComponent: spellComId } = message;
 
-        if (player.delayed()) {
+        if (player.delayed) {
             player.write(new UnsetMapFlag());
             return false;
         }

--- a/src/network/rs225/client/handler/OpObjUHandler.ts
+++ b/src/network/rs225/client/handler/OpObjUHandler.ts
@@ -13,7 +13,7 @@ export default class OpObjUHandler extends MessageHandler<OpObjU> {
     handle(message: OpObjU, player: NetworkPlayer): boolean {
         const { x, z, obj: objId, useObj: item, useSlot: slot, useComponent: comId } = message;
 
-        if (player.delayed()) {
+        if (player.delayed) {
             player.write(new UnsetMapFlag());
             return false;
         }

--- a/src/network/rs225/client/handler/OpPlayerHandler.ts
+++ b/src/network/rs225/client/handler/OpPlayerHandler.ts
@@ -10,7 +10,7 @@ export default class OpPlayerHandler extends MessageHandler<OpPlayer> {
     handle(message: OpPlayer, player: NetworkPlayer): boolean {
         const { pid } = message;
 
-        if (player.delayed()) {
+        if (player.delayed) {
             player.write(new UnsetMapFlag());
             return false;
         }

--- a/src/network/rs225/client/handler/OpPlayerTHandler.ts
+++ b/src/network/rs225/client/handler/OpPlayerTHandler.ts
@@ -11,7 +11,7 @@ export default class OpPlayerTHandler extends MessageHandler<OpPlayerT> {
     handle(message: OpPlayerT, player: NetworkPlayer): boolean {
         const { pid, spellComponent: spellComId } = message;
 
-        if (player.delayed()) {
+        if (player.delayed) {
             player.write(new UnsetMapFlag());
             return false;
         }

--- a/src/network/rs225/client/handler/OpPlayerUHandler.ts
+++ b/src/network/rs225/client/handler/OpPlayerUHandler.ts
@@ -13,7 +13,7 @@ export default class OpPlayerUHandler extends MessageHandler<OpPlayerU> {
     handle(message: OpPlayerU, player: NetworkPlayer): boolean {
         const { pid, useObj: item, useSlot: slot, useComponent: comId } = message;
 
-        if (player.delayed()) {
+        if (player.delayed) {
             player.write(new UnsetMapFlag());
             return false;
         }


### PR DESCRIPTION
Changes:
- Move delay logic back to the beginning of player processing, like in osrs. There are no sources showing different behaviour from osrs.
- Make delay duration the same no matter at what point in the tick it was started. This is motivated by p_arrivedelay, which delays a full tick both from packet processing (spade digging) and interaction.

In practice this means that you can no longer start a new action on the last tick of a delay. For example, previously you could smelt and cook 1t faster than expected due to this.

Delay durations are not changed by this, except in edge cases. For example, p_delay/npc_delay started from world processing are probably 1t longer now. I could only find one such case in rashiliyia.rs2.