### PR TITLE
feat(engine): improve searching speed for nearby npcs

### DIFF
--- a/src/engine/entity/BuildArea.ts
+++ b/src/engine/entity/BuildArea.ts
@@ -2,6 +2,7 @@ import {CoordGrid} from '#/engine/CoordGrid.js';
 import Player from '#/engine/entity/Player.js';
 import World from '#/engine/World.js';
 import Npc from '#/engine/entity/Npc.js';
+import { coerceAtLeast, coerceAtMost } from '#/util/Numbers.js';
 
 export default class BuildArea {
     public static readonly INTERVAL: number = 10;
@@ -69,12 +70,7 @@ export default class BuildArea {
         this.appearances.set(pid, tick);
     }
 
-    *getNearbyPlayers(pid: number, level: number, x: number, z: number, originX: number, originZ: number): IterableIterator<Player> {
-        const absLeftX: number = originX - 48;
-        const absRightX: number = originX + 48;
-        const absTopZ: number = originZ + 48;
-        const absBottomZ: number = originZ - 48;
-
+    *getNearbyPlayers(pid: number, level: number, x: number, z: number): IterableIterator<Player> {
         const radius = this.viewDistance * 2;
         const min = -radius >> 1;
         const max = radius >> 1;
@@ -98,8 +94,7 @@ export default class BuildArea {
                             player.pid !== pid &&
                             CoordGrid.isWithinDistanceSW({ x: x + dx, z: z + dz }, player, this.viewDistance) &&
                             !this.players.has(player) &&
-                            player.level === level &&
-                            !(player.x <= absLeftX || player.x >= absRightX || player.z >= absTopZ || player.z <= absBottomZ)
+                            player.level === level
                         ) {
                             yield player;
                         }
@@ -118,27 +113,21 @@ export default class BuildArea {
         }
     }
 
-    *getNearbyNpcs(level: number, x: number, z: number, originX: number, originZ: number): IterableIterator<Npc> {
-        const absLeftX: number = originX - 48;
-        const absRightX: number = originX + 48;
-        const absTopZ: number = originZ + 48;
-        const absBottomZ: number = originZ - 48;
+    *getNearbyNpcs(level: number, x: number, z: number): IterableIterator<Npc> {
+        const startX: number = coerceAtLeast(0, CoordGrid.zone(x - BuildArea.PREFERRED_VIEW_DISTANCE));
+        const startZ: number = coerceAtLeast(0, CoordGrid.zone(z - BuildArea.PREFERRED_VIEW_DISTANCE));
+        const endX: number = coerceAtMost(0x7ff, CoordGrid.zone(x + BuildArea.PREFERRED_VIEW_DISTANCE));
+        const endZ: number = coerceAtMost(0x7ff, CoordGrid.zone(z + BuildArea.PREFERRED_VIEW_DISTANCE));
 
-        const centerX = CoordGrid.zone(x);
-        const centerZ = CoordGrid.zone(z);
-
-        const minx = centerX - 2;
-        const minz = centerZ - 2;
-        const maxx = centerX + 2;
-        const maxz = centerZ + 2;
-
-        for (let cx = minx; cx <= maxx; cx++) {
-            for (let cz = minz; cz <= maxz; cz++) {
-                for (const npc of World.gameMap.getZone(cx << 3, cz << 3, level).getAllNpcsSafe()) {
+        for (let zx = startX; zx <= endX; zx++) {
+            const zoneX: number = zx << 3;
+            for (let zz = startZ; zz <= endZ; zz++) {
+                const zoneZ: number = zz << 3;
+                for (const npc of World.gameMap.getZone(zoneX, zoneZ, level).getAllNpcsSafe()) {
                     if (this.npcs.size >= BuildArea.PREFERRED_NPCS) {
                         return;
                     }
-                    if (!CoordGrid.isWithinDistanceSW({ x, z }, npc, BuildArea.PREFERRED_VIEW_DISTANCE) || npc.nid === -1 || this.npcs.has(npc) || npc.level !== level || npc.x <= absLeftX || npc.x >= absRightX || npc.z >= absTopZ || npc.z <= absBottomZ) {
+                    if (!CoordGrid.isWithinDistanceSW({ x, z }, npc, BuildArea.PREFERRED_VIEW_DISTANCE) || npc.nid === -1 || this.npcs.has(npc) || npc.level !== level) {
                         continue;
                     }
                     yield npc;

--- a/src/engine/entity/BuildArea.ts
+++ b/src/engine/entity/BuildArea.ts
@@ -2,7 +2,6 @@ import {CoordGrid} from '#/engine/CoordGrid.js';
 import Player from '#/engine/entity/Player.js';
 import World from '#/engine/World.js';
 import Npc from '#/engine/entity/Npc.js';
-import { coerceAtLeast, coerceAtMost } from '#/util/Numbers.js';
 
 export default class BuildArea {
     public static readonly INTERVAL: number = 10;
@@ -114,10 +113,10 @@ export default class BuildArea {
     }
 
     *getNearbyNpcs(level: number, x: number, z: number): IterableIterator<Npc> {
-        const startX: number = coerceAtLeast(0, CoordGrid.zone(x - BuildArea.PREFERRED_VIEW_DISTANCE));
-        const startZ: number = coerceAtLeast(0, CoordGrid.zone(z - BuildArea.PREFERRED_VIEW_DISTANCE));
-        const endX: number = coerceAtMost(0x7ff, CoordGrid.zone(x + BuildArea.PREFERRED_VIEW_DISTANCE));
-        const endZ: number = coerceAtMost(0x7ff, CoordGrid.zone(z + BuildArea.PREFERRED_VIEW_DISTANCE));
+        const startX: number = CoordGrid.zone(x - BuildArea.PREFERRED_VIEW_DISTANCE);
+        const startZ: number = CoordGrid.zone(z - BuildArea.PREFERRED_VIEW_DISTANCE);
+        const endX: number = CoordGrid.zone(x + BuildArea.PREFERRED_VIEW_DISTANCE);
+        const endZ: number = CoordGrid.zone(z + BuildArea.PREFERRED_VIEW_DISTANCE);
 
         for (let zx = startX; zx <= endX; zx++) {
             const zoneX: number = zx << 3;

--- a/src/network/rs225/server/codec/NpcInfoEncoder.ts
+++ b/src/network/rs225/server/codec/NpcInfoEncoder.ts
@@ -77,8 +77,8 @@ export default class NpcInfoEncoder extends MessageEncoder<NpcInfo> {
 
     private writeNewNpcs(buf: Packet, updates: Packet, message: NpcInfo, bytes: number): void {
         const { renderer, player } = message;
-        const { buildArea, level, x, z, originX, originZ } = player;
-        for (const npc of buildArea.getNearbyNpcs(level, x, z, originX, originZ)) {
+        const { buildArea, level, x, z } = player;
+        for (const npc of buildArea.getNearbyNpcs(level, x, z)) {
             const nid: number = npc.nid;
             const length: number = renderer.lowdefinitions(nid) + renderer.highdefinitions(nid);
             // bits to add npc + extended info size + bits to break loop (13)

--- a/src/network/rs225/server/codec/PlayerInfoEncoder.ts
+++ b/src/network/rs225/server/codec/PlayerInfoEncoder.ts
@@ -102,8 +102,8 @@ export default class PlayerInfoEncoder extends MessageEncoder<PlayerInfo> {
 
     private writeNewPlayers(buf: Packet, updates: Packet, message: PlayerInfo, bytes: number): void {
         const { renderer, player } = message;
-        const { buildArea, pid, level, x, z, originX, originZ } = player;
-        for (const other of buildArea.getNearbyPlayers(pid, level, x, z, originX, originZ)) {
+        const { buildArea, pid, level, x, z } = player;
+        for (const other of buildArea.getNearbyPlayers(pid, level, x, z)) {
             if (other.visibility === Visibility.HARD) {
                 continue;
             }

--- a/src/util/Numbers.ts
+++ b/src/util/Numbers.ts
@@ -45,3 +45,11 @@ function initMaskArray(): number[] {
     }
     return data;
 }
+
+export function coerceAtMost(value: number, max: number): number {
+    return value > max ? max : value;
+}
+
+export function coerceAtLeast(value: number, min: number): number {
+    return value < min ? min : value;
+}

--- a/src/util/Numbers.ts
+++ b/src/util/Numbers.ts
@@ -45,11 +45,3 @@ function initMaskArray(): number[] {
     }
     return data;
 }
-
-export function coerceAtMost(value: number, max: number): number {
-    return value > max ? max : value;
-}
-
-export function coerceAtLeast(value: number, min: number): number {
-    return value < min ? min : value;
-}


### PR DESCRIPTION
Today we loop 25 zones around the player to search for nearby npcs.

An optimization can be made where, standing on the edge of your zone, will loop 20 zones around you, and standing in the corner of a zone, will loop 16 zones around you.

I also removed the redundant checks, it should not be possible to view players or npcs outside of your build area. The maximum view distance is 15 tiles.

![image](https://github.com/user-attachments/assets/23a2681e-5bca-4def-8d36-0b644ea5c66e)
