### PR TITLE
fix(engine): stop relying on player zones to compute shared enclosed zone buffers

### DIFF
--- a/src/engine/World.ts
+++ b/src/engine/World.ts
@@ -946,17 +946,14 @@ class World {
         this.cycleStats[WorldStat.LOGIN] = Date.now() - start;
     }
 
-    // - build list of active zones around players
     // - loc/obj despawn/respawn
     // - compute shared buffer
     private processZones(): void {
         const start: number = Date.now();
         const tick: number = this.currentTick;
         // - loc/obj despawn/respawn
-        this.zonesTracking.get(tick)?.forEach(zone => zone.tick(tick));
-        // - build list of active zones around players
         // - compute shared buffer
-        this.computeSharedEvents();
+        this.zonesTracking.get(tick)?.forEach(zone => zone.tick(tick));
         this.cycleStats[WorldStat.ZONE] = Date.now() - start;
     }
 
@@ -1173,19 +1170,6 @@ class World {
         const inventory: Inventory = Inventory.fromType(inv);
         this.invs.add(inventory);
         return inventory;
-    }
-
-    computeSharedEvents(): void {
-        const zones: Set<number> = new Set();
-        for (const player of this.players) {
-            if (!isClientConnected(player)) {
-                continue;
-            }
-            for (const zone of player.buildArea.loadedZones) {
-                zones.add(zone);
-            }
-        }
-        zones.forEach(zoneIndex => this.gameMap.getZoneIndex(zoneIndex).computeShared());
     }
 
     addNpc(npc: Npc, duration: number, firstSpawn: boolean = true): void {

--- a/src/network/server/codec/ZoneMessageEncoder.ts
+++ b/src/network/server/codec/ZoneMessageEncoder.ts
@@ -6,10 +6,8 @@ import MessageEncoder from '#/network/server/codec/MessageEncoder.js';
 export default abstract class ZoneMessageEncoder<T extends ZoneMessage> extends MessageEncoder<T> {
     abstract prot: ZoneProt;
 
-    enclose(message: T): Uint8Array {
-        const buf: Packet = new Packet(new Uint8Array(1 + this.prot.length));
+    enclose(buf: Packet, message: T): void {
         buf.p1(this.prot.id);
         this.encode(buf, message);
-        return buf.data;
     }
 }


### PR DESCRIPTION
When a player logs in, they do not have any loaded zones yet when enclosed shared zone buffers are computed. Because 2004scape builds a list of zones, based on players loaded zones, for this computation, if there are 0 players nearby, this work is not done. This is only a problem when players login for the 1 tick this happens, logging into these zones, versus running back into them, etc. Because the server wants to send these updates from the zones as shared enclosed updates.

I adjusted the durations to match my login speed accordingly for quickly testing.
I wasn't able to reproduce this with Locs, but there may be some edge case I'm not thinking of. But either way Locs seem unaffected.

This is basically the fix I did.
![image](https://github.com/user-attachments/assets/e46f55ed-b7fc-4402-86f9-4d5341c7823e)

I made `computeShared` slightly better by using a statically allocated Packet to create the block of bytes for the zone to use.

### Before
![idk 217](https://github.com/user-attachments/assets/9bb1da88-2c60-47a3-9469-a7355b9660ba)

### After
![idk 218](https://github.com/user-attachments/assets/ef3a72e1-e634-4548-a647-f2d20022546c)

