### PR TITLE
fix(content): autocast "You need to choose a spell first." mes

### DIFF
--- a/data/src/scripts/skill_combat/scripts/player/weapon_category.rs2
+++ b/data/src/scripts/skill_combat/scripts/player/weapon_category.rs2
@@ -68,6 +68,10 @@
 
 [if_button,combat_staff_2:auto_toggle]
 if_close;
+if (%attackstyle_magic = 0) {
+    mes("You need to choose a spell first."); // https://youtu.be/Mo6AcO4rg4A?t=69
+    return;
+}
 if (p_finduid(uid) = true) {
     %attackstyle_magic = togglebit(%attackstyle_magic, 0);
     return;


### PR DESCRIPTION
from [video](https://youtu.be/Mo6AcO4rg4A?t=69)
![VS--YouTube-MemberofRunescape-1’10”](https://github.com/user-attachments/assets/8d20a117-d71d-4569-9dc6-e4a0c1652ce6)
