### PR TITLE
fix(content): Correct f2p drop from goblin

### DIFF
--- a/data/src/scripts/drop tables/scripts/goblin.rs2
+++ b/data/src/scripts/drop tables/scripts/goblin.rs2
@@ -82,8 +82,8 @@ if ($dropint < 3) {
     if (map_members = true) {
         obj_add(npc_coord, bronze_spear, 1, ^lootdrop_duration);
     } else {
-        // guessing it gets replaced
-        obj_add(npc_coord, hammer, 1, ^lootdrop_duration);
+        // it gets replaced by coins according to OSRS
+        obj_add(npc_coord, coins, 10, ^lootdrop_duration);
     }
 } else if ($dropint < 16) {
     obj_add(npc_coord, bronze_arrow, 7, ^lootdrop_duration);


### PR DESCRIPTION
# Changes
- Fix incorrect drop for goblins in goblin village when playing on F2P Server

# Sources
- https://oldschool.runescape.wiki/w/Goblin
- https://runescape.wiki/w/Goblin

The whole goblin drop table rates may need to be audited.
<!-- #Outside of scope ->