### PR TITLE
fix(engine): Change strong queue behaviour to match early osrs

### DIFF
--- a/src/engine/entity/Player.ts
+++ b/src/engine/entity/Player.ts
@@ -632,10 +632,6 @@ export default class Player extends PathingEntity {
         // - thank you De0 for the explanation
         // essentially, if a script is before the end of the list, it can be processed this tick and result in inconsistent queue timing (authentic)
         for (let request = this.queue.head(); request !== null; request = this.queue.next()) {
-            if (request.type === PlayerQueueType.STRONG) {
-                this.closeModal();
-            }
-
             if (this.tryLogout && request.type === PlayerQueueType.LONG) {
                 if (request.args[0] === 0) {
                     // ^accelerate


### PR DESCRIPTION
Jagex reworked the queue fairly recently (2021?), this is one of the things they changed. Revert to the old behaviour.