### PR TITLE
fix(content): remove pineapple_plants debug message

### DIFF
--- a/data/src/scripts/areas/area_brimhaven/scripts/pineapple_plants.rs2
+++ b/data/src/scripts/areas/area_brimhaven/scripts/pineapple_plants.rs2
@@ -5,7 +5,7 @@ if (inv_freespace(inv) = 0) {
 }
 
 loc_change(loc_param(next_loc_stage), 500);
-mes(lc_debugname(loc_type));
+//mes(lc_debugname(loc_type));
 inv_add(inv, pineapple, 1);
 
 mes("You pick a pineapple.");

--- a/data/src/scripts/areas/area_brimhaven/scripts/pineapple_plants.rs2
+++ b/data/src/scripts/areas/area_brimhaven/scripts/pineapple_plants.rs2
@@ -5,7 +5,6 @@ if (inv_freespace(inv) = 0) {
 }
 
 loc_change(loc_param(next_loc_stage), 500);
-//mes(lc_debugname(loc_type));
 inv_add(inv, pineapple, 1);
 
 mes("You pick a pineapple.");


### PR DESCRIPTION
Looks like this was used during testing to ensure the plant was being "depleted" whilst picking, but wasn't removed after

![screenshot-1738373650](https://github.com/user-attachments/assets/6854a48e-ecb3-4455-898f-4d4a62192251)
