### PR TITLE
fix(engine): in packets failed accounting towards queue limit

### DIFF
--- a/src/engine/entity/NetworkPlayer.ts
+++ b/src/engine/entity/NetworkPlayer.ts
@@ -133,16 +133,15 @@ export class NetworkPlayer extends Player {
 
         if (decoder) {
             const message = decoder.decode(NetworkPlayer.inBuf, this.client.waiting);
-
-            // todo: move out of model
-            if (message.category === ClientProtCategory.USER_EVENT) {
-                this.userLimit++;
-            } else if (message.category === ClientProtCategory.CLIENT_EVENT) {
-                this.clientLimit++;
+            const success: boolean = ClientProtRepository.getHandler(packetType)?.handle(message, this) ?? false;
+            if (success) {
+                // todo: move out of model
+                if (message.category === ClientProtCategory.USER_EVENT) {
+                    this.userLimit++;
+                } else if (message.category === ClientProtCategory.CLIENT_EVENT) {
+                    this.clientLimit++;
+                }
             }
-
-            const handler = ClientProtRepository.getHandler(packetType)!;
-            handler.handle(message, this);
         }
 
         this.client.opcode = -1;

--- a/src/engine/entity/NetworkPlayer.ts
+++ b/src/engine/entity/NetworkPlayer.ts
@@ -134,13 +134,11 @@ export class NetworkPlayer extends Player {
         if (decoder) {
             const message = decoder.decode(NetworkPlayer.inBuf, this.client.waiting);
             const success: boolean = ClientProtRepository.getHandler(packetType)?.handle(message, this) ?? false;
-            if (success) {
-                // todo: move out of model
-                if (message.category === ClientProtCategory.USER_EVENT) {
-                    this.userLimit++;
-                } else if (message.category === ClientProtCategory.CLIENT_EVENT) {
-                    this.clientLimit++;
-                }
+            // todo: move out of model
+            if (success && message.category === ClientProtCategory.USER_EVENT) {
+                this.userLimit++;
+            } else {
+                this.clientLimit++;
             }
         }
 


### PR DESCRIPTION
For example, the current logic, makes you not able to spam click to pickup items on the floor, because your "queue" essentially gets filled with handles to objs that no longer exist.

Now it will only count towards the limiter when they are successfully handled.

![idk 216](https://github.com/user-attachments/assets/b1d299e8-a5f9-4f49-b10f-3abe8df95f3c)
