### PR TITLE
fix(content): More accurate potion and gnome food delays

### DIFF
--- a/data/src/scripts/player/configs/consumption/consume.dbtable
+++ b/data/src/scripts/player/configs/consumption/consume.dbtable
@@ -11,6 +11,4 @@ column=consume_message1,string
 column=consume_message2,string
 column=restore_message1,string
 column=restore_message2,string
-column=message_delay1,int
-column=message_delay2,int
-column=end_delay,int
+column=message_delay,int

--- a/data/src/scripts/player/configs/consumption/consume_messages.dbrow
+++ b/data/src/scripts/player/configs/consumption/consume_messages.dbrow
@@ -135,8 +135,7 @@ data=consumable,worm_batta
 data=consumable,toad_batta
 data=consume_message2,It's a bit chewy.
 data=restore_message2,"It's a bit chewy, but it heals some health."
-data=message_delay2,2
-data=end_delay,0
+data=message_delay,2
 
 [premade_cheese_tom_batta_consume_messages]
 table=consume_messages_table
@@ -145,8 +144,7 @@ data=consumable,cheese_tom_batta
 data=consume_message1,You eat the cheese and tomato batta.
 data=consume_message2,It tastes quite good.
 data=restore_message2,It tastes quite good and makes you feel a bit better.
-data=message_delay2,2
-data=end_delay,0
+data=message_delay,2
 
 [batta2_consume_messages]
 table=consume_messages_table
@@ -156,8 +154,7 @@ data=consumable,fruit_batta
 data=consumable,vegetable_batta
 data=consume_message2,It tastes pretty good.
 data=restore_message2,It tastes pretty good and makes you feel a bit better.
-data=message_delay2,2
-data=end_delay,0
+data=message_delay,2
 
 [vodka_consume_messages]
 table=consume_messages_table
@@ -202,8 +199,6 @@ data=consumable,drunk_dragon
 data=consume_message1,"You drink the cocktail. It tastes great,"
 data=consume_message2,although you feel slighlty dizzy.
 data=restore_message2,0
-// data=message_delay2,2
-data=end_delay,0
 
 [cocktail2_consume_messages]
 table=consume_messages_table
@@ -214,8 +209,6 @@ data=consumable,fruit_blast
 data=consume_message1,"You drink the cocktail. It tastes great."
 data=restore_message1,"You drink the cocktail. It tastes great,"
 data=restore_message2,You feel slightly reinvigorated.
-// data=message_delay2,2
-data=end_delay,0
 
 [odd_cocktail_consume_messages]
 table=consume_messages_table
@@ -225,8 +218,6 @@ data=consumable,odd_cocktail3
 data=consumable,odd_cocktail4
 data=consume_message1,You drink the cocktail.
 data=consume_message2,It tastes awful... yuck.
-data=message_delay2,2
-data=end_delay,0
 
 [odd_batta_consume_messages]
 table=consume_messages_table
@@ -234,8 +225,7 @@ data=consumable,odd_batta
 data=consume_message1,You eat the batta.
 data=consume_message2,It tastes awful... yuck.
 data=restore_message2,0
-data=message_delay2,2
-data=end_delay,0
+data=message_delay,2
 
 [odd_gnomebowl_consume_messages]
 table=consume_messages_table
@@ -243,8 +233,7 @@ data=consumable,odd_gnomebowl
 data=consume_message1,You eat the gnomebowl.
 data=consume_message2,It tastes awful... yuck.
 data=restore_message2,0
-data=message_delay2,2
-data=end_delay,0
+data=message_delay,2
 
 [odd_crunchies_consume_messages]
 table=consume_messages_table
@@ -252,8 +241,7 @@ data=consumable,odd_crunchies
 data=consume_message1,You eat the crunchies.
 data=consume_message2,They taste awful... yuck.
 data=restore_message2,0
-data=message_delay2,2
-data=end_delay,0
+data=message_delay,2
 
 // complete guess
 [unfinished_cocktail_consume_messages]
@@ -276,8 +264,6 @@ data=consumable,unfinished_drunk_dragon3
 data=consume_message1,You drink the cocktail. It doesn't taste right...
 data=consume_message2,...you feel slightly dizzy too.
 data=restore_message2,0
-data=message_delay2,2
-data=end_delay,0
 
 // complete guess
 [unfinished_cocktail2_consume_messages]
@@ -288,8 +274,6 @@ data=consumable,unfinished_pineapple_punch2
 data=consumable,unfinished_pineapple_punch3
 data=consume_message1,You drink the cocktail. It doesn't taste right...
 data=restore_message2,0
-data=message_delay2,2
-data=end_delay,0
 
 [lemon_chunks_consume_messages]
 table=consume_messages_table
@@ -349,8 +333,7 @@ data=consumable,worm_crunchies
 data=consumable,premade_worm_crunchies
 data=consume_message1,You eat the worm crunchies. They're somehow both very crunchy and very chewy.
 data=restore_message2,0
-data=message_delay2,2
-data=end_delay,0
+data=message_delay,2
 
 [premade_choc_chip_crunchies_consume_messages]
 table=consume_messages_table
@@ -359,8 +342,7 @@ data=consumable,premade_choc_chip_crunchies
 data=consume_message1,You eat the choc chip crunchies.
 data=consume_message2,They're very tasty.
 data=restore_message2,They're very tasty. They heal some health.
-data=message_delay2,2
-data=end_delay,0
+data=message_delay,2
 
 [premade_spicy_crunchies_consume_messages]
 table=consume_messages_table
@@ -369,8 +351,7 @@ data=consumable,premade_spicy_crunchies
 data=consume_message1,You eat the spicy crunchies.
 data=consume_message2,They taste great.
 data=restore_message2,"They taste great, you feel much better."
-data=message_delay2,2
-data=end_delay,0
+data=message_delay,2
 
 [premade_toad_crunchies_consume_messages]
 table=consume_messages_table
@@ -379,8 +360,7 @@ data=consumable,premade_toad_crunchies
 data=consume_message1,You eat the toad crunchies.
 data=consume_message2,They certainly taste... unique.
 data=restore_message2,They certainly taste... unique. They heal some health.
-data=message_delay2,2
-data=end_delay,0
+data=message_delay,2
 
 [dwellberry_consume_messages]
 table=consume_messages_table
@@ -404,56 +384,64 @@ table=consume_messages_table
 data=consumable,toad_legs
 data=consume_message1,You eat the toad's legs. They're a bit chewy.
 data=restore_message2,0
+// can be combo eaten in osrs
+data=message_delay,2
 
 [equa_toad_legs_consume_messages]
 table=consume_messages_table
 data=consumable,equa_toad_legs
 data=consume_message1,You eat the equa toad's legs. They're a bit chewy.
 data=restore_message2,0
+data=message_delay,2
 
 [spicy_toad_legs_consume_messages]
 table=consume_messages_table
 data=consumable,spicy_toad_legs
 data=consume_message1,You eat the spicy toad's legs. They're a bit chewy.
 data=restore_message2,0
+data=message_delay,2
 
 [seasoned_toad_legs_consume_messages]
 table=consume_messages_table
 data=consumable,seasoned_toad_legs
 data=consume_message1,You eat the seasoned toad's legs. They're a bit chewy.
 data=restore_message2,0
+data=message_delay,2
 
 [spicy_worm_consume_messages]
 table=consume_messages_table
 data=consumable,spicy_worm
 data=consume_message1,You eat the spicy worm. They're a bit chewy.
 data=restore_message2,0
+data=message_delay,2
 
 [king_worm_consume_messages]
 table=consume_messages_table
 data=consumable,king_worm
 data=consume_message1,You eat the king worm. They're a bit chewy.
 data=restore_message2,0
+// can be combo eaten in osrs
+data=message_delay,2
 
 [chocolate_bomb_consume_messages]
 table=consume_messages_table
 data=consumable,chocolate_bomb
 data=consumable,premade_chocolate_bomb
+// https://www.youtube.com/watch?v=pXOm0miJVhY&t=86s
 data=consume_message1,You eat the chocolate bomb.
 data=consume_message2,It tastes great.
 data=restore_message2,It tastes great and makes you feel much better.
-data=message_delay2,2
-data=end_delay,0
+data=message_delay,2
 
 [tangled_toads_legs_consume_messages]
 table=consume_messages_table
 data=consumable,tangled_toads_legs
 data=consumable,premade_tangled_toads_legs
+// https://www.youtube.com/watch?v=pXOm0miJVhY&t=86s
 data=consume_message1,You eat the tangled toads legs.
 data=consume_message2,It tastes... slimy.
 data=restore_message2,"It tastes... slimy, but it heals some health."
-data=message_delay2,2
-data=end_delay,0
+data=message_delay,2
 
 [worm_hole_consume_messages]
 table=consume_messages_table
@@ -462,8 +450,7 @@ data=consumable,premade_worm_hole
 data=consume_message1,You eat the worm hole.
 data=consume_message2,It tastes awful.
 data=restore_message2,"It tastes awful, but it heals little health."
-data=message_delay2,2
-data=end_delay,0
+data=message_delay,2
 
 [veg_ball_consume_messages]
 table=consume_messages_table
@@ -472,8 +459,7 @@ data=consumable,premade_veg_ball
 data=consume_message1,You eat the veg ball.
 data=consume_message2,It tastes quite good.
 data=restore_message2,It tastes quite good and makes you feel a bit better.
-data=message_delay2,2
-data=end_delay,0
+data=message_delay,2
 
 [cooked_wrapped_oomlie_consume_messages]
 table=consume_messages_table
@@ -581,10 +567,9 @@ data=consumable,4dose2strength
 data=consumable,3dose2strength
 data=consumable,2dose2strength
 data=consumable,1dose2strength
-data=consume_message1,You drink some of your strength potion.
-data=message_delay2,2
 // https://youtu.be/Rif_5-90nkI?t=368
-data=end_delay,0
+data=consume_message1,You drink some of your strength potion.
+data=message_delay,1
 
 [attack_potion_consume_messages]
 table=consume_messages_table
@@ -596,9 +581,9 @@ data=consumable,4dose2attack
 data=consumable,3dose2attack
 data=consumable,2dose2attack
 data=consumable,1dose2attack
+// https://youtu.be/Rif_5-90nkI?t=368
 data=consume_message1,You drink some of your attack potion.
-data=message_delay2,2
-data=end_delay,0
+data=message_delay,1
 
 [restore_potion_consume_messages]
 table=consume_messages_table
@@ -607,8 +592,7 @@ data=consumable,3dose1restore
 data=consumable,2dose1restore
 data=consumable,1dose1restore
 data=consume_message1,You drink some of your stat restoration potion.
-data=message_delay2,2
-data=end_delay,0
+data=message_delay,1
 
 [defence_potion_consume_messages]
 table=consume_messages_table
@@ -620,9 +604,9 @@ data=consumable,4dose2defense
 data=consumable,3dose2defense
 data=consumable,2dose2defense
 data=consumable,1dose2defense
+// https://youtu.be/Rif_5-90nkI?t=368
 data=consume_message1,You drink some of your defence potion.
-data=message_delay2,2
-data=end_delay,0
+data=message_delay,1
 
 [prayer_potion_consume_messages]
 table=consume_messages_table
@@ -630,9 +614,9 @@ data=consumable,4doseprayerrestore
 data=consumable,3doseprayerrestore
 data=consumable,2doseprayerrestore
 data=consumable,1doseprayerrestore
+// https://www.youtube.com/watch?v=s5sDZdBzapk&t=151s
 data=consume_message1,You drink some of your restore prayer potion.
-data=message_delay2,2
-data=end_delay,0
+data=message_delay,1
 
 [fishing_potion_consume_messages]
 table=consume_messages_table
@@ -641,8 +625,7 @@ data=consumable,3dosefisherspotion
 data=consumable,2dosefisherspotion
 data=consumable,1dosefisherspotion
 data=consume_message1,You drink some of your fishing potion.
-data=message_delay2,2
-data=end_delay,0
+data=message_delay,1
 
 [ranging_potion_consume_messages]
 table=consume_messages_table
@@ -651,8 +634,7 @@ data=consumable,3doserangerspotion
 data=consumable,2doserangerspotion
 data=consumable,1doserangerspotion
 data=consume_message1,You drink some of your ranging potion.
-data=message_delay2,2
-data=end_delay,0
+data=message_delay,1
 
 [antipoison_potion_consume_messages]
 table=consume_messages_table
@@ -665,8 +647,7 @@ data=consumable,3dose2antipoison
 data=consumable,2dose2antipoison
 data=consumable,1dose2antipoison
 data=consume_message1,You drink some of your antipoison potion.
-data=message_delay2,2
-data=end_delay,0
+data=message_delay,1
 
 [zamorak_potion_consume_messages]
 table=consume_messages_table
@@ -675,8 +656,7 @@ data=consumable,3dosepotionofzamorak
 data=consumable,2dosepotionofzamorak
 data=consumable,1dosepotionofzamorak
 data=consume_message1,You drink some of the foul liquid.
-data=message_delay2,2
-data=end_delay,0
+data=message_delay,1
 
 [antifire_potion_consume_messages]
 table=consume_messages_table
@@ -686,8 +666,7 @@ data=consumable,2dose1antidragon
 data=consumable,1dose1antidragon
 // https://youtu.be/91eqk3Lu_Qw?t=37
 data=consume_message1,You drink some of your dragon potion.
-data=message_delay2,2
-data=end_delay,0
+data=message_delay,1
 
 [unfinished_batta_consume_messages]
 table=consume_messages_table
@@ -705,8 +684,7 @@ data=consumable,unfinished_vegetable_batta1
 data=consume_message1,You eat the batta.
 data=consume_message2,It doesn't taste right...
 data=restore_message2,0
-data=message_delay2,2
-data=end_delay,0
+data=message_delay,2
 
 [unfinished_crunchies_consume_messages]
 table=consume_messages_table
@@ -717,8 +695,7 @@ data=consumable,unfinished_toad_crunchies1
 data=consume_message1,You eat the crunchies.
 data=consume_message2,They don't taste right...
 data=restore_message2,0
-data=message_delay2,2
-data=end_delay,0
+data=message_delay,2
 
 [unfinished_gnomebowl_consume_messages]
 table=consume_messages_table
@@ -730,8 +707,7 @@ data=consumable,unfinished_veg_ball1
 data=consume_message1,You eat the gnomebowl.
 data=consume_message2,It doesn't taste right...
 data=restore_message2,0
-data=message_delay2,2
-data=end_delay,0
+data=message_delay,2
 
 [strange_fruit_consume_messages]
 table=consume_messages_table

--- a/data/src/scripts/player/scripts/consumption/effects/scripts/consume_effects.rs2
+++ b/data/src/scripts/player/scripts/consumption/effects/scripts/consume_effects.rs2
@@ -81,11 +81,6 @@ while ($i < db_getfieldcount($effect_data, consume_table:stat_heal)) {
 ~consume_effect_sound(db_getfield($effect_data, consume_table:consume_sound, 0));
 // display messages
 ~consume_effect_messages($consumable, $hitpoints, $say);
-db_find(consume_messages_table:consumable, $consumable);
-def_dbrow $message_data = db_findnext;
-if ($message_data ! null & db_getfieldcount($message_data, consume_messages_table:end_delay) > 0) {
-    p_delay(db_getfield($message_data, consume_messages_table:end_delay, 0));
-}
 
 [proc,consume_effect_sound](synth $sound)
 if ($sound = null) {
@@ -114,11 +109,6 @@ if ($message_data ! null) {
     if (string_length(db_getfield($message_data, consume_messages_table:restore_message2, 0)) > 0) {
         $restore_message2 = db_getfield($message_data, consume_messages_table:restore_message2, 0);
     }
-    // delay
-    if (db_getfieldcount($message_data, consume_messages_table:message_delay1) > 0) {
-        p_delay(db_getfield($message_data, consume_messages_table:message_delay1, 0));
-    }
-
 }
 
 // if potion then display doses left instead of consume_message2
@@ -131,9 +121,9 @@ if ($consumable ! null & oc_category($consumable) = category_69) {
             mes("You drink the <lowercase(oc_name($consumable))>.");
         }
     }
-    //potions have delay https://youtu.be/PvDSzx7lAfU?t=119
-    if (db_getfieldcount($message_data, consume_messages_table:message_delay2) > 0) {
-        p_delay(db_getfield($message_data, consume_messages_table:message_delay2, 0));
+    // potions have delay: https://www.youtube.com/watch?v=s5sDZdBzapk&t=151s
+    if (db_getfieldcount($message_data, consume_messages_table:message_delay) > 0) {
+        p_delay(db_getfield($message_data, consume_messages_table:message_delay, 0));
     }
     if ($consumable = vial_empty) {
         mes("You have finished your potion.");
@@ -174,8 +164,8 @@ if (compare($restore_message1, "0") ! 0 & $hitpoints < stat(hitpoints) & string_
 // gnome food probably uses this, since karambwans and gnome food are the same in osrs
 // https://oldschool.runescape.wiki/w/Update:Chat_update_and_%27Operate%27
 // https://youtu.be/Z-e_O0O6A50?t=33
-if ($message_data ! null & db_getfieldcount($message_data, consume_messages_table:message_delay2) > 0) {
-    p_delay(db_getfield($message_data, consume_messages_table:message_delay2, 0));
+if ($message_data ! null & db_getfieldcount($message_data, consume_messages_table:message_delay) > 0) {
+    p_delay(db_getfield($message_data, consume_messages_table:message_delay, 0));
 }
 
 if (compare($restore_message2, "0") ! 0 & $hitpoints < stat(hitpoints)) {


### PR DESCRIPTION
All combo eatable gnome food in osrs is assumed to have been 3t delays back then. Source exists for chocolate bomb and tangled toad legs. Cocktails on the other hand act like normal food in osrs, so assume they were back then as well. Couldn't find any sources though.