### PR TITLE
fix(content): Add missing if_close in luthas dialogue

### DIFF
--- a/data/src/scripts/quests/quest_hunt/scripts/luthas.rs2
+++ b/data/src/scripts/quests/quest_hunt/scripts/luthas.rs2
@@ -14,6 +14,7 @@ if (%crate_bananas = 10) {
     ~chatplayer("<p,happy>I've filled a crate with bananas.");
     ~chatnpc("<p,happy>Well done, here's your payment.");
 
+    if_close;
     mes("Luthas hands you 30 coins.");
     inv_add(inv, coins, 30);
     %hunt_store_employed = clearbit(%hunt_store_employed, ^plantation);


### PR DESCRIPTION
Source: https://www.youtube.com/watch?v=SInMQzx1K1I&t=181s

Pretty sure something is wrong with the engine to require using if_close here, but we already do it in lots of other places.