### PR TITLE
fix(engine): clear pending action upon failed packet validations

### DIFF
--- a/src/network/rs225/client/handler/OpHeldHandler.ts
+++ b/src/network/rs225/client/handler/OpHeldHandler.ts
@@ -15,21 +15,25 @@ export default class OpHeldHandler extends MessageHandler<OpHeld> {
 
         const com = Component.get(comId);
         if (typeof com === 'undefined' || !player.isComponentVisible(com)) {
+            player.clearPendingAction();
             return false;
         }
 
         const type = ObjType.get(item);
         if (message.op !== 5 && ((type.iop && !type.iop[message.op - 1]) || !type.iop)) {
+            player.clearPendingAction();
             return false;
         }
 
         const listener = player.invListeners.find(l => l.com === comId);
         if (!listener) {
+            player.clearPendingAction();
             return false;
         }
 
         const inv = player.getInventoryFromListener(listener);
         if (!inv || !inv.validSlot(slot) || !inv.hasAt(slot, item)) {
+            player.clearPendingAction();
             return false;
         }
 

--- a/src/network/rs225/client/handler/OpHeldTHandler.ts
+++ b/src/network/rs225/client/handler/OpHeldTHandler.ts
@@ -15,21 +15,25 @@ export default class OpHeldTHandler extends MessageHandler<OpHeldT> {
 
         const com = Component.get(comId);
         if (typeof com === 'undefined' || !player.isComponentVisible(com)) {
+            player.clearPendingAction();
             return false;
         }
 
         const spellCom = Component.get(spellComId);
         if (typeof spellCom === 'undefined' || !player.isComponentVisible(spellCom)) {
+            player.clearPendingAction();
             return false;
         }
 
         const listener = player.invListeners.find(l => l.com === comId);
         if (!listener) {
+            player.clearPendingAction();
             return false;
         }
 
         const inv = player.getInventoryFromListener(listener);
         if (!inv || !inv.validSlot(slot) || !inv.hasAt(slot, item)) {
+            player.clearPendingAction();
             return false;
         }
 

--- a/src/network/rs225/client/handler/OpHeldUHandler.ts
+++ b/src/network/rs225/client/handler/OpHeldUHandler.ts
@@ -19,23 +19,27 @@ export default class OpHeldUHandler extends MessageHandler<OpHeldU> {
 
         const com = Component.get(comId);
         if (typeof com === 'undefined' || !player.isComponentVisible(com)) {
+            player.clearPendingAction();
             return false;
         }
 
         const useCom = Component.get(comId);
         if (typeof useCom === 'undefined' || !player.isComponentVisible(useCom)) {
+            player.clearPendingAction();
             return false;
         }
 
         {
             const listener = player.invListeners.find(l => l.com === comId);
             if (!listener) {
+                player.clearPendingAction();
                 return false;
             }
 
             const inv = player.getInventoryFromListener(listener);
             if (!inv || !inv.validSlot(slot) || !inv.hasAt(slot, item)) {
                 player.moveClickRequest = false; // removed early osrs
+                player.clearPendingAction();
                 return false;
             }
         }
@@ -43,12 +47,14 @@ export default class OpHeldUHandler extends MessageHandler<OpHeldU> {
         {
             const listener = player.invListeners.find(l => l.com === useComId);
             if (!listener) {
+                player.clearPendingAction();
                 return false;
             }
 
             const inv = player.getInventoryFromListener(listener);
             if (!inv || !inv.validSlot(useSlot) || !inv.hasAt(useSlot, useItem)) {
                 player.moveClickRequest = false; // removed early osrs
+                player.clearPendingAction();
                 return false;
             }
         }

--- a/src/network/rs225/client/handler/OpLocHandler.ts
+++ b/src/network/rs225/client/handler/OpLocHandler.ts
@@ -22,18 +22,21 @@ export default class OpLocHandler extends MessageHandler<OpLoc> {
         const absBottomZ = player.originZ - 52;
         if (x < absLeftX || x > absRightX || z < absBottomZ || z > absTopZ) {
             player.write(new UnsetMapFlag());
+            player.clearPendingAction();
             return false;
         }
 
         const loc = World.getLoc(x, z, player.level, locId);
         if (!loc) {
             player.write(new UnsetMapFlag());
+            player.clearPendingAction();
             return false;
         }
 
         const locType = LocType.get(loc.type);
         if (!locType.op || !locType.op[message.op - 1]) {
             player.write(new UnsetMapFlag());
+            player.clearPendingAction();
             return false;
         }
 

--- a/src/network/rs225/client/handler/OpLocTHandler.ts
+++ b/src/network/rs225/client/handler/OpLocTHandler.ts
@@ -19,6 +19,7 @@ export default class OpLocTHandler extends MessageHandler<OpLocT> {
         const spellCom = Component.get(spellComId);
         if (typeof spellCom === 'undefined' || !player.isComponentVisible(spellCom)) {
             player.write(new UnsetMapFlag());
+            player.clearPendingAction();
             return false;
         }
 
@@ -28,12 +29,14 @@ export default class OpLocTHandler extends MessageHandler<OpLocT> {
         const absBottomZ = player.originZ - 52;
         if (x < absLeftX || x > absRightX || z < absBottomZ || z > absTopZ) {
             player.write(new UnsetMapFlag());
+            player.clearPendingAction();
             return false;
         }
 
         const loc = World.getLoc(x, z, player.level, locId);
         if (!loc) {
             player.moveClickRequest = false;
+            player.clearPendingAction();
             return false;
         }
 

--- a/src/network/rs225/client/handler/OpLocUHandler.ts
+++ b/src/network/rs225/client/handler/OpLocUHandler.ts
@@ -21,6 +21,7 @@ export default class OpLocUHandler extends MessageHandler<OpLocU> {
         const com = Component.get(comId);
         if (typeof com === 'undefined' || !player.isComponentVisible(com)) {
             player.write(new UnsetMapFlag());
+            player.clearPendingAction();
             return false;
         }
 
@@ -29,24 +30,29 @@ export default class OpLocUHandler extends MessageHandler<OpLocU> {
         const absTopZ = player.originZ + 52;
         const absBottomZ = player.originZ - 52;
         if (x < absLeftX || x > absRightX || z < absBottomZ || z > absTopZ) {
+            player.write(new UnsetMapFlag());
+            player.clearPendingAction();
             return false;
         }
 
         const listener = player.invListeners.find(l => l.com === comId);
         if (!listener) {
             player.write(new UnsetMapFlag());
+            player.clearPendingAction();
             return false;
         }
 
         const inv = player.getInventoryFromListener(listener);
         if (!inv || !inv.validSlot(slot) || !inv.hasAt(slot, item)) {
             player.write(new UnsetMapFlag());
+            player.clearPendingAction();
             return false;
         }
 
         const loc = World.getLoc(x, z, player.level, locId);
         if (!loc) {
             player.write(new UnsetMapFlag());
+            player.clearPendingAction();
             return false;
         }
 

--- a/src/network/rs225/client/handler/OpNpcHandler.ts
+++ b/src/network/rs225/client/handler/OpNpcHandler.ts
@@ -19,17 +19,20 @@ export default class OpNpcHandler extends MessageHandler<OpNpc> {
         const npc = World.getNpc(nid);
         if (!npc || npc.delayed) {
             player.write(new UnsetMapFlag());
+            player.clearPendingAction();
             return false;
         }
 
         if (!player.buildArea.npcs.has(npc)) {
             player.write(new UnsetMapFlag());
+            player.clearPendingAction();
             return false;
         }
 
         const npcType = NpcType.get(npc.type);
         if (!npcType.op || !npcType.op[message.op - 1]) {
             player.write(new UnsetMapFlag());
+            player.clearPendingAction();
             return false;
         }
 

--- a/src/network/rs225/client/handler/OpNpcTHandler.ts
+++ b/src/network/rs225/client/handler/OpNpcTHandler.ts
@@ -19,17 +19,20 @@ export default class OpNpcTHandler extends MessageHandler<OpNpcT> {
         const spellCom = Component.get(spellComId);
         if (typeof spellCom === 'undefined' || !player.isComponentVisible(spellCom)) {
             player.write(new UnsetMapFlag());
+            player.clearPendingAction();
             return false;
         }
 
         const npc = World.getNpc(nid);
         if (!npc || npc.delayed) {
             player.write(new UnsetMapFlag());
+            player.clearPendingAction();
             return false;
         }
 
         if (!player.buildArea.npcs.has(npc)) {
             player.write(new UnsetMapFlag());
+            player.clearPendingAction();
             return false;
         }
 

--- a/src/network/rs225/client/handler/OpNpcUHandler.ts
+++ b/src/network/rs225/client/handler/OpNpcUHandler.ts
@@ -21,29 +21,34 @@ export default class OpNpcUHandler extends MessageHandler<OpNpcU> {
         const com = Component.get(comId);
         if (typeof com === 'undefined' || !player.isComponentVisible(com)) {
             player.write(new UnsetMapFlag());
+            player.clearPendingAction();
             return false;
         }
 
         const listener = player.invListeners.find(l => l.com === comId);
         if (!listener) {
             player.write(new UnsetMapFlag());
+            player.clearPendingAction();
             return false;
         }
 
         const inv = player.getInventoryFromListener(listener);
         if (!inv || !inv.validSlot(slot) || !inv.hasAt(slot, item)) {
             player.write(new UnsetMapFlag());
+            player.clearPendingAction();
             return false;
         }
 
         const npc = World.getNpc(nid);
         if (!npc || npc.delayed) {
             player.write(new UnsetMapFlag());
+            player.clearPendingAction();
             return false;
         }
 
         if (!player.buildArea.npcs.has(npc)) {
             player.write(new UnsetMapFlag());
+            player.clearPendingAction();
             return false;
         }
 

--- a/src/network/rs225/client/handler/OpObjHandler.ts
+++ b/src/network/rs225/client/handler/OpObjHandler.ts
@@ -22,12 +22,14 @@ export default class OpObjHandler extends MessageHandler<OpObj> {
         const absBottomZ = player.originZ - 52;
         if (x < absLeftX || x > absRightX || z < absBottomZ || z > absTopZ) {
             player.write(new UnsetMapFlag());
+            player.clearPendingAction();
             return false;
         }
 
         const obj = World.getObj(x, z, player.level, objId, player.hash64);
         if (!obj) {
             player.moveClickRequest = false;
+            player.clearPendingAction();
             return false;
         }
 
@@ -35,6 +37,7 @@ export default class OpObjHandler extends MessageHandler<OpObj> {
         // todo: validate all options
         if ((message.op === 1 && ((objType.op && !objType.op[0]) || !objType.op)) || (message.op === 4 && ((objType.op && !objType.op[3]) || !objType.op))) {
             player.write(new UnsetMapFlag());
+            player.clearPendingAction();
             return false;
         }
 

--- a/src/network/rs225/client/handler/OpObjTHandler.ts
+++ b/src/network/rs225/client/handler/OpObjTHandler.ts
@@ -19,6 +19,7 @@ export default class OpObjTHandler extends MessageHandler<OpObjT> {
         const spellCom = Component.get(spellComId);
         if (typeof spellCom === 'undefined' || !player.isComponentVisible(spellCom)) {
             player.write(new UnsetMapFlag());
+            player.clearPendingAction();
             return false;
         }
 
@@ -28,12 +29,14 @@ export default class OpObjTHandler extends MessageHandler<OpObjT> {
         const absBottomZ = player.originZ - 52;
         if (x < absLeftX || x > absRightX || z < absBottomZ || z > absTopZ) {
             player.write(new UnsetMapFlag());
+            player.clearPendingAction();
             return false;
         }
 
         const obj = World.getObj(x, z, player.level, objId, player.hash64);
         if (!obj) {
             player.write(new UnsetMapFlag());
+            player.clearPendingAction();
             return false;
         }
 

--- a/src/network/rs225/client/handler/OpObjUHandler.ts
+++ b/src/network/rs225/client/handler/OpObjUHandler.ts
@@ -21,6 +21,7 @@ export default class OpObjUHandler extends MessageHandler<OpObjU> {
         const com = Component.get(comId);
         if (typeof com === 'undefined' || !player.isComponentVisible(com)) {
             player.write(new UnsetMapFlag());
+            player.clearPendingAction();
             return false;
         }
 
@@ -30,24 +31,28 @@ export default class OpObjUHandler extends MessageHandler<OpObjU> {
         const absBottomZ = player.originZ - 52;
         if (x < absLeftX || x > absRightX || z < absBottomZ || z > absTopZ) {
             player.write(new UnsetMapFlag());
+            player.clearPendingAction();
             return false;
         }
 
         const listener = player.invListeners.find(l => l.com === comId);
         if (!listener) {
             player.write(new UnsetMapFlag());
+            player.clearPendingAction();
             return false;
         }
 
         const inv = player.getInventoryFromListener(listener);
         if (!inv || !inv.validSlot(slot) || !inv.hasAt(slot, item)) {
             player.write(new UnsetMapFlag());
+            player.clearPendingAction();
             return false;
         }
 
         const obj = World.getObj(x, z, player.level, objId, player.hash64);
         if (!obj) {
             player.write(new UnsetMapFlag());
+            player.clearPendingAction();
             return false;
         }
 

--- a/src/network/rs225/client/handler/OpPlayerHandler.ts
+++ b/src/network/rs225/client/handler/OpPlayerHandler.ts
@@ -18,11 +18,13 @@ export default class OpPlayerHandler extends MessageHandler<OpPlayer> {
         const other = World.getPlayer(pid);
         if (!other) {
             player.write(new UnsetMapFlag());
+            player.clearPendingAction();
             return false;
         }
 
         if (!player.buildArea.players.has(other)) {
             player.write(new UnsetMapFlag());
+            player.clearPendingAction();
             return false;
         }
 

--- a/src/network/rs225/client/handler/OpPlayerTHandler.ts
+++ b/src/network/rs225/client/handler/OpPlayerTHandler.ts
@@ -19,17 +19,20 @@ export default class OpPlayerTHandler extends MessageHandler<OpPlayerT> {
         const spellCom = Component.get(spellComId);
         if (typeof spellCom === 'undefined' || !player.isComponentVisible(spellCom)) {
             player.write(new UnsetMapFlag());
+            player.clearPendingAction();
             return false;
         }
 
         const other = World.getPlayer(pid);
         if (!other) {
             player.write(new UnsetMapFlag());
+            player.clearPendingAction();
             return false;
         }
 
         if (!player.buildArea.players.has(other)) {
             player.write(new UnsetMapFlag());
+            player.clearPendingAction();
             return false;
         }
 

--- a/src/network/rs225/client/handler/OpPlayerUHandler.ts
+++ b/src/network/rs225/client/handler/OpPlayerUHandler.ts
@@ -21,29 +21,34 @@ export default class OpPlayerUHandler extends MessageHandler<OpPlayerU> {
         const com = Component.get(comId);
         if (typeof com === 'undefined' || !player.isComponentVisible(com)) {
             player.write(new UnsetMapFlag());
+            player.clearPendingAction();
             return false;
         }
 
         const listener = player.invListeners.find(l => l.com === comId);
         if (!listener) {
             player.write(new UnsetMapFlag());
+            player.clearPendingAction();
             return false;
         }
 
         const inv = player.getInventoryFromListener(listener);
         if (!inv || !inv.validSlot(slot) || !inv.hasAt(slot, item)) {
             player.write(new UnsetMapFlag());
+            player.clearPendingAction();
             return false;
         }
 
         const other = World.getPlayer(pid);
         if (!other) {
             player.write(new UnsetMapFlag());
+            player.clearPendingAction();
             return false;
         }
 
         if (!player.buildArea.players.has(other)) {
             player.write(new UnsetMapFlag());
+            player.clearPendingAction();
             return false;
         }
 


### PR DESCRIPTION
All of these packets call into `player.clearPendingAction();` anyways, but we need to do it on hard failed handled packets, like menu options, visibility, inventory listeners, etc, things that should be impossible for the client to see or do. I did not add these to any of the `delayed` checks.

![idk 227](https://github.com/user-attachments/assets/ab5d8705-2200-4475-9ea0-8b38633c72a8)