### PR TITLE
fix(engine): deleting objs of the same type being sent out to clients incorrectly

### DIFF
--- a/src/engine/zone/Zone.ts
+++ b/src/engine/zone/Zone.ts
@@ -340,7 +340,7 @@ export default class Zone {
             if (obj.lifecycle === EntityLifeCycle.RESPAWN || obj.receiver64 === Obj.NO_RECEIVER) {
                 this.queueEvent(obj, new ZoneEvent(ZoneEventType.ENCLOSED, Obj.NO_RECEIVER, new ObjDel(coord, obj.type)));
             } else if (obj.lifecycle === EntityLifeCycle.DESPAWN) {
-                this.queueEvent(obj, new ZoneEvent(ZoneEventType.FOLLOWS, Obj.NO_RECEIVER, new ObjDel(coord, obj.type)));
+                this.queueEvent(obj, new ZoneEvent(ZoneEventType.FOLLOWS, obj.receiver64, new ObjDel(coord, obj.type)));
             }
         }
     }


### PR DESCRIPTION
If the obj has an owner and gets deleted, this does a `follows` event, the problem however, is the event was being sent for `-1` receivers, which is allowing the follow events to be sent out for everyone. The problem is only found when this is done using the same type of obj on the same tile.

```ts
    writePartialFollows(player: Player): void {
        if (this.events.size === 0) {
            return;
        }
        player.write(new UpdateZonePartialFollows(this.x, this.z, player.originX, player.originZ));
        for (const event of this.follows()) {
            if (event.receiver64 !== Obj.NO_RECEIVER && event.receiver64 !== player.hash64) {
                continue;
            }
            player.write(event.message);
        }
    }
```