### PR TITLE
feat(content): Implement Siegfried Erkle 

### DIFF
--- a/data/src/scripts/areas/area_ardougne_east/scripts/siegfried_erkle.rs2
+++ b/data/src/scripts/areas/area_ardougne_east/scripts/siegfried_erkle.rs2
@@ -1,0 +1,12 @@
+[opnpc1,siegfried_erkle]
+~chatnpc("<p,sad>Hello there and welcome to the shop of useful items. Can I help you at all?");
+def_int $option = ~p_choice2("Yes please. What are you selling?", 1, "No thanks." , 2);
+if ($option = 1){
+    ~chatplayer("<p,neutral>Yes please. What are you selling?");
+    ~chatnpc("<p,sad>Take a look.");
+    ~openshop_activenpc;
+}
+else if($option = 2){
+    ~chatplayer("<p,neutral>No thanks.");
+    ~chatnpc("<p,sad>Ok, well, if you change your mind, do pop back.");
+}


### PR DESCRIPTION
# Changes
- Connect Legends' Guild Shop of Useful Items
- Implement Siegdried Erkle

# Sources
Later sources show right-click trade but our cache does not have it so it was added later.
- https://runescape.wiki/w/Siegfried_Erkle
- https://oldschool.runescape.wiki/w/Siegfried_Erkle
- https://classic.runescape.wiki/w/Siegfried_Erkle

> Strangely, whenever you talk to him, he appears to be sad instead of happy. This is likely a glitch.

RSC has Siegdried Erkle tell you off if you have not completed legend's guild but others do not. For now I have not implemented that restriction