### PR TITLE
fix(content): Remove hammer drop from goblins

### DIFF
--- a/data/src/scripts/drop tables/scripts/goblin.rs2
+++ b/data/src/scripts/drop tables/scripts/goblin.rs2
@@ -18,7 +18,7 @@ obj_add(npc_coord, npc_param(death_drop), 1, ^lootdrop_duration);
 
 def_int $dropint = random(128);
 
-// todo: may need to redo this table, and/or add bronze_javelin (check old fan sites)
+// may need to redo this table, and/or add bronze_javelin (check old fan sites)
 // That appears to only be fore the goblin_armed_red and _green
 // https://oldschool.runescape.wiki/w/Goblin_(Goblin_Village)
 if ($dropint < 1) {
@@ -53,7 +53,7 @@ if ($dropint < 1) {
     obj_add(npc_coord, goblin_mail, 1, ^lootdrop_duration);
 } else if ($dropint < 45) {
     obj_add(npc_coord, waterrune, 6, ^lootdrop_duration);
-} else if ($dropint < 88) {
+} else if ($dropint < 63) {
     obj_add(npc_coord, coins, 5, ^lootdrop_duration);
 }
 

--- a/data/src/scripts/drop tables/scripts/goblin.rs2
+++ b/data/src/scripts/drop tables/scripts/goblin.rs2
@@ -19,6 +19,8 @@ obj_add(npc_coord, npc_param(death_drop), 1, ^lootdrop_duration);
 def_int $dropint = random(128);
 
 // todo: may need to redo this table, and/or add bronze_javelin (check old fan sites)
+// That appears to only be fore the goblin_armed_red and _green
+// https://oldschool.runescape.wiki/w/Goblin_(Goblin_Village)
 if ($dropint < 1) {
     obj_add(npc_coord, coins, 1, ^lootdrop_duration);
 } else if ($dropint < 2) {
@@ -51,8 +53,6 @@ if ($dropint < 1) {
     obj_add(npc_coord, goblin_mail, 1, ^lootdrop_duration);
 } else if ($dropint < 45) {
     obj_add(npc_coord, waterrune, 6, ^lootdrop_duration);
-} else if ($dropint < 60) {
-    obj_add(npc_coord, hammer, 1, ^lootdrop_duration);
 } else if ($dropint < 88) {
     obj_add(npc_coord, coins, 5, ^lootdrop_duration);
 }


### PR DESCRIPTION
https://oldschool.runescape.wiki/w/Goblin
> 18 February 2016
> (update | poll)
> Hammers are now dropped by goblins. 

https://oldschool.runescape.wiki/w/Poll:Quality_of_Life_-_Top_10_PvM_Suggestions
> Should a hammer drop be added to the drop table of goblins? This would make it easier to get into the Bandos Godwars room if > you have forgotten a hammer.