### PR TITLE
fix: NPC drops were a little too rare!

### DIFF
--- a/data/src/scripts/areas/area_desert/scripts/desert_heat.rs2
+++ b/data/src/scripts/areas/area_desert/scripts/desert_heat.rs2
@@ -23,8 +23,6 @@ if ($head ! null) {
 
 if ($body ! null) {
     if($body = desert_shirt) {
-        $time = calc($time + 20);
-    } else if($body = slave_shirt) {
         $time = calc($time + 10);
     } else if(oc_category($body) = armour_body) {
         $time = calc($time - 40);
@@ -34,8 +32,6 @@ if ($body ! null) {
 if ($legs ! null) {
     if($legs = desert_robe) {
         $time = calc($time + 20);
-    } else if($legs = slave_robe) {
-        $time = calc($time + 10);
     } else if(oc_category($legs) = armour_legs) {
         $time = calc($time - 30);
     }
@@ -44,8 +40,6 @@ if ($legs ! null) {
 if ($feet ! null) {
     if($feet = desert_boots) {
         $time = calc($time + 10);
-    } else if($feet = slave_boots) {
-        $time = calc($time + 5);
     }// else if(oc_category($feet) = armour_feet) {
      //   $time = calc($time - 10);
     //} no feet armour in 225?
@@ -65,6 +59,7 @@ settimer(desert_heat, $time);
 if(~inzone_coord_pair_table(desert_zones, coord) = false) {
     %desert = ^false;
     cleartimer(desert_heat);
+    mes("Desert effect is now over."); // found in 2004-2005 images
     return;
 }
 

--- a/data/src/scripts/quests/quest_desertrescue/scripts/quest_desertrescue.rs2
+++ b/data/src/scripts/quests/quest_desertrescue/scripts/quest_desertrescue.rs2
@@ -217,6 +217,13 @@ if(coordx(coord) > 3284) {
 if(distance(coord, loc_coord) > 2) {
     ~forcewalk2(0_51_47_18_29);
 }
+// https://web.archive.org/web/20060215230504/http://img.photobucket.com/albums/v72/me9alomaniac/tt1.png
+~mesbox("It looks as if there is a rocky escarpment that|you could climb up here. Would you like to try?");
+def_int $op = ~p_choice2("Yes, I'll give it a try.", 1, "No, I'd better stay here.", 2); // complete guess
+if($op = 2) {
+    mes("You decide not to climb the rocks."); // complete guess
+    return;
+}
 @desertrescue_climb_to_rocks;
 
 [aploc2,loc_2695] @desertrescue_climb_to_rocks;
@@ -681,8 +688,8 @@ if(loc_coord = ^desertrescue_upper_barrel_coord) {
 [oploc2,loc_2680]
 if(loc_coord = ^desertrescue_upper_barrel_coord) {
     if(testbit(%desertrescue_map_mechanisms, ^desertrescue_ana_lift_barrel) = true) {
-        ~mesbox("You search the barrel and find Ana.");
-        ~chatnpc_specific("Ana (in a Barrel)", anabarrel, "<p,angry>Let me out of here, I feel sick!");
+        // https://web.archive.org/web/20060215230522/http://img.photobucket.com/albums/v72/me9alomaniac/tt4.png
+        ~chatnpc_specific("Ana (in a Barrel)", anabarrel, "<p,angry>@dbl@-- You search the barrels and find Ana. --|Let me out of here, I feel sick!");
         if(inv_freespace(inv) = 0) {
             ~mesbox("You're carrying so many items that you cannot manage Ana as well.");
             return;
@@ -793,10 +800,11 @@ if(%desertrescue_progress = ^desertrescue_given_pineapple) %desertrescue_progres
 mes("You succeed!");
 if(loc_coord = ^desertrescue_lower_minecart_coord) {
     p_teleport(0_51_147_55_23);
-    ~mesbox("You appear in a large open room with what looks like lots of miners working away. This is a very rough looking area, the miners look like they're on their last legs.");
+    // https://web.archive.org/web/20060215230516/http://img.photobucket.com/albums/v72/me9alomaniac/tt3.png
+    ~mesbox("You appear in a large open room with what looks|like lots of miners working away.|This is a very rough looking area,|the miners look like they're on their last legs.");
 } else {
     p_teleport(0_51_147_38_9);
-    ~mesbox("You appear back in the barrel loading room. A nearby slave looks surprised to see you popping out of the cart.");
+    ~mesbox("You appear back in the barrel loading room.|A nearby slave looks surprised to see you popping out of the cart.");
 }
 
 [oplocu,loc_2684]

--- a/data/src/scripts/quests/quest_itgronigen/scripts/quest_itgronigen.rs2
+++ b/data/src/scripts/quests/quest_itgronigen/scripts/quest_itgronigen.rs2
@@ -81,14 +81,17 @@ mes("You search the chest.");
 mes("The chest contains nothing.");
 
 [oploc2,loc_2198]
-mes("You search the chest.");
-mes("You find a small key inside.");
-loc_change(loc_2197, 300);
 if(~obj_gettotal(keep_key) > 0) {
     mes("You already have a keep key.");
     mes("Another one will be of no use.");
     return;
 }
+if(inv_freespace(inv) = 0) {
+    mes("There's a key in there, but you don't have space to carry it.");
+    return;
+}
+~objbox(keep_key, "You find a keep key.", 250, 0, 0);
+loc_change(loc_2197, 300);
 inv_add(inv, keep_key, 1);
 
 [oplocu,_observatory_dungeon_gate] 

--- a/src/engine/entity/Npc.ts
+++ b/src/engine/entity/Npc.ts
@@ -110,7 +110,6 @@ export default class Npc extends PathingEntity {
         this.activeScript = null;
         this.huntTarget = null;
         this.queue.clear();
-        this.heroPoints.clear();
     }
 
     getVar(id: number) {


### PR DESCRIPTION
After the last update - `npc_death` called `npc_del`, which then would clear NPC heropoints immediately. I'm not sure how it didn't prevent all npc_findhero drops, but it was found because random events were suspiciously dropping nothing