### PR TITLE
feat(content): implement oomlie bird drop

### DIFF
--- a/data/src/scripts/drop tables/oomlie_bird.rs2
+++ b/data/src/scripts/drop tables/oomlie_bird.rs2
@@ -1,0 +1,10 @@
+[ai_queue3,oomlie_bird]
+gosub(npc_death);
+if (npc_findhero = false) {
+    return;
+}
+// Default drop from config.
+obj_add(npc_coord, npc_param(death_drop), 1, ^lootdrop_duration);
+
+// Normal drop
+obj_add(npc_coord, raw_oomlie, 1, ^lootdrop_duration);


### PR DESCRIPTION
# Changes
- Implement Oomlie bird raw meat drop as always

# Sources
- https://runescape.wiki/w/Oomlie_bird
- https://oldschool.runescape.wiki/w/Oomlie_bird
- https://classic.runescape.wiki/w/Oomlie_Bird


Also tried cooking it. RS3/OSRS talk about burning it if you try and cook without a leaf but in 2004 it appears that you just could not cook it. What we are doing right now is authentic. You can use a palm leaf and wrap the meat then cook it.

[historic source](https://runescape.wiki/w/Raw_oomlie?direction=next&oldid=1417322)

<!-- #Outside of scope ->