### PR TITLE
fix(content): digsite quest fixes

### DIFF
--- a/data/src/pack/varp.pack
+++ b/data/src/pack/varp.pack
@@ -130,13 +130,13 @@
 129=shop_haggle
 130=blackknight_progress
 131=itexam_progress
-132=thieving_stall_timer
-133=varp_133
+132=itexam_errands
+133=itexam_bits
 134=varp_134
 135=varp_135
 136=varp_136
 137=varp_137
-138=varp_138
+138=thieving_stall_timer
 139=legends_progress
 140=book_page
 141=gnome_bar_progress

--- a/data/src/scripts/_unpack/all.varp
+++ b/data/src/scripts/_unpack/all.varp
@@ -153,11 +153,6 @@ type=player_uid
 
 [skill_sound]
 
-[thieving_stall_timer]
-scope=perm
-
-[varp_133]
-
 [varp_134]
 
 [varp_135]
@@ -166,7 +161,8 @@ scope=perm
 
 [varp_137]
 
-[varp_138]
+[thieving_stall_timer]
+scope=perm
 
 [legends_progress]
 scope=perm

--- a/data/src/scripts/areas/area_varrock/scripts/curator.rs2
+++ b/data/src/scripts/areas/area_varrock/scripts/curator.rs2
@@ -1,32 +1,9 @@
 [opnpc1,curator]
 ~chatnpc("<p,neutral>Welcome to the museum of Varrock.");
-if (inv_total(inv, unstamped_letter) > 0) {
-    ~chatplayer("<p,neutral>I have been given this letter by an examiner at the Dig Site. Can you stamp this for me?");
-    ~chatnpc("<p,neutral>What we have here? A letter of recommendation indeed...");
-    // TODO: I'm not sure if this variance was available in the original 2004 port or not (likely not based on the rsc video)
-    if (%phoenixgang_progress = ^phoenixgang_complete | %blackarmgang_progress = ^blackarmgang_complete) {
-        ~chatnpc("<p,neutral>The letter here says your name is <displayname>. Well, <displayname>, I wouldn't normally do this for just anyone, but as you did such a great service with the Shielf of Arrav I don't see why not. Run this letter back to the Examiner to begin your adventure into the world of Earth Sciences. Enjoy your studies, Student!");
-    } else if (%romeojuliet_progress = ^romeojuliet_spoken_father) {
-        ~chatnpc("<p,neutral>The letter here says your name is <displayname>. Well, <displayname>, I wouldn't normally do this for just anyone, but I heard what you did for Romeo and Juliet so I don't see why not. Run this letter back to the Examiner to begin your adventure into the world of Earth Sciences. Enjoy your studies, Student!");
-    } else {
-        ~chatnpc("<p,neutral>The letter here says your name is <displayname>. Well, <displayname>, I wouldn't normally do this for just anyone, but in this instance I don't see why not. Run this letter back to the Examiner to begin your adventure into the world of Earth Sciences. Enjoy your studies, Student!");
-    }
-    // osrs sets varbit 2552 (varp 135, bit 9) to 1 signifying we've already stamped once, if we bring another letter to stamp the curator will instead say
-    // player: I have another letter here; could you stamp it for me again?
-    // curator <confused>: You've already given me one of those! But... ok, give it here...
-    // player: Thanks!
-
-    // another fun fact is that osrs clears this varbit after quest completion, meaning we can go back to the curator and get the initial dialogue again
-
-    // there's also this if we loose all the stamped letters and are still in the %itexam_progress = ^itexam_stamping quest stage
-    // player <sad>: I seem to have lost the letter of recommendation that you stamped for me.
-    // curator: Yes, I saw you drop it as you walked off last time. Here it is.
-    // player: Thanks!
-    inv_del(inv, unstamped_letter, 1);
-    inv_add(inv, stamped_letter, 1);
-    ~chatnpc("<p,neutral>There you go, good luck student... Be sure to come back and show me your certificates. I would like to see how you get on.");
-    ~chatplayer("<p,neutral>Ok, I will. Thanks, see you later.");
-}
+if (inv_total(inv, unstamped_letter) > 0) @curator_stamp_letter;
+if (inv_total(inv, level_1_certificate) > 0) @curator_level_1;
+if (inv_total(inv, level_2_certificate) > 0) @curator_level_2;
+if (inv_total(inv, level_3_certificate) > 0) @curator_level_3;
 if(%phoenixgang_progress = ^phoenixgang_joined | %blackarmgang_progress = ^blackarmgang_joined) {
     if(inv_total(inv, arravshield1) > 0 & inv_total(inv, arravshield2) > 0) { // mostly 1-1 with RSC
         ~chatplayer("<p,quiz>I have retrieved the shield of Arrav|and I would like to claim my reward.");
@@ -60,4 +37,64 @@ if($option = 1) {
     ~chatnpc("<p,neutral>Look around you! This museum is full of treasures!");
     ~chatplayer("<p,sad>No, I meant treasures for ME.");
     ~chatnpc("<p,neutral>Any treasures this museum knows about it goes to great lengths to acquire.");
+}
+
+[opnpcu,curator]
+switch_obj(last_useitem) {
+    case unstamped_letter : @curator_stamp_letter;
+    case stamped_letter : ~chatnpc("<p,confused>No, I don't want it back, thank you.");
+    case level_1_certificate : @curator_level_1;
+    case level_2_certificate : @curator_level_2;
+    case level_3_certificate : @curator_level_3;
+    case default : ~displaymessage(^dm_default);
+}
+
+[label,curator_stamp_letter]
+~chatplayer("<p,happy>I have been given this letter by an examiner at the Dig Site. Can you stamp this for me?");
+~chatnpc("<p,confused>What we have here? A letter of recommendation indeed...");
+~chatnpc("<p,happy>Normally I wouldn't do this...|But in this instance I don't see why not.");
+// osrs sets varbit 2552 (varp 135, bit 9) to 1 signifying we've already stamped once, if we bring another letter to stamp the curator will instead say
+// player: I have another letter here; could you stamp it for me again?
+// curator <confused>: You've already given me one of those! But... ok, give it here...
+// player: Thanks!
+
+// another fun fact is that osrs clears this varbit after quest completion, meaning we can go back to the curator and get the initial dialogue again
+
+// there's also this if we loose all the stamped letters and are still in the %itexam_progress = ^itexam_stamping quest stage
+// player <sad>: I seem to have lost the letter of recommendation that you stamped for me.
+// curator: Yes, I saw you drop it as you walked off last time. Here it is.
+// player: Thanks!
+inv_del(inv, unstamped_letter, 1);
+inv_add(inv, stamped_letter, 1);
+~chatnpc("<p,happy>There you go, good luck student...|Be sure to come back and show me your certificates.|I would like to see how you get on.");
+ ~chatplayer("<p,happy>Okay, I will. Thanks, see you later.");
+
+
+[label,curator_level_1]
+inv_del(inv, level_1_certificate, 1);
+~chatplayer("<p,happy>Look what I have been awarded.");
+~chatnpc("<p,happy>Well that's great, well done.|I'll take that for safekeeping;|come and tell me when you are the next level.");
+
+[label,curator_level_2]
+inv_del(inv, level_2_certificate, 1);
+~chatplayer("<p,happy>Look, I am level 2 now...");
+~chatnpc("<p,happy>Excellent work!|I'll take that for safe keeping,|remember to come and see me when you have graduated.");
+
+[label,curator_level_3]
+inv_del(inv, level_3_certificate, 1);
+~chatplayer("<p,happy>Look at this certificate, curator...");
+~chatnpc("<p,happy>Well, well - a level 3 graduate!|I'll keep your certificate safe for you.|I feel I must reward you for your work...");
+~chatnpc("<p,neutral>What would you prefer: something to eat or drink?");
+switch_int(~p_choice2("Something to eat please.", 1, "Something to drink please.", 2)) { 
+    case 1 :
+        ~chatplayer("<p,happy>Something to eat please.");
+        inv_add(inv, chocolate_cake, 1);
+        ~chatnpc("<p,happy>Very good! Come and eat this cake I baked!");
+    case 2 : 
+        ~chatnpc("<p,happy>Certainly, have this...");
+        inv_add(inv, fruit_blast, 1);
+        ~chatplayer("<p,quiz>A cocktail?");
+        ~chatnpc("<p,happy>It's a new recipe from the gnome kingdom.|You'll like it I'm sure!");
+        ~chatplayer("<p,happy>Cheers!");
+        ~chatnpc("<p,happy>Cheers!");
 }

--- a/data/src/scripts/quests/quest_itexam/configs/quest_itexam.constant
+++ b/data/src/scripts/quests/quest_itexam/configs/quest_itexam.constant
@@ -10,19 +10,14 @@
 ^itexam_removed_blockage = 8
 ^itexam_complete = 9
 
-^itexam_errands_offset = 4
-
 ^itexam_errand_student1 = 0
 ^itexam_errand_student2 = 1
 ^itexam_errand_student3 = 2
-
-^itexam_bits_offset = 12
 
 ^itexam_bit_panning_guide_tea_given = 1
 ^itexam_bit_winch_rope_attached = 2
 ^itexam_bit_private_winch_rope_attached = 3
 ^itexam_bit_barrel_open = 4
 ^itexam_bit_stone_tablet_taken = 5
-^itexam_bit_searched_bricks = 6
 ^itexam_bit_shown_ancient_symbol = 7
 ^itexam_bit_stamped_letter = 9

--- a/data/src/scripts/quests/quest_itexam/configs/quest_itexam.varp
+++ b/data/src/scripts/quests/quest_itexam/configs/quest_itexam.varp
@@ -1,2 +1,8 @@
 [itexam_progress]
 scope=perm
+
+[itexam_errands]
+scope=perm
+
+[itexam_bits]
+scope=perm

--- a/data/src/scripts/quests/quest_itexam/scripts/area_digsite.rs2
+++ b/data/src/scripts/quests/quest_itexam/scripts/area_digsite.rs2
@@ -441,6 +441,7 @@ def_int $rand = random(20);
 
 if ($rand < 2) {
     mes("You find nothing.");
+    return;
 } else if ($rand < 3) {
     if (~itexam_testbit(^itexam_bit_shown_ancient_symbol) = false & inv_total(inv, talisman_of_zaros) = 0) {
         inv_add(inv, talisman_of_zaros, 1);
@@ -705,7 +706,6 @@ facesquare(0_52_53_25_25);
 if (~itexam_progress = ^itexam_poured_compound_on_bricks) {
     ~chatplayer("<p,neutral>The brick is covered with the chemicals I made.");
 } else {
-    ~itexam_setbit(^itexam_bit_searched_bricks);
     ~chatplayer("<p,neutral>Hmmm, there's a room past these bricks. If I could move them out of the way then I could find out what's inside. Maybe there's someone around here who can help...");
 }
 

--- a/data/src/scripts/quests/quest_itexam/scripts/digsite_workman.rs2
+++ b/data/src/scripts/quests/quest_itexam/scripts/digsite_workman.rs2
@@ -112,7 +112,7 @@ if(stat_random(stat(thieving), 100, 240) = false) {
 [opnpcu,digsite_workman]
 if (last_useitem = invitation_letter) {
     inv_del(inv, invitation_letter, 1);
-    ~itexam_set_progress(^itexam_mineshaft_permit);
+    if(%itexam_progress = ^itexam_impress_archeological_expert) ~itexam_set_progress(^itexam_mineshaft_permit);
     ~chatplayer("<p,happy>Here, have a look at this...");
     ~chatnpc("<p,bored>I give permission... blah de blah... etc. Okay, that's all in order; you may use the mineshaft now. I'll hang onto this scroll, shall I?");
 } else {

--- a/data/src/scripts/quests/quest_itexam/scripts/examiner.rs2
+++ b/data/src/scripts/quests/quest_itexam/scripts/examiner.rs2
@@ -44,12 +44,12 @@ if ($choice = 1) {
 ////////////////////////////////////////////////
 
 [label,itexam_examiner_deliver_stamped_letter]
-~chatplayer("<p,neutral>Hello.");
-~chatnpc("<p,neutral>Hello again.");
+~chatplayer("<p,happy>Hello.");
+~chatnpc("<p,happy>Hello again.");
 
 if (inv_total(inv, stamped_letter) > 0) {
-    ~chatplayer("<p,neutral>Here is the stamped letter you asked for.");
-    ~chatnpc("<p,neutral>Good, good. We will begin the exam...");
+    ~chatplayer("<p,happy>Here is the stamped letter you asked for.");
+    ~chatnpc("<p,happy>Good good, we will begin the exam...");
     inv_del(inv, stamped_letter, ^max_32bit_int);
     ~itexam_set_progress(^itexam_first_exam);
     @itexam_examiner_first_exam;
@@ -58,22 +58,22 @@ if (inv_total(inv, stamped_letter) > 0) {
         ~mesbox("Perhaps you should fetch the Letter of Recommendation from your bank before talking to the examiner.");
         return;
     }
-    ~chatnpc("<p,neutral>I am still waiting for your letter of recommendation.");
+    ~chatnpc("<p,confused>I am still waiting for your letter of recommendation.");
     def_int $choice = ~p_choice2("I have lost the letter you gave me.", 1, "Alright I'll try and get it.", 2);
 
     if ($choice = 1) {
         ~chatplayer("<p,sad>I have lost the letter you gave me.");
-        if (inv_total(inv, unstamped_letter) > 0) {
-            ~chatnpc("<p,neutral>Oh now come on. You have it with you!");
-        } else if (inv_total(bank, unstamped_letter) > 0) {
-            ~chatnpc("<p,neutral>You already have the letter in your bank.");
+        if (inv_total(bank, unstamped_letter) > 0) {
+            ~chatnpc("<p,confused>You already have the letter in your bank.");
+        } else if (inv_total(inv, unstamped_letter) > 0) {
+            ~chatnpc("<p,confused>Oh now come on. You have it with you!");
         } else {
             inv_add(inv, unstamped_letter, 1);
-            ~chatnpc("<p,sad>That was foolish. Take this one and don't lose it!");
+            ~chatnpc("<p,angry>That was foolish. Take this one and don't lose it!");
         }
     } else {
         ~chatplayer("<p,neutral>Alright I'll try and get it.");
-        ~chatnpc("<p,neutral>I am sure you won't get any problems. Speak to the Curator of Varrock's museum.");
+        ~chatnpc("<p,happy>I am sure you won't get any problems. Speak to the Curator of Varrock's museum.");
     }
 }
 
@@ -82,16 +82,16 @@ if (inv_total(inv, stamped_letter) > 0) {
 ////////////////////////////////////////////////
 
 [label,itexam_examiner_take_first_exam]
-~chatplayer("<p,neutral>Hello.");
-~chatnpc("<p,neutral>Hello again. Are you ready for another shot at the exam?");
+~chatplayer("<p,happy>Hello.");
+~chatnpc("<p,happy>Hello again. Are you ready for another shot at the exam?");
 def_int $choice = ~p_choice2("Yes, I certainly am.", 1, "No, not at the moment.", 2);
 
 if ($choice = 1) {
-    ~chatplayer("<p,neutral>Yes, I certainly am.");
+    ~chatplayer("<p,happy>Yes, I certainly am.");
     @itexam_examiner_first_exam;
 } else {
     ~chatplayer("<p,neutral>No, not at the moment.");
-    ~chatnpc("<p,neutral>Okay, take your time if you wish.");
+    ~chatnpc("<p,happy>Okay, take your time if you wish.");
 }
 
 ////////////////////////////////////////////////
@@ -154,7 +154,7 @@ def_int $q1choice;
 def_int $q2choice;
 def_int $q3choice;
 
-~chatnpc("<p,neutral>Okay, we will start with the first exam: Earth Sciences level 1 - Beginner.");
+~chatnpc("<p,happy>Okay, we will start with the first exam: Earth Sciences level 1 - Beginner.");
 ~chatnpc("<p,neutral>Question 1 - Earth Sciences overview. Can you tell me what Earth Science is?");
 
 if (~itexam_errand_progress(^itexam_errand_student1) = 2) {
@@ -229,7 +229,7 @@ if (~itexam_errand_progress(^itexam_errand_student3) = 2) {
     }
 }
 ~chatnpc("<p,neutral>That concludes the exam for Earth Sciences level 1.");
-~chatnpc("<p,neutral>Let's see how you did...");
+~chatnpc("<p,happy>Let's see how you did...");
 
 def_int $correct_answer_count = 0;
 

--- a/data/src/scripts/quests/quest_itexam/scripts/panning_guide.rs2
+++ b/data/src/scripts/quests/quest_itexam/scripts/panning_guide.rs2
@@ -21,8 +21,8 @@ if (~itexam_testbit(^itexam_bit_panning_guide_tea_given) = false) {
 if (inv_total(inv, cup_of_tea) > 0) {
     ~chatplayer("<p,happy>I've some here that you can have.");
     inv_del(inv, cup_of_tea, 1);
-    ~chatnpc("<p,happy>Ah! Lovely! You can't beat a good cuppa... You're free to pan all you want.");
     ~itexam_setbit(^itexam_bit_panning_guide_tea_given);
+    ~chatnpc("<p,happy>Ah! Lovely! You can't beat a good cuppa... You're free to pan all you want.");
 } else {
     ~chatplayer("<p,shock>Tea?!");
     ~chatnpc("<p,happy>Absolutely, I'm parched!");

--- a/data/src/scripts/quests/quest_itexam/scripts/private_dig_worker.rs2
+++ b/data/src/scripts/quests/quest_itexam/scripts/private_dig_worker.rs2
@@ -6,27 +6,59 @@ switch_int (~itexam_progress) {
 
 [label,digsite_workman_cave_default]
 ~chatplayer("<p,happy>Hello.");
-~chatnpc("<p,confused>Well, well... I have a visitor. What are you doing here?");
-
-if (~itexam_testbit(^itexam_bit_searched_bricks) = true) {
-    @multi4("I have been invited to research here.", digsite_workman_cave_invited_to_research, "I am not sure really.", digsite_workman_cave_not_sure, "I'm here to get rich, rich, rich!", digsite_workman_cave_not_rich_rich, "How could I move a large pile of rocks?", digsite_workman_cave_move_pile_of_rocks);
-} else {
-    @multi3("I have been invited to research here.", digsite_workman_cave_invited_to_research, "I am not sure really.", digsite_workman_cave_not_sure, "I'm here to get rich, rich, rich!", digsite_workman_cave_not_rich_rich);
-}
+~chatnpc("<p,confused>Well, well...|I have a visitor.|What are you doing here?");
+@multi3("I have been invited to research here.", digsite_workman_cave_invited_to_research, "I am not sure really.", digsite_workman_cave_not_sure, "I'm here to get rich, rich, rich!", digsite_workman_cave_not_rich_rich);
 
 [label,digsite_workman_cave_invited_to_research]
 ~chatplayer("<p,happy>I have been invited to research here.");
-~chatnpc("<p,happy>Indeed, you must be someone special to be allowed down here.");
+~chatnpc("<p,happy>Indeed, you must be someone special to be allowed down here...");
 
-def_int $choice = ~p_choice2("Do you know where to find a specimen jar?", 1, "I have things to do...", 2);
+def_int $choice = ~p_choice2("Do you know where to find a specimen jar?", 1, "Do you know where to find a chest key?", 2);
 
 if ($choice = 1) {
     ~chatplayer("<p,neutral>Do you know where to find a specimen jar?");
     ~chatnpc("<p,quiz>Hmmm, let me think... Nope, can't help you there I'm afraid.");
 } else {
-    ~chatplayer("<p,neutral>I have things to do...");
-    ~chatnpc("<p,happy>Of course, don't let me keep you.");
+    // https://web.archive.org/web/20060909012420/http://www.runeweb.net/index.php?page=rs2-quest-digsite, "Pickpocket a workmen to get two ropes and go down the northern wench. Beg the workmen till he gives you a key to a chest."
+    ~chatplayer("<p,neutral>Do you know where to find a chest key?"); // whole chain is from RSC, so guessing mesanims from here on unfortunately
+    ~chatnpc("<p,neutral>Yes, I might have one...");
+    @multi3("I don't suppose I could use it?", digsite_workman_usekey, "Can I buy it from you?", digsite_workman_buykey, "Hey that's my key!", digsite_workman_mykey);
 }
+
+[label,digsite_workman_usekey]
+~chatplayer("<p,quiz>I don't suppose I could use it?");
+~chatnpc("<p,sad>Aww, but I need it...");
+@multi3("Please?", digsite_workman_please, "Can I buy it from you?", digsite_workman_buykey, "Hey that's my key!", digsite_workman_mykey);
+
+[label,digsite_workman_please]
+~chatplayer("<p,happy>Please?");
+~chatnpc("<p,confused>I am not sure about this...");
+@multi3("Aww... go on.", digsite_workman_aww, "Can I buy it from you?", digsite_workman_buykey, "Hey that's my key!", digsite_workman_mykey);
+
+[label,digsite_workman_aww]
+~chatplayer("<p,happy>Aww... go on.");
+~chatnpc("<p,confused>Hmmm... well I don't know.");
+@multi3("Pretty please!", digsite_workman_please2, "Can I buy it from you?", digsite_workman_buykey, "Hey that's my key!", digsite_workman_mykey);
+
+[label,digsite_workman_please2]
+~chatplayer("<p,happy>Pretty please!");
+~chatnpc("<p,confused>You are trying to change my mind.");
+~chatplayer("<p,happy>Of course!");
+@multi3("Pretty please with sugar on top!", digsite_workman_please3, "Can I buy it from you?", digsite_workman_buykey, "Hey that's my key!", digsite_workman_mykey);
+
+[label,digsite_workman_please3]
+~chatplayer("<p,happy>Pretty please with sugar on top!");
+inv_add(inv, digsite_chest_key, 1);
+~chatnpc("<p,neutral>All right, all right!|Stop begging I can't stand it.|Here's the key... take care of it.");
+~chatplayer("<p,happy>Thanks!");
+
+[label,digsite_workman_buykey]
+~chatplayer("<p,quiz>Can I buy it from you?");
+~chatnpc("<p,neutral>Ooo no, I need it!");
+
+[label,digsite_workman_mykey]
+~chatplayer("<p,happy>Hey that's my key!");
+~chatnpc("<p,angry>You don't think im going to fall for that do you?|Get lost!");
 
 [label,digsite_workman_cave_not_sure]
 ~chatplayer("<p,confused>I am not sure really.");
@@ -35,15 +67,6 @@ if ($choice = 1) {
 [label,digsite_workman_cave_not_rich_rich]
 ~chatplayer("<p,happy>I'm here to get rich, rich, rich!");
 ~chatnpc("<p,happy>Oh, well, don't forget that wealth and riches aren't everything.");
-
-[label,digsite_workman_cave_move_pile_of_rocks]
-~chatplayer("<p,quiz>How do you move a large pile of rocks?");
-~chatnpc("<p,neutral>There used to be this chap that worked in the other shaft. He was working on an explosive chemical mixture to be used for clearing blocked areas underground.");
-~chatnpc("<p,confused>He left in a hurry one day; something in the shaft scared him to death, but he didn't say what.");
-~chatplayer("<p,quiz>Oh?");
-~chatnpc("<p,shifty>Rumour has it he'd been writing a book on his chemical mixture. I'm not sure what goes in it but I'm sure you'll find the stuff he was using scattered around the digsite. He left so quickly he didn't take anything with him. In fact, I still have a chest key he gave me to look after; perhaps it's more useful to you.");
-inv_add(inv, digsite_chest_key, 1);
-~objbox(digsite_chest_key, "Doug hands you a key.", 250, 0, divide(^objbox_height, 2));
 
 [label,digsite_workman_cave_quest_complete]
 ~chatnpc("<p,neutral>Well, hello again. Congratulations on your finds");

--- a/data/src/scripts/quests/quest_itexam/scripts/quest_itexam.rs2
+++ b/data/src/scripts/quests/quest_itexam/scripts/quest_itexam.rs2
@@ -20,18 +20,18 @@ return (getbit_range(%itexam_progress, 0, 3));
 
 [proc,itexam_errand_progress](int $errand)(int)
 // we're reserving 2 bits for each errand, 0 = not started, 1 = in progress, 2 = complete
-def_int $bit_start = calc(^itexam_errands_offset + $errand * 2);
-return (getbit_range(%itexam_progress, $bit_start, calc($bit_start + 1)));
+def_int $bit_start = calc($errand * 2);
+return (getbit_range(%itexam_errands, $bit_start, calc($bit_start + 1)));
 
 [proc,itexam_set_errand_progress](int $errand, int $progress)
-def_int $bit_start = calc(^itexam_errands_offset + $errand * 2);
-%itexam_progress = setbit_range_toint(%itexam_progress, $progress, $bit_start, calc($bit_start + 1));
+def_int $bit_start = calc($errand * 2);
+%itexam_errands = setbit_range_toint(%itexam_errands, $progress, $bit_start, calc($bit_start + 1));
 
 [proc,itexam_testbit](int $bit)(boolean)
-return (testbit(%itexam_progress, calc(^itexam_bits_offset + $bit)));
+return (testbit(%itexam_bits, $bit));
 
 [proc,itexam_setbit](int $bit)
-%itexam_progress = setbit(%itexam_progress, calc(^itexam_bits_offset + $bit));
+%itexam_bits = setbit(%itexam_bits, $bit);
 
 [queue,itexam_complete]
 ~itexam_set_progress(^itexam_complete);

--- a/data/src/scripts/quests/quest_itexam/scripts/student1.rs2
+++ b/data/src/scripts/quests/quest_itexam/scripts/student1.rs2
@@ -73,7 +73,8 @@ inv_del(inv, rock_sample_1, ^max_32bit_int);
 ~chatplayer("<p,happy>I need more help with the exam.");
 ~chatnpc("<p,happy>Well ok, this is what I have learned since I last spoke to you...");
 ~itexam_set_errand_progress(^itexam_errand_student1, 2);
-~chatnpc("<p,neutral>Correct rock pick usage: Always handle with care; strike the rock cleanly on its cleaving point.");
+// https://web.archive.org/web/20060909012420im_/http://www.runeweb.net/fireball/Digsite%20Images/digsite8.png
+~chatnpc("<p,neutral>Correct rockpick usage:|Always handle with care,|strike the rock cleanly on its cleaving point.");
 ~chatplayer("<p,happy>Okay, I'll remember that.");
 
 [label,itexam_student1_third_exam_tips]
@@ -81,5 +82,6 @@ inv_del(inv, rock_sample_1, ^max_32bit_int);
 ~chatplayer("<p,happy>I need more help with the exam.");
 ~chatnpc("<p,happy>Well ok, this is what I have learned since I last spoke to you...");
 ~itexam_set_errand_progress(^itexam_errand_student1, 2);
-~chatnpc("<p,neutral>Specimen brush use: Brush carefully and slowly using short strokes.");
+// https://web.archive.org/web/20060909012420im_/http://www.runeweb.net/fireball/Digsite%20Images/digsite12.png
+~chatnpc("<p,neutral>Specimen brush use:|Brush carefully and slowly using short strokes.");
 ~chatplayer("<p,happy>Okay, I'll remember that. Thanks for all your help.");

--- a/data/src/scripts/quests/quest_itexam/scripts/student2.rs2
+++ b/data/src/scripts/quests/quest_itexam/scripts/student2.rs2
@@ -55,7 +55,8 @@ if ($errand_state = 0) {
     ~chatnpc("<p,happy>How's it going?");
     ~chatplayer("<p,neutral>There are more exam questions I'm stuck on.");
     ~chatnpc("<p,happy>Hey, I'll tell you what I've learned. That may help.");
-    ~chatnpc("<p,neutral>The people eligible to use the digsite are: All that have passed the appropriate Earth Sciences exams.");
+    // https://web.archive.org/web/20060909012420im_/http://www.runeweb.net/fireball/Digsite%20Images/digsite7.png
+    ~chatnpc("<p,neutral>The eligible people to use the digsite are:|All that have passed the appropriate earth sciences exams.");
     ~chatplayer("<p,happy>Thanks for the information.");
 }
 
@@ -64,7 +65,7 @@ if ($errand_state = 0) {
 inv_del(inv, rock_sample_2, ^max_32bit_int);
 ~itexam_set_errand_progress(^itexam_errand_student2, 2);
 ~chatnpc("<p,happy>Excellent! I'm so happy. Let me now help you with your exams...");
-~chatnpc("<p,neutral>The people eligible to use the digsite are: All that have passed the appropriate Earth Sciences exams.");
+~chatnpc("<p,neutral>The eligible people to use the digsite are:|All that have passed the appropriate earth sciences exams.");
 ~chatplayer("<p,happy>Thanks for the information.");
 
 [label,itexam_student2_second_exam_tips]
@@ -73,7 +74,8 @@ inv_del(inv, rock_sample_2, ^max_32bit_int);
 ~chatplayer("<p,neutral>There are more exam questions I'm stuck on.");
 ~chatnpc("<p,happy>Hey, I'll tell you what I've learned. That may help.");
 ~itexam_set_errand_progress(^itexam_errand_student2, 2);
-~chatnpc("<p,neutral>Correct sample transportation: Samples taken in rough form; kept only in sealed containers.");
+// https://web.archive.org/web/20060909012420im_/http://www.runeweb.net/fireball/Digsite%20Images/digsite9.png
+~chatnpc("<p,neutral>Correct sample transportation:|Samples taken in rough form,|kept only in sealed containers.");
 ~chatplayer("<p,happy>Thanks for the information.");
 
 [label,itexam_student2_third_exam_tips]
@@ -82,5 +84,6 @@ inv_del(inv, rock_sample_2, ^max_32bit_int);
 ~chatplayer("<p,neutral>There are more exam questions I'm stuck on.");
 ~chatnpc("<p,happy>Hey, I'll tell you what I've learned. That may help.");
 ~itexam_set_errand_progress(^itexam_errand_student2, 2);
-~chatnpc("<p,neutral>The proper technique for handling bones is: Handle bones carefully and keep them away from other samples.");
+// https://web.archive.org/web/20060909012420im_/http://www.runeweb.net/fireball/Digsite%20Images/digsite13.png
+~chatnpc("<p,neutral>The proper technique for handling bones is:|Handle bones carefully|and keep away from other samples.");
 ~chatplayer("<p,happy>Thanks for the information.");

--- a/data/src/scripts/quests/quest_itexam/scripts/student3.rs2
+++ b/data/src/scripts/quests/quest_itexam/scripts/student3.rs2
@@ -52,7 +52,8 @@ if ($errand_state = 0) {
     ~chatnpc("<p,happy>How's it going?");
     ~chatplayer("<p,confused>I am stuck on some more exam questions.");
     ~chatnpc("<p,happy>Okay, I'll tell you my latest notes...");
-    ~chatnpc("<p,neutral>The proper health and safety points are: Leather gloves and boots to be worn at all times; proper tools must be used.");
+    // https://web.archive.org/web/20060909012420im_/http://www.runeweb.net/fireball/Digsite%20Images/digsite6.png
+    ~chatnpc("<p,neutral>The proper health and safety points are:|Leather gloves and boots to be worn at all times,|proper tools must be used.");
     ~chatplayer("<p,happy>Great, thanks for your advice.");
 }
 
@@ -61,7 +62,7 @@ if ($errand_state = 0) {
 inv_del(inv, rock_sample_3, ^max_32bit_int);
 ~itexam_set_errand_progress(^itexam_errand_student3, 2);
 ~chatnpc("<p,happy>Hey! My sample! Thanks ever so much. Let me help you with those questions now.");
-~chatnpc("<p,neutral>The proper health and safety points are: Leather gloves and boots to be worn at all times; proper tools must be used.");
+~chatnpc("<p,neutral>The proper health and safety points are:|Leather gloves and boots to be worn at all times,|proper tools must be used.");
 ~chatplayer("<p,happy>Great, thanks for your advice.");
 
 [label,itexam_student3_second_exam_tips]
@@ -69,7 +70,8 @@ inv_del(inv, rock_sample_3, ^max_32bit_int);
 ~chatplayer("<p,confused>I am stuck on some more exam questions.");
 ~chatnpc("<p,happy>Okay, I'll tell you my latest notes...");
 ~itexam_set_errand_progress(^itexam_errand_student3, 2);
-~chatnpc("<p,neutral>Finds handling: Finds must be carefully handled, and gloves worn.");
+// https://web.archive.org/web/20060909012420im_/http://www.runeweb.net/fireball/Digsite%20Images/digsite10.png
+~chatnpc("<p,neutral>Finds handling:|Finds must be carefully handled, and gloves worn.");
 ~chatplayer("<p,happy>Great, thanks for your advice.");
 
 [label,itexam_student3_third_exam_tips]
@@ -96,7 +98,8 @@ if ($errand_state = 0) {
         ~chatnpc("<p,happy>Wow, great, you've found one. This will look beautiful set in my necklace. Thanks for that; now I'll tell you what I know...");
         inv_del(inv, opal, 1);
         ~itexam_set_errand_progress(^itexam_errand_student3, 2);
-        ~chatnpc("<p,neutral>Sample preparation: Samples cleaned, and carried only in specimen jars.");
+        // https://web.archive.org/web/20060909012420im_/http://www.runeweb.net/fireball/Digsite%20Images/digsite11.png
+        ~chatnpc("<p,neutral>Sample preparation:|Samples cleaned and carried only in specimen jars.");
         ~chatplayer("<p,happy>Great, thanks for your advice.");
     } else {
         ~chatplayer("<p,sad>I haven't found one yet.");
@@ -106,7 +109,7 @@ if ($errand_state = 0) {
     ~chatnpc("<p,happy>How's it going?");
     ~chatplayer("<p,confused>I am stuck on some more exam questions.");
     ~chatnpc("<p,happy>Okay, I'll tell you my latest notes...");
-    ~chatnpc("<p,neutral>Sample preparation: Samples cleaned, and carried only in specimen jars.");
+    ~chatnpc("<p,neutral>Sample preparation:|Samples cleaned and carried only in specimen jars.");
     ~chatplayer("<p,happy>Great, thanks for your advice.");
 }
 


### PR DESCRIPTION
- move bits used for itexam out of the progress varp and into varp 132/133, move thieving timer to 138
- add interactions for level 1/2/3 cert to the varrock curator
- don't send the clean message if you find nothing from level-3 digging
- alter flow for getting the key from the digsite workman to match RSC/pre-rework
- adjusted some dialogue/mesanims based off old images/OSRS 