### PR TITLE
fix(content): thurgo post-quest dialogue

### DIFF
--- a/data/src/scripts/areas/area_port_sarim/scripts/thurgo.rs2
+++ b/data/src/scripts/areas/area_port_sarim/scripts/thurgo.rs2
@@ -1,8 +1,12 @@
 [opnpc1,thurgo]
-// todo: Figure out if Thurgo has any possible post-quest dialogue pre-skillcapes
 switch_int (%squire_progress) {
     case 2 : @thurgo_inquire;
     case 3 : @thurgo_special_sword_post_pie;
     case 4, 5, 6 : @thurgo_about_sword;
+    case 7 : @thurgo_squire_complete;
     case default : mes("Thurgo doesn't appear to be interested in talking.");
 }
+
+[label,thurgo_squire_complete]
+~chatplayer("<p,neutral>Thanks for your help in getting the sword for me!");
+~chatnpc("<p,happy>No worries mate.");

--- a/data/src/scripts/areas/area_port_sarim/scripts/thurgo.rs2
+++ b/data/src/scripts/areas/area_port_sarim/scripts/thurgo.rs2
@@ -2,11 +2,6 @@
 switch_int (%squire_progress) {
     case 2 : @thurgo_inquire;
     case 3 : @thurgo_special_sword_post_pie;
-    case 4, 5, 6 : @thurgo_about_sword;
-    case 7 : @thurgo_squire_complete;
+    case 4, 5, 6, ^squire_complete : @thurgo_about_sword;
     case default : mes("Thurgo doesn't appear to be interested in talking.");
 }
-
-[label,thurgo_squire_complete]
-~chatplayer("<p,neutral>Thanks for your help in getting the sword for me!");
-~chatnpc("<p,happy>No worries mate.");

--- a/data/src/scripts/quests/quest_squire/scripts/quest_squire.rs2
+++ b/data/src/scripts/quests/quest_squire/scripts/quest_squire.rs2
@@ -180,6 +180,8 @@ if(%squire_progress = 4 | %squire_progress = 5 & inv_total(inv, portrait) = 0) {
     %squire_progress = 6;
 } else if (%squire_progress = 6) {
     @thurgo_check_blurite;
+} else if (%squire_progress = ^squire_complete) {
+    @thurgo_squire_complete;
 }
 
 [label,thurgo_check_blurite]
@@ -220,3 +222,7 @@ return(true);
 session_log(^log_adventure, "Quest complete: The Knight's Sword");
 ~send_quest_complete(questlist:squire, blurite_sword, 250, ^squire_questpoints, "You have completed the Knight's Sword Quest!");
 stat_advance(smithing, 127250);
+
+[label,thurgo_squire_complete]
+~chatplayer("<p,neutral>Thanks for all your help in getting it for me!");
+~chatnpc("<p,happy>No worries mate.");


### PR DESCRIPTION
From RSC Wiki, after the quest:
https://classic.runescape.wiki/w/Transcript:Thurgo#After_The_knight's_sword_quest

_Player: Thanks for your help in getting the sword for me
Thurgo: No worries mate_

From RS3 Wiki, after the quest:
https://runescape.wiki/w/Transcript:Thurgo#After_the_Knight's_Sword

Choice 3: Something else.
_Player: About that sword...
Player: Thanks for all your help getting it for me!
Thurgo: No worries mate._

OSRS Wiki, just for reference:
https://oldschool.runescape.wiki/w/Transcript:The_Knight%27s_Sword
There is no mention of "_No worries mate._" which was used in Classic -> RS3 which suggests the OSRS dialogue was re-written at some point.

I've therefore gone with the RSC Wiki version because there are no other Choices like in RS3, and can presume it would just be: Click Thurgo -> "Thanks for your help in getting the sword for me!" -> "No worries mate." 

RS3 still uses "No worries mate." after completion which suggests this is unchanged from RSC (other than punctuation) and therefore should be the same in 2004.

This may not be 100% authentic, but is a step closer than the pre-quest "Thurgo doesn't appear to be interested in talking." message