### PR TITLE
fix(content): wilderness height check

### DIFF
--- a/data/src/scripts/areas/area_wilderness/configs/wilderness_zones.dbrow
+++ b/data/src/scripts/areas/area_wilderness/configs/wilderness_zones.dbrow
@@ -1,6 +1,6 @@
 [wilderness_zones]
 table=coord_pair_table
 // main wilderness
-data=coord_pair,0_46_55_0_0,0_52_99_63_63
+data=coord_pair,0_46_55_0_0,3_52_99_63_63
 // edgeville dungeon wildy
 data=coord_pair,0_46_155_0_0,0_52_199_63_63


### PR DESCRIPTION
Dark Warrior's Fortress goes up to level 3. For example, checking each coord at the south east ladder:
0,47,56,28,42
1,47,56,28,42
2,47,56,28,42
3,47,56,28,42

Rogues' Castle also goes up to level 3:
0,51,61,17,32
1,51,61,17,32
2,51,61,17,32
3,51,61,17,32

Used the same method as resolving the Tutorial Island height check:
https://github.com/2004Scape/Server/commit/494d404227787a8c02f331215d213f83531ddc93

Tested working at each level