### PR TITLE
feat(engine): improve the speed of zone entity list capacity checking

### DIFF
--- a/src/engine/zone/Zone.ts
+++ b/src/engine/zone/Zone.ts
@@ -54,9 +54,6 @@ export default class Zone {
     private readonly events: Set<ZoneEvent>;
     private shared: Uint8Array | null = null;
 
-    totalLocs: number = 0;
-    totalObjs: number = 0;
-
     constructor(index: number) {
         this.index = index;
         const coord: CoordGrid = ZoneMap.unpackIndex(index);
@@ -69,6 +66,14 @@ export default class Zone {
         this.locs = new LocList(Zone.LOCS, (loc: Loc) => World.removeLoc(loc, 100));
         this.objs = new ObjList(Zone.OBJS, (obj: Obj) => World.removeObj(obj, 100));
         this.entityEvents = new Map();
+    }
+
+    get totalLocs(): number {
+        return this.locs.count;
+    }
+
+    get totalObjs(): number {
+        return this.objs.count;
     }
 
     enter(entity: PathingEntity): void {
@@ -225,14 +230,12 @@ export default class Zone {
     addStaticLoc(loc: Loc): void {
         const coord: number = CoordGrid.packZoneCoord(loc.x, loc.z);
         this.locs.addLast(coord, loc, true);
-        this.totalLocs++;
         this.locs.sortStack(coord, true);
     }
 
     addStaticObj(obj: Obj): void {
         const coord: number = CoordGrid.packZoneCoord(obj.x, obj.z);
         this.objs.addLast(coord, obj, true);
-        this.totalObjs++;
         this.objs.sortStack(coord, true);
     }
 
@@ -242,7 +245,6 @@ export default class Zone {
         const coord: number = CoordGrid.packZoneCoord(loc.x, loc.z);
         if (loc.lifecycle === EntityLifeCycle.DESPAWN) {
             this.locs.addLast(coord, loc);
-            this.totalLocs++;
         }
 
         this.locs.sortStack(coord);
@@ -254,7 +256,6 @@ export default class Zone {
         const coord: number = CoordGrid.packZoneCoord(loc.x, loc.z);
         if (loc.lifecycle === EntityLifeCycle.DESPAWN) {
             this.locs.remove(coord, loc);
-            this.totalLocs--;
         }
 
         this.locs.sortStack(coord);
@@ -288,7 +289,6 @@ export default class Zone {
         const coord: number = CoordGrid.packZoneCoord(obj.x, obj.z);
         if (obj.lifecycle === EntityLifeCycle.DESPAWN) {
             this.objs.addLast(coord, obj);
-            this.totalObjs++;
         }
 
         this.objs.sortStack(coord);
@@ -330,7 +330,6 @@ export default class Zone {
         const coord: number = CoordGrid.packZoneCoord(obj.x, obj.z);
         if (obj.lifecycle === EntityLifeCycle.DESPAWN) {
             this.objs.remove(coord, obj);
-            this.totalObjs--;
         }
 
         this.objs.sortStack(coord);
@@ -520,7 +519,7 @@ export default class Zone {
             this.entityEvents.set(entity, [event]);
             return;
         }
-        this.entityEvents.set(entity, exist.concat(event));
+        exist.push(event);
     }
 
     /**

--- a/src/engine/zone/ZoneEntityList.ts
+++ b/src/engine/zone/ZoneEntityList.ts
@@ -7,6 +7,8 @@ export default abstract class ZoneEntityList<T> extends Array<T[] | undefined> {
     private readonly capacity: number;
     private readonly onFilled: (item: T) => void;
 
+    count: number = 0;
+
     constructor(capacity: number, onFilled: (item: T) => void) {
         super();
         this.capacity = capacity;
@@ -60,11 +62,13 @@ export default abstract class ZoneEntityList<T> extends Array<T[] | undefined> {
     addLast(coord: number, item: T, unchecked: boolean = false): void {
         this.check(coord, unchecked);
         this[coord]?.push(item);
+        this.count++;
     }
 
     addFirst(coord: number, item: T, unchecked: boolean = false): void {
         this.check(coord, unchecked);
         this[coord]?.unshift(item);
+        this.count++;
     }
 
     sortStack(coord: number, unchecked: boolean = false): void {
@@ -92,6 +96,7 @@ export default abstract class ZoneEntityList<T> extends Array<T[] | undefined> {
             return;
         }
         items.splice(index, 1);
+        this.count--;
     }
 
     contains(coord: number, item: T): boolean {
@@ -107,24 +112,12 @@ export default abstract class ZoneEntityList<T> extends Array<T[] | undefined> {
         if (typeof items === 'undefined') {
             this[coord] = [];
         }
-        if (!unchecked && this.total === this.capacity) {
+        if (!unchecked && this.count === this.capacity) {
             const bottom: T | undefined = this.nextBottomAll();
             if (typeof bottom !== 'undefined') {
                 this.onFilled(bottom);
             }
         }
-    }
-
-    private get total(): number {
-        let total: number = 0;
-        for (let index: number = 0; index < this.length; index++) {
-            const items: T[] | undefined = this[index];
-            if (typeof items === 'undefined') {
-                continue;
-            }
-            total += items.length;
-        }
-        return total;
     }
 }
 


### PR DESCRIPTION
Zones have a hard limit to the number of locs and objs that can be within one. The current implementation is manually counting the number of them in the zone every time an obj or loc is added or removed.

```ts
    private get total(): number {
        let total: number = 0;
        for (let index: number = 0; index < this.length; index++) {
            const items: T[] | undefined = this[index];
            if (typeof items === 'undefined') {
                continue;
            }
            total += items.length;
        }
        return total;
    }
```

Instead of doing this, we just keep track of the amount using `count` and boom 500ms faster.

### Before
![image](https://github.com/user-attachments/assets/062ca9fe-9a85-4e9c-9bca-1aa3bdf8f06e)

### After
![image](https://github.com/user-attachments/assets/cedb974c-f64c-4c81-99ba-1f0c70280c7e)
