### PR TITLE
fix(content): desertrescue fixes

### DIFF
--- a/data/src/scripts/quests/quest_desertrescue/configs/desertrescue.constant
+++ b/data/src/scripts/quests/quest_desertrescue/configs/desertrescue.constant
@@ -38,9 +38,9 @@
 ^desertrescue_gained_tent_access = 11
 ^desertrescue_ana_minecart_barrel = 12
 ^desertrescue_ana_on_lift = 13
-^desertrescue_ana_lift_barrel = 13
-^desertrescue_ana_mining_cart = 14
-^desertrescue_ready_rescue = 15
+^desertrescue_ana_lift_barrel = 14
+^desertrescue_ana_mining_cart = 15
+^desertrescue_ready_rescue = 16
 
 ^desertrescue_prison_coord = 0_51_47_21_26
 ^desertrescue_underground_prison_coord = 0_51_147_24_29

--- a/data/src/scripts/quests/quest_desertrescue/scripts/ana.rs2
+++ b/data/src/scripts/quests/quest_desertrescue/scripts/ana.rs2
@@ -105,8 +105,9 @@ if(~inzone_coord_pair_table(mining_camp_zones, coord) = false) {
 if(inzone(0_51_47_20_23, 0_51_47_23_29, coord) = true) { // if in jail do nothing (OSRS behaviour)
     return;
 }
-inv_del(inv, desertrescue_barrel, 1);
-inv_add(inv, anainabarrel, 1);
+if_close;
+inv_del(inv, anainabarrel, 1);
+inv_add(inv, desertrescue_barrel, 1);
 npc_add(map_findsquare(coord, 1, 1, ^map_findsquare_lineofwalk), ana, 8);
 npc_say("How dare you put me in that barrel you barbarian!");
 mes("Ana's outburst attracts the guards, they come running over.");

--- a/data/src/scripts/quests/quest_desertrescue/scripts/captain_siad.rs2
+++ b/data/src/scripts/quests/quest_desertrescue/scripts/captain_siad.rs2
@@ -150,6 +150,7 @@ if(%desertrescue_progress >= ^desertrescue_given_bedobin_key) {
 [label,siad_weller]
 ~chatplayer("<p,neutral>Well, er... erm, I err....");
 ~chatnpc("<p,angry>Come on, spit it out!|Right that's it! Guards!");
+@siad_sendguards;
 
 [label,siad_noslave]
 ~chatplayer("<p,neutral>Er, no, one of the slaves told me.");
@@ -162,6 +163,9 @@ mes("The Captain goes back to his desk and starts studying.");
 mes("The Captain goes back to his desk and starts studying.");
 
 [label,siad_sendguards]
+if(%desertrescue_progress < ^desertrescue_complete) {
+    return;
+}
 if_close;
 mes("The guards search you!");
 p_delay(1);

--- a/data/src/scripts/quests/quest_desertrescue/scripts/irena.rs2
+++ b/data/src/scripts/quests/quest_desertrescue/scripts/irena.rs2
@@ -62,8 +62,8 @@ if(%desertrescue_progress = ^desertrescue_not_started) {
 [label,irena_daughter]
 ~chatplayer("<p,shifty>Okay Irena, calm down. I'll get your daughter back for you.");
 ~chatnpc("<p,happy>That would be great! That's really very nice of you! She was wearing a red silk scarf when she left.");
-~send_quest_progress(questlist:desertrescue, %desertrescue_progress, ^desertrescue_complete);
 %desertrescue_progress = ^desertrescue_started;
+~send_quest_progress(questlist:desertrescue, %desertrescue_progress, ^desertrescue_complete);
 
 [label,irena_toobusy]
 ~chatplayer("<p,neutral>No, sorry, I'm just too busy!");

--- a/data/src/scripts/quests/quest_desertrescue/scripts/quest_desertrescue.rs2
+++ b/data/src/scripts/quests/quest_desertrescue/scripts/quest_desertrescue.rs2
@@ -423,6 +423,10 @@ if(~wearing_slave_robes = true) {
     npc_say("Hey, you're no slave, where do you think you're going!");
     p_delay(1);
     npc_say("Guards! Guards!");
+    if(%desertrescue_progress = ^desertrescue_complete) {
+        mes("No other guards come to the rescue.");
+        return;
+    }
     ~mercenary_camp_attack;
 }
 
@@ -436,15 +440,15 @@ if(inv_total(worn, slave_shirt) > 0 & inv_total(worn, slave_robe) > 0 & inv_tota
 return (false);
 
 [oploc1,_desertrescue_minecave]
-if(~wearing_slave_robes = false) {
-    // shouldn't ever fail since you can't attack these guards
-    if(npc_find(coord, npc_828, 6, 0) = true | npc_find(coord, npc_829, 6, 0) = true) {
-        ~npc_retaliate(0);
-        ~desertcamp_guard_search;
-    }
-    return;
-}
 if(coordx(coord) < coordx(loc_coord)) {
+    if(~wearing_slave_robes = false) {
+        // shouldn't ever fail since you can't attack these guards
+        if(npc_find(coord, npc_829, 6, 0) = true) {
+            ~npc_retaliate(0);
+            ~desertcamp_guard_search;
+        }
+        return;
+    }
     if(%desertrescue_progress < ^desertrescue_given_pineapple) { 
         mes("Two guards block your way further into the caves.");
         ~chatnpc_specific(nc_name(npc_829), npc_829, "<p,angry>Hey you, move away from there!");
@@ -455,6 +459,14 @@ if(coordx(coord) < coordx(loc_coord)) {
         p_teleport(0_51_147_22_7);
     }
 } else {
+    if(~wearing_slave_robes = false & %desertrescue_progress < ^desertrescue_complete) {
+        // shouldn't ever fail since you can't attack these guards
+        if(npc_find(coord, npc_828, 6, 0) = true | npc_find(coord, npc_829, 6, 0) = true) {
+            ~npc_retaliate(0);
+            ~desertcamp_guard_search;
+        }
+        return;
+    }
     if(inv_total(inv, anainabarrel) > 0) {
         if(npc_find(coord, npc_828, 6, 0) = true | npc_find(coord, npc_829, 6, 0) = true) { // basing off rsc w/osrs delays cause osrs version is not possible
             npc_say("Hey, where d'ya think you're going with that Barrel?");
@@ -493,6 +505,9 @@ if(coordx(coord) < coordx(loc_coord)) {
 ~doubleobjbox(technical_plans, hammer, "The plans look very technical!|But you can see that this item will require|a bronze bar and at least 10 feathers.", 150);
 
 [proc,desertcamp_guard_search]
+if(%desertrescue_progress < ^desertrescue_complete) {
+    return;
+}
 if(inv_total(inv, anainabarrel) > 0) {
     npc_say("Hey, what's in this barrel?");
     p_delay(1);
@@ -778,8 +793,10 @@ if(%desertrescue_progress = ^desertrescue_given_pineapple) %desertrescue_progres
 mes("You succeed!");
 if(loc_coord = ^desertrescue_lower_minecart_coord) {
     p_teleport(0_51_147_55_23);
+    ~mesbox("You appear in a large open room with what looks like lots of miners working away. This is a very rough looking area, the miners look like they're on their last legs.");
 } else {
     p_teleport(0_51_147_38_9);
+    ~mesbox("You appear back in the barrel loading room. A nearby slave looks surprised to see you popping out of the cart.");
 }
 
 [oplocu,loc_2684]


### PR DESCRIPTION
- fix wrong obj deletion when dropping ana
- fix siad not sending guards on a dialogue branch
- prevent guards from being sent after completing quest
- change camp cave entrance blocking after quest to match OSRS
- fix duplicate constant value being used for ana's rescue