### PR TITLE
fix(engine): face_coord in a bunch of scenarios not working properly

### DIFF
--- a/src/engine/CoordGrid.ts
+++ b/src/engine/CoordGrid.ts
@@ -114,6 +114,10 @@ export const CoordGrid = {
         return 0;
     },
 
+    fine(pos: number, size: number): number {
+        return pos * 2 + size;
+    },
+
     unpackCoord(coord: number): CoordGrid {
         const level: number = (coord >> 28) & 0x3;
         const x: number = (coord >> 14) & 0x3fff;

--- a/src/engine/World.ts
+++ b/src/engine/World.ts
@@ -982,6 +982,7 @@ class World {
         // TODO: benchmark this?
         for (const player of this.players) {
             player.convertMovementDir();
+            player.reorient();
 
             const grid = this.playerGrid;
             const coord = CoordGrid.packCoord(player.level, player.x, player.z);
@@ -996,6 +997,7 @@ class World {
 
         for (const npc of this.npcs) {
             npc.convertMovementDir();
+            npc.reorient();
             this.npcRenderer.computeInfo(npc);
         }
     }

--- a/src/engine/entity/Npc.ts
+++ b/src/engine/entity/Npc.ts
@@ -131,10 +131,7 @@ export default class Npc extends PathingEntity {
         if (respawn) {
             this.type = this.origType;
             this.uid = (this.type << 16) | this.nid;
-            this.faceX = -1;
-            this.faceZ = -1;
-            this.orientationX = -1;
-            this.orientationZ = -1;
+            this.unfocus();
             this.playAnimation(-1, 0); // reset animation or last anim has a chance to appear on respawn
             for (let index = 0; index < this.baseLevels.length; index++) {
                 this.levels[index] = this.baseLevels[index];
@@ -1001,11 +998,7 @@ export default class Npc extends PathingEntity {
     }
 
     faceSquare(x: number, z: number) {
-        this.faceX = x * 2 + 1;
-        this.faceZ = z * 2 + 1;
-        this.orientationX = this.faceX;
-        this.orientationZ = this.faceZ;
-        this.masks |= InfoProt.NPC_FACE_COORD.id;
+        this.focus(CoordGrid.fine(x, 1), CoordGrid.fine(z, 1), true);
     }
 
     changeType(type: number) {

--- a/src/engine/entity/PathingEntity.ts
+++ b/src/engine/entity/PathingEntity.ts
@@ -398,7 +398,7 @@ export default abstract class PathingEntity extends Entity {
         if (target instanceof PathingEntity) {
             // Try to focus back on a possible target because they move.
             this.focus(CoordGrid.fine(target.x, target.width), CoordGrid.fine(target.z, target.length), false);
-        } else if (this.targetX !== -1 && !this.hasWaypoints()) {
+        } else if (this.targetX !== -1 && this.stepsTaken === 0) {
             // If the entity targeted then moved off, then we try to refocus after running out of steps.
             // this is only set when clicking non pathing entities.
             // we do not update the client, the client was already notified of the update.

--- a/src/engine/entity/PathingEntity.ts
+++ b/src/engine/entity/PathingEntity.ts
@@ -35,6 +35,7 @@ import {
     reachedLoc,
     reachedObj
 } from '#/engine/GameMap.js';
+import NonPathingEntity from '#/engine/entity/NonPathingEntity.js';
 
 type TargetSubject = {
     type: number,
@@ -82,6 +83,12 @@ export default abstract class PathingEntity extends Entity {
     apRange: number = 10;
     apRangeCalled: boolean = false;
 
+    // this is only used to hack in the turning after walking on non pathing entity.
+    // do not use this for anything else.
+    targetX: number = -1;
+    targetZ: number = -1;
+
+    // info update masks. resets at the end of every tick.
     masks: number = 0;
     exactStartX: number = -1;
     exactStartZ: number = -1;
@@ -228,8 +235,9 @@ export default abstract class PathingEntity extends Entity {
         const previousZ: number = this.z;
         this.x = CoordGrid.moveX(this.x, dir);
         this.z = CoordGrid.moveZ(this.z, dir);
-        this.orientationX = CoordGrid.moveX(this.x, dir) * 2 + this.width;
-        this.orientationZ = CoordGrid.moveZ(this.z, dir) * 2 + this.length;
+        const moveX: number = CoordGrid.moveX(this.x, dir);
+        const moveZ: number = CoordGrid.moveZ(this.z, dir);
+        this.focus(CoordGrid.fine(moveX, this.width), CoordGrid.fine(moveZ, this.length), false);
         this.stepsTaken++;
         this.refreshZonePresence(previousX, previousZ, this.level);
 
@@ -288,6 +296,10 @@ export default abstract class PathingEntity extends Entity {
         this.x = x;
         this.z = z;
         this.level = level;
+        const dir: number = CoordGrid.face(previousX, previousZ, x, z);
+        const moveX: number = CoordGrid.moveX(this.x, dir);
+        const moveZ: number = CoordGrid.moveZ(this.z, dir);
+        this.focus(CoordGrid.fine(moveX, this.width), CoordGrid.fine(moveZ, this.length), false);
         this.refreshZonePresence(previousX, previousZ, previousLevel);
         this.lastStepX = this.x - 1;
         this.lastStepZ = this.z;
@@ -347,6 +359,53 @@ export default abstract class PathingEntity extends Entity {
         this.walkDir = walkDir;
         this.runDir = runDir;
         this.tele = tele;
+    }
+
+    /**
+     * Face and orient to a specified fine coord.
+     * Enable `client` to update connected clients about the new focus, enabling the face_coord mask.
+     */
+    focus(fineX: number, fineZ: number, client: boolean): void {
+        // set the direction of the player/npc every time an interaction is set.
+        // does not necessarily require the coord mask to be sent.
+        // direction when the player/npc is first observed (updates on movement)
+        this.orientationX = fineX;
+        this.orientationZ = fineZ;
+        if (client) {
+            // direction update (only updates from facesquare or interactions)
+            this.faceX = fineX;
+            this.faceZ = fineZ;
+            this.masks |= this.coordmask;
+        }
+    }
+
+    /**
+     * Face and orient back to the default south.
+     */
+    unfocus(): void {
+        this.orientationX = CoordGrid.fine(this.x, this.width);
+        this.orientationZ = CoordGrid.fine(this.z - 1, this.length);
+    }
+
+    /**
+     * Try to focus back on a possible target.
+     * This is needed because the target can move.
+     * This should be done after all pathing entities have moved.
+     * If the entity targeted then moved off, then we try to refocus after running out of steps.
+     */
+    reorient(): void {
+        const target: Entity | null = this.target;
+        if (target instanceof PathingEntity) {
+            // Try to focus back on a possible target because they move.
+            this.focus(CoordGrid.fine(target.x, target.width), CoordGrid.fine(target.z, target.length), false);
+        } else if (this.targetX !== -1 && !this.hasWaypoints()) {
+            // If the entity targeted then moved off, then we try to refocus after running out of steps.
+            // this is only set when clicking non pathing entities.
+            // we do not update the client, the client was already notified of the update.
+            this.focus(this.targetX, this.targetZ, false);
+            this.targetX = -1;
+            this.targetZ = -1;
+        }
     }
 
     /**
@@ -518,18 +577,11 @@ export default abstract class PathingEntity extends Entity {
         this.apRange = 10;
         this.apRangeCalled = false;
 
-        // set the direction of the player/npc every time an interaction is set.
-        // does not necessarily require the coord mask to be sent.
-        const faceX: number = target.x * 2 + target.width;
-        const faceZ: number = target.z * 2 + target.length;
-
-        // direction when the player/npc is first observed (updates on movement)
-        this.orientationX = faceX;
-        this.orientationZ = faceZ;
-
-        // direction update (only updates from facesquare or interactions)
-        this.faceX = faceX;
-        this.faceZ = faceZ;
+        this.focus(
+            CoordGrid.fine(target.x, target.width),
+            CoordGrid.fine(target.z, target.length),
+            target instanceof NonPathingEntity && interaction === Interaction.ENGINE
+        );
 
         if (target instanceof Player) {
             const pid: number = target.pid + 32768;
@@ -544,10 +596,8 @@ export default abstract class PathingEntity extends Entity {
                 this.masks |= this.entitymask;
             }
         } else {
-            if (interaction === Interaction.ENGINE) {
-                // mask updates will be sent every time from the packet handler
-                this.masks |= this.coordmask;
-            }
+            this.targetX = CoordGrid.fine(target.x, target.width);
+            this.targetZ = CoordGrid.fine(target.z, target.length);
         }
 
         if (interaction === Interaction.SCRIPT) {
@@ -613,6 +663,8 @@ export default abstract class PathingEntity extends Entity {
         this.graphicId = -1;
         this.graphicHeight = -1;
         this.graphicDelay = -1;
+        this.faceX = -1;
+        this.faceZ = -1;
 
         if (!this.target && this.faceEntity !== -1) {
             this.masks |= this.entitymask;

--- a/src/engine/entity/Player.ts
+++ b/src/engine/entity/Player.ts
@@ -338,10 +338,7 @@ export default class Player extends PathingEntity {
 
     resetEntity(respawn: boolean) {
         if (respawn) {
-            this.faceX = -1;
-            this.faceZ = -1;
-            this.orientationX = -1;
-            this.orientationZ = -1;
+            this.unfocus();
         }
         super.resetPathingEntity();
         this.repathed = false;
@@ -1604,11 +1601,7 @@ export default class Player extends PathingEntity {
     }
 
     faceSquare(x: number, z: number) {
-        this.faceX = x * 2 + 1;
-        this.faceZ = z * 2 + 1;
-        this.orientationX = this.faceX;
-        this.orientationZ = this.faceZ;
-        this.masks |= InfoProt.PLAYER_FACE_COORD.id;
+        this.focus(CoordGrid.fine(x, 1), CoordGrid.fine(z, 1), true);
     }
 
     playSong(name: string) {

--- a/src/network/rs225/server/codec/NpcInfoEncoder.ts
+++ b/src/network/rs225/server/codec/NpcInfoEncoder.ts
@@ -156,11 +156,12 @@ export default class NpcInfoEncoder extends MessageEncoder<NpcInfo> {
         }
 
         if (!renderer.has(nid, InfoProt.NPC_FACE_COORD)) {
-            if (other.orientationX !== -1) {
-                renderer.cache(nid, new NpcInfoFaceCoord(other.orientationX, other.orientationZ), InfoProt.NPC_FACE_COORD);
-            } else if (other.faceX !== -1) {
+            if (other.faceX !== -1) {
                 renderer.cache(nid, new NpcInfoFaceCoord(other.faceX, other.faceZ), InfoProt.NPC_FACE_COORD);
+            } else if (other.orientationX !== -1) {
+                renderer.cache(nid, new NpcInfoFaceCoord(other.orientationX, other.orientationZ), InfoProt.NPC_FACE_COORD);
             } else {
+                // this is a fail safe but should not happen.
                 renderer.cache(nid, new NpcInfoFaceCoord(other.x * 2 + 1, (other.z - 1) * 2 + 1), InfoProt.NPC_FACE_COORD);
             }
         }

--- a/src/network/rs225/server/codec/PlayerInfoEncoder.ts
+++ b/src/network/rs225/server/codec/PlayerInfoEncoder.ts
@@ -207,11 +207,12 @@ export default class PlayerInfoEncoder extends MessageEncoder<PlayerInfo> {
         }
 
         if (!renderer.has(pid, InfoProt.PLAYER_FACE_COORD)) {
-            if (other.orientationX !== -1) {
-                renderer.cache(pid, new PlayerInfoFaceCoord(other.orientationX, other.orientationZ), InfoProt.PLAYER_FACE_COORD);
-            } else if (other.faceX !== -1) {
+            if (other.faceX !== -1) {
                 renderer.cache(pid, new PlayerInfoFaceCoord(other.faceX, other.faceZ), InfoProt.PLAYER_FACE_COORD);
+            } else if (other.orientationX !== -1) {
+                renderer.cache(pid, new PlayerInfoFaceCoord(other.orientationX, other.orientationZ), InfoProt.PLAYER_FACE_COORD);
             } else {
+                // this is a fail safe but should not happen.
                 renderer.cache(pid, new PlayerInfoFaceCoord(other.x * 2 + 1, (other.z - 1) * 2 + 1), InfoProt.PLAYER_FACE_COORD);
             }
         }


### PR DESCRIPTION
`faceX/Z` *direction update (only updates from facesquare or interactions)*
`orientationX/Z` *direction when the player/npc is first observed (updates on movement)*
- Prioritize sending `face` > `orientation` > `default south` when encoding player & npc updates.
- Create `CoordGrid#fine` function for client coords.
- Fix teleporting was not updating the `orientationX/Z`.
- Fix `orientationX/Z` when a `PathingEntity` is targetting a `PathingEntity` and the target moves. This is now refreshing properly.
- Fix `orientationX/Z` when targetting a `NonPathingEntity` and you turn after running out of steps.
- `faceX/Z` is now reset like the other info update masks at the end of every tick, as this is only used for the one time that tick when sending high definition updates.

## Teleporting
### Before
https://github.com/user-attachments/assets/17e2ba38-d61f-476a-9a11-2ab1cd9c129e

### After
https://github.com/user-attachments/assets/042577a8-8f12-487d-93f5-a549cd5969a3

## Target Moves (We are the target in this case)
### Before
https://github.com/user-attachments/assets/cdb41567-a445-4a15-bb60-f4a2c8bf765b

### After
https://github.com/user-attachments/assets/2b492436-bf7e-4611-a7c7-e30840024cb6

## Whatever You Call This?
### Before
https://github.com/user-attachments/assets/a103dae7-5514-4ef8-b92d-cb09f5fc69d0

### After
https://github.com/user-attachments/assets/79393667-c228-421b-99ee-f11b11a89048

