### PR TITLE
fix(content): fix typo, improve quest stage setting, also fix quest-related black knight aggression

### DIFF
--- a/data/src/scripts/areas/area_falador/scripts/sir_amik_varze.rs2
+++ b/data/src/scripts/areas/area_falador/scripts/sir_amik_varze.rs2
@@ -61,7 +61,7 @@ if (%blackknight_progress = 1) {
     ~chatnpc("<p,quiz>How's the mission going?");
     ~chatplayer("<p,neutral>I haven't managed to find what the secret weapon is yet.");
 } else if (%blackknight_progress = 2) {
-    ~chatnpc("<p,quiz>How' the mission going?");
+    ~chatnpc("<p,quiz>How's the mission going?");
     ~chatplayer("<p,neutral>I've found out what the Black Knight's secret weapon is. It's a potion of invincibility.");
     ~chatnpc("<p,sad>That is bad news.|If you can sabotage it somehow, you will be paid well.");
 } else if (%blackknight_progress = 3) {

--- a/data/src/scripts/quests/quest_blackknight/scripts/quest_blackknight.rs2
+++ b/data/src/scripts/quests/quest_blackknight/scripts/quest_blackknight.rs2
@@ -21,9 +21,9 @@ if ($is_outside = true & ((inv_getobj(worn, ^wearpos_hat) ! bronze_med_helm) | (
 [oploc1,blackknight_door_to_grill]
 def_boolean $is_outside = ~check_axis(coord, loc_coord, loc_angle);
 if ($is_outside = false) {
-    def_boolean $has_spoken = false;
-    $has_spoken = ~set_black_knight_aggro(1_47_54_17_55, $has_spoken);
-    ~set_black_knight_aggro(1_47_54_15_55, $has_spoken);
+    // black knights guarding the ladder down to the grill will aggress the player
+    ~set_black_knight_aggro(1_47_54_17_55);
+    ~set_black_knight_aggro(1_47_54_15_55);
 }
 ~open_and_close_door(loc_param(next_loc_stage), $is_outside, false);
 
@@ -53,7 +53,6 @@ if ($option = 1) {
 } else if ($option = 2) {
    ~chatplayer("<p,neutral>Oh sorry.");
    ~chatnpc("<p,angry>Don't let it happen again.");
-   // todo: Set all black knights in the banquet hall to attack player and yell "Die intruder!"
 } else if ($option = 3) {
     ~chatplayer("<p,neutral>So who does it belong to?");
     ~chatnpc("<p,angry>This fortress belongs to the order of Black Knights known as the Kinshra.");
@@ -89,11 +88,10 @@ if ($option = 1) {
 } else {
    ~chatplayer("<p,neutral>I don't care. I'm going in anyway.");
    ~open_and_close_door(loc_param(next_loc_stage), $is_inside, false);
-   // todo: Set all black knights in the banquet hall to attack player and yell "Die intruder!"
-   def_boolean $has_spoken = false;
-   $has_spoken =  ~set_black_knight_aggro(0_47_54_13_59, $has_spoken);
-   ~set_black_knight_aggro(0_47_54_21_59, $has_spoken);
-   ~set_black_knight_aggro(0_47_54_22_55, $has_spoken);
+   // black knights in the banquet hall will aggress the player
+   ~set_black_knight_aggro(0_47_54_13_59);
+   ~set_black_knight_aggro(0_47_54_21_59);
+   ~set_black_knight_aggro(0_47_54_22_55);
 }
 [oploc1,blackknight_potion_room_door]
 mes("It's locked.");
@@ -118,8 +116,11 @@ if (%blackknight_progress = 2) {
     p_delay(2);
     mes("You hear the witch groan in dismay.");
     p_delay(2);
-    ~chatplayer("<p,quiz>Right I think that's successfully sabotaged the secret weapon.");
+    // initially we did not update quest stage unless the player clicked here to
+    // continue on the chatplayer, but a few people got tripped up by that
+    // now we are updating quest stage first so it cannot be interrupted
     ~update_blackknight_progress;
+    ~chatplayer("<p,quiz>Right I think that's successfully sabotaged the secret weapon.");
 } else {
     ~chatplayer("<p,confused>Why would I want to do that?");
 }
@@ -153,14 +154,11 @@ if (%blackknight_progress = 1) {
     mes("I can't hear much right now.");
 }
 
-[proc,set_black_knight_aggro](coord $coord, boolean $has_spoken)(boolean)
+[proc,set_black_knight_aggro](coord $coord)(boolean)
 npc_findallzone($coord);
 while (npc_findnext = true) {
     if (npc_type = black_knight_aggre) {
-        if ($has_spoken = false) {
-            npc_say("Die intruder!");
-            $has_spoken = true;
-        }
+        npc_say("Die intruder!");
         npc_setmode(opplayer2);
     }
 }

--- a/data/src/scripts/quests/quest_blackknight/scripts/quest_blackknight.rs2
+++ b/data/src/scripts/quests/quest_blackknight/scripts/quest_blackknight.rs2
@@ -154,7 +154,7 @@ if (%blackknight_progress = 1) {
     mes("I can't hear much right now.");
 }
 
-[proc,set_black_knight_aggro](coord $coord)(boolean)
+[proc,set_black_knight_aggro](coord $coord)
 npc_findallzone($coord);
 while (npc_findnext = true) {
     if (npc_type = black_knight_aggre) {
@@ -162,7 +162,6 @@ while (npc_findnext = true) {
         npc_setmode(opplayer2);
     }
 }
-return($has_spoken);
 
 [proc,update_blackknight_progress]
 %blackknight_progress = calc(%blackknight_progress + 1);


### PR DESCRIPTION
Sorry for the double PR, I had to quickly relearn `git remote` and branch from the correct place.

This closes #1058 with the added bonus that I _think_ I have fixed black knight overhead text/aggression correctly (tested both areas several times and saw no issues with removing the `$has_spoken` stuff).