### PR TITLE
fix(content): add queen's guard to ice_warrior droptable

### DIFF
--- a/data/src/pack/npc.pack
+++ b/data/src/pack/npc.pack
@@ -143,7 +143,7 @@
 142=npc_142
 143=npc_143
 144=npc_144
-145=ice_warrior_icequeen
+145=ice_warrior_royal_guard
 146=npc_146
 147=npc_147
 148=npc_148

--- a/data/src/pack/npc.pack
+++ b/data/src/pack/npc.pack
@@ -143,7 +143,7 @@
 142=npc_142
 143=npc_143
 144=npc_144
-145=npc_145
+145=ice_warrior_icequeen
 146=npc_146
 147=npc_147
 148=npc_148

--- a/data/src/scripts/_unpack/all.npc
+++ b/data/src/scripts/_unpack/all.npc
@@ -3966,7 +3966,7 @@ huntrange=2
 // osrs stats and Vislvl match 1:1
 // https://raw.githubusercontent.com/Joshua-F/osrs-dumps/refs/heads/master/config/dump.npc npc_3027
 
-[npc_145]
+[ice_warrior_icequeen]
 hasalpha=yes
 walkanim=earthwarrior_walk
 readyanim=earthwarrior_ready

--- a/data/src/scripts/_unpack/all.npc
+++ b/data/src/scripts/_unpack/all.npc
@@ -3533,6 +3533,7 @@ param=defend_sound,ice_warrior_hit
 param=death_sound,ice_warrior_death
 huntmode=cowardly
 huntrange=1
+category=ice_warrior
 // Stats match osrs version but our version Vislvl is different.
 // https://raw.githubusercontent.com/Joshua-F/osrs-dumps/refs/heads/master/config/dump.npc npc_2841
 
@@ -3966,7 +3967,7 @@ huntrange=2
 // osrs stats and Vislvl match 1:1
 // https://raw.githubusercontent.com/Joshua-F/osrs-dumps/refs/heads/master/config/dump.npc npc_3027
 
-[ice_warrior_icequeen]
+[ice_warrior_royal_guard]
 hasalpha=yes
 walkanim=earthwarrior_walk
 readyanim=earthwarrior_ready
@@ -4014,6 +4015,7 @@ param=defend_sound,ice_warrior_hit
 param=death_sound,ice_warrior_death
 huntmode=cowardly
 huntrange=1
+category=ice_warrior
 // Stats match osrs version but our version Vislvl is different.
 // https://raw.githubusercontent.com/Joshua-F/osrs-dumps/refs/heads/master/config/dump.npc npc_2851
 

--- a/data/src/scripts/drop tables/scripts/ice_warrior.rs2
+++ b/data/src/scripts/drop tables/scripts/ice_warrior.rs2
@@ -1,7 +1,4 @@
-[ai_queue3,ice_warrior] @ice_warrior_drop_table;
-[ai_queue3,ice_warrior_icequeen] @ice_warrior_drop_table;
-
-[label,ice_warrior_drop_table]
+[ai_queue3,_ice_warrior]
 gosub(npc_death);
 if (npc_findhero = false) {
     return;

--- a/data/src/scripts/drop tables/scripts/ice_warrior.rs2
+++ b/data/src/scripts/drop tables/scripts/ice_warrior.rs2
@@ -1,4 +1,6 @@
 [ai_queue3,ice_warrior]
+[ai_queue3,ice_warrior_icequeen]
+
 gosub(npc_death);
 if (npc_findhero = false) {
     return;

--- a/data/src/scripts/drop tables/scripts/ice_warrior.rs2
+++ b/data/src/scripts/drop tables/scripts/ice_warrior.rs2
@@ -1,6 +1,7 @@
-[ai_queue3,ice_warrior]
-[ai_queue3,ice_warrior_icequeen]
+[ai_queue3,ice_warrior] @ice_warrior_drop_table;
+[ai_queue3,ice_warrior_icequeen] @ice_warrior_drop_table;
 
+[label,ice_warrior_drop_table]
 gosub(npc_death);
 if (npc_findhero = false) {
     return;


### PR DESCRIPTION
I verified this against RSC/OSRS wikis and also checked in-game in OSRS, these warriors should be on the drop table too!