### PR TITLE
fix(content): gas rock prospect message

### DIFF
--- a/data/src/scripts/skill_mining/scripts/prospect.rs2
+++ b/data/src/scripts/skill_mining/scripts/prospect.rs2
@@ -2,6 +2,7 @@
 [oploc2,_mining_rock_fast] @prospect_rock(finish_prospect_normal);
 [oploc2,loc_2491] @prospect_rock(finish_prospect_essence);
 [oploc2,gemrock] @prospect_rock(finish_prospect_normal);
+[oploc2,_mining_rock_macro_gas] @prospect_rock(finish_prospect_normal); // todo: confirm prospect message for gas rocks
 
 [label,prospect_rock](label $finish_prospect)
 mes("You examine the rock for ores...");


### PR DESCRIPTION
Prospecting a gas rock currently returns "Nothing interesting happens."

This fix will return the normal prospect message. It may have been different in 2004 but I haven't yet been able to find a source