### PR TITLE
fix(content): was possible to attempt stat_add with negative value

### DIFF
--- a/data/src/scripts/player/scripts/stat.rs2
+++ b/data/src/scripts/player/scripts/stat.rs2
@@ -70,7 +70,7 @@ if (calc($level + $boost) > $max_level) {
 }
 
 // add the boost, with no percent
-stat_add($stat, $boost, 0);
+stat_add($stat, max($boost, 0), 0);
 
 // not sure if this is used anywhere
 // thought it was for kebabs but its not the case


### PR DESCRIPTION
Commented example of drinking a beer given a boosted str lvl of 3 and base str lvl of 1:

```js
[proc,stat_addclamp](stat $stat, int $constant, int $percent) //strength,1,2
def_int $base_level = stat_base($stat); // 1
def_int $level = stat($stat); // 3

// calculate the maximum level based on the base level
def_int $max_level = calc($base_level + ($constant + scale($base_level, 100, $percent)));
// => 1 + (1 + (1*2)/100) => 2

// calculate the boost and lower it to max - level if it goes over
def_int $boost = calc($constant + scale($level, 100, $percent));
// => 1 + (3*2)/100 => 1
if (calc($level + $boost) > $max_level) { // => true
    $boost = calc($max_level - $level);
    // => 2 - 3 => -1
}

// add the boost, with no percent
stat_add($stat, $boost, 0); // $boost is -1 => exception
```