### PR TITLE
fix(engine): Close modal improvements

### DIFF
--- a/src/network/rs225/client/handler/CloseModalHandler.ts
+++ b/src/network/rs225/client/handler/CloseModalHandler.ts
@@ -4,10 +4,13 @@ import CloseModal from '#/network/client/model/CloseModal.js';
 
 export default class CloseModalHandler extends MessageHandler<CloseModal> {
     handle(_message: CloseModal, player: Player): boolean {
-        if ((player.modalState & 16) === 0) {
-            // ignores the login window
-            player.closeModal();
-        }
+        // For whatever reason the modal is not closed directly here.
+        // This was tested in osrs by sending close modal and being traded
+        // on the same tick. If you have pid, the trade works. If the other
+        // player has pid, they get told you are still busy.
+        // Another test is to send close modal and open a new interface same
+        // tick. In this case the new interface will also end up closed.
+        player.requestModalClose = true;
         return true;
     }
 }


### PR DESCRIPTION
Fixes:
- Handle close modal request at start of player processing
- Make last login info modal purely client sided