### PR TITLE
fix(content): fire making and woodcutting unlock messages

### DIFF
--- a/data/src/scripts/levelup/scripts/levelup_unlocks_firemaking.rs2
+++ b/data/src/scripts/levelup/scripts/levelup_unlocks_firemaking.rs2
@@ -1,9 +1,9 @@
 [label,levelup_firemaking]
 //firemaking level up unlock messages
 switch_int(stat_base(firemaking)) {
-    case 15 : ~objbox(oak_logs,"You can now burn @dbl@Oak Logs@bla@.", 250, 0, 0);
-    case 30 : ~objbox(willow_logs,"You can now burn @dbl@Willow Logs@bla@.", 250, 0, 0);    
-    case 45 : ~objbox(maple_logs,"You can now burn @dbl@Maple Logs@bla@.", 250, 0, 0);
-    case 60 : ~objbox(yew_logs,"You can now burn @dbl@Yew Logs@bla@.", 250, 0, 0);
-    case 75 : ~objbox(magic_logs,"You can now burn @dbl@Magic Logs@bla@.", 250, 0, 0);
+    case 15 : ~objbox(oak_logs,"You can now burn @dbl@Oak Logs.", 180, 0, divide(^objbox_height, 3));
+    case 30 : ~objbox(willow_logs,"You can now burn @dbl@Willow Logs.", 180, 0, divide(^objbox_height, 3));
+    case 45 : ~objbox(maple_logs,"You can now burn @dbl@Maple Logs.", 180, 0, divide(^objbox_height, 3));
+    case 60 : ~objbox(yew_logs,"You can now burn @dbl@Yew Logs.", 180, 0, divide(^objbox_height, 3));
+    case 75 : ~objbox(magic_logs,"Members can now burn @dbl@Magic Logs.", 180, 0, divide(^objbox_height, 3));
 }

--- a/data/src/scripts/levelup/scripts/levelup_unlocks_woodcutting.rs2
+++ b/data/src/scripts/levelup/scripts/levelup_unlocks_woodcutting.rs2
@@ -6,5 +6,5 @@ switch_int(stat_base(woodcutting)) {
     case 30 : ~objbox(willow_logs,"You can now cut down @dbl@Willow Trees.", 180, 0, divide(^objbox_height, 3));
     case 45 : ~objbox(maple_logs,"You can now cut down @dbl@Maple Trees.", 180, 0, divide(^objbox_height, 3));
     case 60 : ~objbox(yew_logs,"You can now cut down @dbl@Yew Trees.", 180, 0, divide(^objbox_height, 3));
-    case 75 : ~objbox(magic_logs,"You can now cut down @dbl@Magic Trees.", 180, 0, divide(^objbox_height, 3));
+    case 75 : ~objbox(magic_logs,"Members can now cut down @dbl@Magic Trees.", 180, 0, divide(^objbox_height, 3));
 }


### PR DESCRIPTION
- Firemaking unlocks share the same object size and positioning as woodcutting unlocks, as shown by these old screenshots:
![fm_wc](https://github.com/user-attachments/assets/d9240c36-1d94-4826-a4b5-5997c0db492d)
- Removed black punctuation from firemaking unlocks
- "You can now cut down Magic Trees" fixed to "Members can now cut down Magic Trees"
- "You can now burn Magic Logs" fixed to "Members can now burn Magic Logs"