### PR TITLE
fix(content): change ikov bridge logic

### DIFF
--- a/data/src/pack/varp.pack
+++ b/data/src/pack/varp.pack
@@ -25,7 +25,7 @@
 24=music5
 25=music6
 26=ikov_progress
-27=ikov_lever
+27=ikov_dungeon
 28=ikov_icearrowchest_coord
 29=cook_progress
 30=drunkmonk_progress

--- a/data/src/scripts/_test/scripts/cheats/cheat_quest.rs2
+++ b/data/src/scripts/_test/scripts/cheats/cheat_quest.rs2
@@ -196,7 +196,7 @@ if (p_finduid(uid) = true) {
                 %sheepherder_progress = 0;
             case 43 : %zombiequeen_progress = 0;
             case 44 :
-                %ikov_lever = 0;
+                %ikov_dungeon = 0;
                 %ikov_icearrowchest_coord = 0_0_0_0_0;
                 %haunted_lever = 0;
                 %haunted_manor_fountain_poisoned = 0;

--- a/data/src/scripts/quests/quest_desertrescue/scripts/quest_desertrescue.rs2
+++ b/data/src/scripts/quests/quest_desertrescue/scripts/quest_desertrescue.rs2
@@ -866,4 +866,5 @@ p_opnpc(1);
 
 [queue,desertrescue_complete]
 %desertrescue_progress = ^desertrescue_complete;
-~send_quest_complete(questlist:desertrescue, bronze_dart, 250, ^desertrescue_questpoints, "You have completed the\\nTourist Trap Quest!");
+// https://web.archive.org/web/20051025141912im_/http://runeweb.net/rathofdoom/quests/touristtrap/7.png
+~send_quest_complete(questlist:desertrescue, bronze_dart, 200, ^desertrescue_questpoints, "You have completed the\\nTourist Trap Quest!");

--- a/data/src/scripts/quests/quest_ikov/configs/quest_ikov.constant
+++ b/data/src/scripts/quests/quest_ikov/configs/quest_ikov.constant
@@ -9,5 +9,8 @@
 ^ikov_completed_armadyl = 80
 ^ikov_completed_lucien = 90
 
+^ikov_lever = 0
+^ikov_bridge = 1
+
 ^ikovbridge_zone_lower = 0_41_153_24_36
 ^ikovbridge_zone_upper = 0_41_153_26_37

--- a/data/src/scripts/quests/quest_ikov/configs/quest_ikov.varp
+++ b/data/src/scripts/quests/quest_ikov/configs/quest_ikov.varp
@@ -1,7 +1,7 @@
 [ikov_progress]
 scope=perm
 
-[ikov_lever]
+[ikov_dungeon]
 scope=perm
 
 [ikov_icearrowchest_coord]

--- a/data/src/scripts/quests/quest_ikov/scripts/ikov_dungeon.rs2
+++ b/data/src/scripts/quests/quest_ikov/scripts/ikov_dungeon.rs2
@@ -27,26 +27,35 @@ p_exactmove(coord, movecoord(coord, 0, 0, -1), 30, 56, ^exact_north);
 
 [label,open_ikov_southgate](int $side)
 def_boolean $entering = ~check_axis_locactive(coord);
-if($entering = false | %ikov_lever = 1) {
+if($entering = false | testbit(%ikov_dungeon, ^ikov_lever) = true) {
     ~open_and_close_double_door2($entering, $side, grate_open);
     return;
 }
 ~mesbox("The door won't open!");
 
-[mapzoneexit,0_41_153] cleartimer(move_ikovtrigger);
+[mapzoneexit,0_41_153] 
+cleartimer(move_ikovtrigger);
+%ikov_dungeon = clearbit(%ikov_dungeon, ^ikov_bridge);
 
 [timer,move_ikovtrigger]
+// coming from west side is queued and will take 1t longer, coming from east side is not, meaning you can cancel coming from west side
 if(inzone(^ikovbridge_zone_lower, ^ikovbridge_zone_upper, coord) = true) {
-    queue(ikov_movebridge, 0);
+    if(coordx(coord) = coordx(^ikovbridge_zone_lower)) {
+        queue(ikov_movequeue, 0);
+    } else {
+        @ikov_movebridge;
+    }
 }
 
-[queue,ikov_movebridge]
+[queue,ikov_movequeue] @ikov_movebridge;
+
+[label,ikov_movebridge]
 if(inzone(^ikovbridge_zone_lower, ^ikovbridge_zone_upper, coord) = false) {
     return;
 }
-// todo: refactor this without last_coord
-def_coord $last_coord = coord;
-if(coordx($last_coord) <= coordx(movecoord(^ikovbridge_zone_lower, 1, 0, 0))) {
+def_boolean $crossed_bridge = testbit(%ikov_dungeon, ^ikov_bridge);
+%ikov_dungeon = togglebit(%ikov_dungeon, ^ikov_bridge);
+if($crossed_bridge = true) {
     ~forcemove(movecoord(^ikovbridge_zone_lower, 1, 0, abs(calc(coordz(^ikovbridge_zone_lower) - coordz(coord)))));
     if(weight >= 0) {
         @ikov_bridgefail;
@@ -95,7 +104,7 @@ sound_synth(locked, 0, 0);
 p_delay(0);
 sound_synth(locked, 0, 0);
 p_delay(0);
-%ikov_lever = 1;
+%ikov_dungeon = setbit(%ikov_dungeon, ^ikov_lever);
 ~mesbox("You hear the clunking of some hidden machinery.");
 
 [oploc1,loc_103] ~open_chest(loc_104);

--- a/data/src/scripts/quests/quest_ikov/scripts/quest_ikov.rs2
+++ b/data/src/scripts/quests/quest_ikov/scripts/quest_ikov.rs2
@@ -80,7 +80,7 @@ if(p_finduid(uid) = false) {
     return;
 }
 mes("Resetting all varps affected by ikov update");
-%ikov_lever = 0;
+%ikov_dungeon = 0;
 %ikov_icearrowchest_coord = 0_0_0_0_0;
 %haunted_lever = 0;
 %haunted_manor_fountain_poisoned = 0;


### PR DESCRIPTION
Change the ikov bridge to use a varp to determine which side the player is on (this won't be needed for later versions since the middle tiles are blocked off, but we don't know if original behavior was just broken or not), queue when walking from west -> east (matching OSRS behavior)