### PR TITLE
fix(content): fixes for chompy bird hunting, add kill tracking

### DIFF
--- a/data/src/pack/seq.pack
+++ b/data/src/pack/seq.pack
@@ -1009,10 +1009,10 @@
 1008=chompy_ready
 1009=seq_1009
 1010=seq_1010
-1011=seq_1011
-1012=seq_1012
+1011=chompy_attack
+1012=chompy_defend
 1013=seq_1013
-1014=seq_1014
+1014=chompy_landing
 1015=chompy_death
 1016=seq_1016
 1017=spit_anim

--- a/data/src/scripts/_unpack/all.seq
+++ b/data/src/scripts/_unpack/all.seq
@@ -12963,7 +12963,7 @@ stretches=yes
 frame1=anim_4005
 delay1=14464
 
-[seq_1011]
+[chompy_attack]
 stretches=yes
 frame1=anim_4012
 frame2=anim_4019
@@ -12975,7 +12975,7 @@ frame7=anim_4004
 frame8=anim_4014
 frame9=anim_4021
 
-[seq_1012]
+[chompy_defend]
 frame1=anim_4042
 frame2=anim_4054
 frame3=anim_4063
@@ -12986,7 +12986,7 @@ replayoff=2
 frame1=anim_4005
 frame2=anim_4005
 
-[seq_1014]
+[chompy_landing]
 frame1=anim_4044
 frame2=anim_4056
 frame3=anim_4065

--- a/data/src/scripts/quests/quest_chompybird/configs/quest_chompybird.constant
+++ b/data/src/scripts/quests/quest_chompybird/configs/quest_chompybird.constant
@@ -26,3 +26,7 @@
 // 0 = not set, 1 = tomato, 2 = doogle leaves
 ^chompybird_varbit_fycie_flavour_start = 4
 ^chompybird_varbit_fycie_flavour_end = 5
+
+// max value 16384 (guess)
+^chompybird_varbit_kills_start = 6
+^chompybird_varbit_kills_end = 20

--- a/data/src/scripts/quests/quest_chompybird/configs/quest_chompybird.hunt
+++ b/data/src/scripts/quests/quest_chompybird/configs/quest_chompybird.hunt
@@ -3,6 +3,7 @@ type=npc
 check_npc=bloated_toad
 check_vis=lineofsight
 check_afk=off
+find_keephunting=on
 check_notcombat=%lastcombat
 check_notcombat_self=%npc_lastcombat
 // confirm rate

--- a/data/src/scripts/quests/quest_chompybird/configs/quest_chompybird.npc
+++ b/data/src/scripts/quests/quest_chompybird/configs/quest_chompybird.npc
@@ -93,8 +93,8 @@ hitpoints=10
 attack=5
 strength=5
 defence=3
-param=attack_anim,seq_1012
-param=defend_anim,seq_1011
+param=attack_anim,chompy_attack
+param=defend_anim,chompy_defend
 param=death_anim,seq_1009
 param=attack_sound,chompy_bird_attack
 param=defend_sound,chompy_bird_hit
@@ -102,7 +102,7 @@ param=death_sound,chompy_bird_death
 // TODO tbc + missing datas
 // Hunt range is a guess
 // If removed, chompy won't hunt for toads during quest
-huntrange=10
+huntrange=2
 // osrs stats and Vislvl match 1:1
 // https://raw.githubusercontent.com/Joshua-F/osrs-dumps/refs/heads/master/config/dump.npc npc_1475
 

--- a/data/src/scripts/quests/quest_chompybird/scripts/chompy_bird.rs2
+++ b/data/src/scripts/quests/quest_chompybird/scripts/chompy_bird.rs2
@@ -5,7 +5,7 @@
     
     npc_add($spawn_coord, chompy_bird, 100);
     %quest_chompybird_baiter = $baiter_uid;
-    // todo anim?
+    npc_anim(chompy_landing, 0);
     npc_say("Sqwirk!");
 
     // todo confirm behaviour, looks like it wanders first then hunts?
@@ -14,19 +14,22 @@
 
 // triggered by the .hunt config, the Chompy has found, and arrived at, the Bloated Toad
 [ai_queue4,chompy_bird]
-if (.npc_find(npc_coord, bloated_toad, 1, 1) = true) {
+if (.npc_find(npc_coord, bloated_toad, 2, 1) = true) {
     npc_sethuntmode(null);
     npc_facesquare(.npc_coord);
     npc_queue(5, 0, 0);
     .npc_queue(5, 0, 0);
 }
 
+
 // the Chompy is eating the toad
 [ai_queue5,chompy_bird]
 npc_say("Sqwark!");
+npc_anim(chompy_attack, 0);
 npc_delay(3);
 npc_say("Gobble!");
 npc_delay(2);
+npc_sethuntmode(chompybird);
 
 // todo consider some check that the toad actually still exists?
 //      might not be necessary though
@@ -180,9 +183,8 @@ if (~player_npc_hit_roll(%damagetype) = true) {
 def_int $delay = add(~player_use_ogre_bow($ammo), 30); // osrs it seems to be delayed an extra tick
 anim(%com_attackanim, 0);
 sound_synth(%com_attacksound, 0, 0);
-~npc_retaliate(calc($delay / 30));
+// Chompies don't fight back
 npc_queue(2, $damage, calc($delay / 30));
-npc_anim(npc_param(defend_anim), sub($delay, 30)); // delay npc this tick
 if (npc_param(defend_sound) ! null) {
     sound_synth(npc_param(defend_sound), 0, sub($delay, 30)); // delay 1 client tick for the hit queue
 }
@@ -198,6 +200,12 @@ if (random(5) ! 0) {
     }
 }
 inv_clear(ranged_quiver_inv);
+
+if (random(2) = 0) {
+    // There's some randomness here, this is a guess
+    npc_say("Screech!");
+    npc_setmode(playerescape);
+}
 
 // Ogre arrow launch spotanim is higher than other arrows by default, so we compensate for that here
 [proc,player_use_ogre_bow](obj $ammo)(int)
@@ -219,4 +227,5 @@ npc_add(npc_coord, chompy_bird_corpse, 100);
 if (%chompybird_progress = ^chompybird_rantz_gave_player_bow) {
     %chompybird_progress = ^chompybird_player_killed_chompy;
 }
-// todo add chompy bird killcount
+def_int $kills = getbit_range(%chompybird_kills, ^chompybird_varbit_kills_start, ^chompybird_varbit_kills_end);
+%chompybird_kills = setbit_range_toint(%chompybird_kills, calc($kills + 1), ^chompybird_varbit_kills_start, ^chompybird_varbit_kills_end);

--- a/data/src/scripts/quests/quest_chompybird/scripts/ogre_bow.rs2
+++ b/data/src/scripts/quests/quest_chompybird/scripts/ogre_bow.rs2
@@ -1,0 +1,79 @@
+[opheld3,ogre_bow]
+if (%chompybird_progress < ^chompybird_complete) {
+    mes("You've scratched up no kills yet! You've got to complete the quest first!");
+    return;
+}
+def_int $kills = getbit_range(%chompybird_kills, ^chompybird_varbit_kills_start, ^chompybird_varbit_kills_end);
+def_string $rank = ~add_article(~get_chompy_rank($kills));
+mes("You've scratched up a total of <tostring($kills)> chompy bird kills so far!");
+mes("~ You're <$rank>! ~");
+// https://media.discordapp.net/attachments/1126857544523063367/1331479444136919040/hunt.png?ex=679afedd&is=6799ad5d&hm=254c6abe7ebfdbf6412478e24ba4dd97a649d33bd9ee3d5c4dacd35e6ee9847d&=&format=webp&quality=lossless
+~objbox(chompy_bird_obj, "You've killed a total of @blu@<tostring($kills)> @bla@chompy birds so far!||@blu@~ You're <$rank>! ~", 250, 0, ^objbox_height);
+
+[proc,get_chompy_rank](int $kills)(string)
+if ($kills < 5) {
+    return("Ogre Novice");
+}
+if ($kills < 15) {
+    return("Beginner");
+}
+if ($kills < 20) {
+    return("Ogre Learner");
+}
+if ($kills < 30) {
+    return("Learner");
+}
+if ($kills < 40) {
+    return("Ogre Bowman");
+}
+if ($kills < 50) {
+    return("Bowman");
+}
+if ($kills < 70) {
+    return("Ogre Yeoman");
+}
+if ($kills < 95) {
+    return("Yeoman");
+}
+if ($kills < 125) {
+    return("Ogre Markman");
+}
+if ($kills < 170) {
+    return("Marksman");
+}
+if ($kills < 225) {
+    return("Ogre Woodsman");
+}
+if ($kills < 300) {
+    return("Woodsman");
+}
+if ($kills < 400) {
+    return("Ogre Forester");
+}
+if ($kills < 550) {
+    return("Forester");
+}
+if ($kills < 700) {
+    return("Ogre Bowmaster");
+}
+if ($kills < 1000) {
+    return("Bowmaster");
+}
+if ($kills < 1300) {
+    return("Ogre Expert");
+}
+if ($kills < 1700) {
+    return("Expert");
+}
+if ($kills < 2250) {
+    return("Ogre Dragon Archer");
+}
+if ($kills < 3000) {
+    return("Dragon Archer");
+}
+if ($kills < 4000) {
+    return("Expert Ogre Dragon Archer");
+}
+else {
+    return("Expert Dragon Archer");
+}

--- a/data/src/scripts/quests/quest_chompybird/scripts/rantz.rs2
+++ b/data/src/scripts/quests/quest_chompybird/scripts/rantz.rs2
@@ -96,7 +96,6 @@ switch_int(%chompybird_progress) {
     case ^chompybird_told_to_cook_chompy :
         @rantz_tell_chompy_flavour;
     case ^chompybird_chompy_cooked :
-        // todo what if the player no longer has the seasoned chompy? Does it still auto-hand in?
         @hand_chompy_to_rantz;
     case ^chompybird_complete :
         ~chatnpc("<p,neutral>Hey deyr, t'anks for da chompy, it was scrumbly!");
@@ -322,6 +321,11 @@ if (p_finduid(uid) = true) {
 [label,hand_chompy_to_rantz]
 // todo mesanim and line breaks TBC
 ~chatnpc("<p,neutral>Hey creature, did you's get da cooked chompy yet?|I smelled something cooking and it mades me 'ungry.|Hand over da chompy if ya know what's good for ya.");
+if (inv_total(inv, seasoned_chompy) < 1) {
+    ~chatplayer("<p,neutral>Well, erm, I don't have one at the moment.");
+    ~chatnpc("<p,neutral>Well, 'urry up... else you's creature is looking tasty to me soon!");
+    return;
+}
 ~chatplayer("<p,neutral>Yes, here you go, here's your cooked chompy bird.");
 inv_del(inv, seasoned_chompy, 1);
 queue(quest_chompybird_complete, 0);

--- a/data/src/scripts/quests/quest_chompybird/scripts/raw_chompy.rs2
+++ b/data/src/scripts/quests/quest_chompybird/scripts/raw_chompy.rs2
@@ -140,9 +140,7 @@ if ($has_rantz_ingredient = false | $has_bugs_ingredient = false | $has_fycie_in
     return;
 }
 
-if (loc_find($loc_coord, ogre_spitroast) = true) {
-    %chompybird_progress = ^chompybird_chompy_cooked;
-    
+if (loc_find($loc_coord, ogre_spitroast) = true) {   
     mes("You carefully place the chompy bird on the spit-roast.");
     inv_del(inv, raw_chompy, 1);
     loc_change(ogre_spitroast_raw_chompy, 4);
@@ -154,6 +152,7 @@ if (loc_find($loc_coord, ogre_spitroast) = true) {
     def_boolean $passes_roll = stat_random(stat(cooking), 200, 255);
     if ($passes_roll = true) {
         mes("You add the other ingredients and cook the food.");
+        %chompybird_progress = ^chompybird_chompy_cooked;
         ~delete_chompy_ingredients($rantz_ingredient, $bugs_ingredient, $fycie_ingredient);
         loc_change(ogre_spitroast_cooked_chompy, 4);
         loc_anim(spit_anim);


### PR DESCRIPTION
- Add chompy kill tracking, fixes #799 
![image](https://github.com/user-attachments/assets/eac45dcc-2f05-4059-9e52-34e3b0bb45c2)
- Fix chompy behaviour:
    - Toad hunt was only triggering if chompy spawned on same tile as toad
    - Add landing animation
    - Remove player retaliation and add retreating
- Ensure burning the chompy during the quest doesn't allow you to progress
- Check player still has the chompy during Rantz's hand-in dialogue
