### PR TITLE
fix(engine): clear multiple stat_advance engine queues of one skill type

### DIFF
--- a/src/engine/entity/Player.ts
+++ b/src/engine/entity/Player.ts
@@ -608,6 +608,28 @@ export default class Player extends PathingEntity {
         }
     }
 
+    unlinkQueuedScript(scriptId: number, type: QueueType = PlayerQueueType.NORMAL) {
+        if (type === PlayerQueueType.ENGINE) {
+            for (let request = this.engineQueue.head(); request !== null; request = this.engineQueue.next()) {
+                if (request.script.id === scriptId) {
+                    request.unlink();
+                }
+            }
+        } else {
+            for (let request = this.queue.head(); request !== null; request = this.queue.next()) {
+                if (request.script.id === scriptId) {
+                    request.unlink();
+                }
+            }
+            for (let request = this.weakQueue.head(); request !== null; request = this.weakQueue.next()) {
+                if (request.script.id === scriptId) {
+                    request.unlink();
+                }
+            }
+        }
+        
+    }
+
     processQueues() {
         // the presence of a strong script closes modals before anything runs regardless of the order
         let hasStrong: boolean = false;
@@ -1489,6 +1511,7 @@ export default class Player extends PathingEntity {
 
             const script = ScriptProvider.getByTriggerSpecific(ServerTriggerType.ADVANCESTAT, stat, -1);
             if (script) {
+                this.unlinkQueuedScript(script.id, PlayerQueueType.ENGINE);
                 this.enqueueScript(script, PlayerQueueType.ENGINE);
             }
         }

--- a/src/engine/script/handlers/PlayerOps.ts
+++ b/src/engine/script/handlers/PlayerOps.ts
@@ -650,7 +650,7 @@ const PlayerOps: CommandHandlers = {
         state.activePlayer.write(new IfSetPosition(com, x, y));
     }),
 
-    [ScriptOpcode.STAT_ADVANCE]: checkedHandler(ProtectedActivePlayer, state => {
+    [ScriptOpcode.STAT_ADVANCE]: checkedHandler(ActivePlayer, state => {
         const [stat, xp] = state.popInts(2);
 
         check(stat, NumberNotNull);
@@ -943,17 +943,7 @@ const PlayerOps: CommandHandlers = {
     // https://x.com/JagexAsh/status/1821831590906859683
     [ScriptOpcode.CLEARQUEUE]: state => {
         const scriptId = state.popInt();
-
-        for (let request = state.activePlayer.queue.head(); request !== null; request = state.activePlayer.queue.next()) {
-            if (request.script.id === scriptId) {
-                request.unlink();
-            }
-        }
-        for (let request = state.activePlayer.weakQueue.head(); request !== null; request = state.activePlayer.weakQueue.next()) {
-            if (request.script.id === scriptId) {
-                request.unlink();
-            }
-        }
+        state.activePlayer.unlinkQueuedScript(scriptId);
     },
 
     [ScriptOpcode.HEALENERGY]: state => {


### PR DESCRIPTION
in osrs, only the last level of a stat level up is shown per skill.

https://github.com/user-attachments/assets/a852d881-b5cb-4c82-8893-e0bafe80286b

