### PR TITLE
fix(content): p_stopaction on pvp stuns

### DIFF
--- a/data/src/scripts/_test/scripts/engine/debug_walktrigger.rs2
+++ b/data/src/scripts/_test/scripts/engine/debug_walktrigger.rs2
@@ -1,0 +1,20 @@
+[debugproc,stunned](int $stun)
+if (p_finduid(uid) = false) {
+    return;
+}
+%stunned = add(map_clock, $stun);
+walktrigger(stunned);
+
+[debugproc,pvpstun1]
+if (p_finduid(uid) = true) {
+    p_teleport(0_49_73_61_35);
+    inv_add(inv, naturerune, 100);
+    inv_add(inv, earthrune, 100);
+    inv_add(inv, waterrune, 100);
+    stat_add(magic, 255, 0);
+}
+
+[debugproc,pvpstun2]
+if (p_finduid(uid) = true) {
+    p_teleport(0_49_73_61_45);
+}

--- a/data/src/scripts/skill_combat/scripts/pvp/pvp_magic.rs2
+++ b/data/src/scripts/skill_combat/scripts/pvp/pvp_magic.rs2
@@ -170,6 +170,9 @@ if ($freeze_time > 0) {
     if (~.check_protect_prayer(^magic_style) = true) {
         $freeze_time = divide($freeze_time, 2); // 50% reduction https://oldschool.runescape.wiki/w/Update:RS2_bugfixes_-_part_4
     }
+    if (.p_finduid(.uid) = true) {
+        .p_stopaction;
+    }
     .%pk_binder = uid;
     .queue(pvp_freeze_player, 0, $freeze_time);
 }
@@ -255,7 +258,7 @@ return($maxhit);
 
 [queue,pvp_freeze_player](int $duration)
 mes("You've been frozen!");
-%frozen = calc(map_clock + $duration + 1);
+%frozen = calc(map_clock + $duration);
 walktrigger(pvp_frozen);
 
 


### PR DESCRIPTION
Sound doesnt play for a tick (I yellow click at 389 ticks and sound begins at 391 ticks)

https://github.com/user-attachments/assets/bc0ff4e6-9ba6-42b8-9ab9-7f142696cd9e


PVP freezes are definitely queued, lasts 8 ticks after the p_delay is over:

https://github.com/user-attachments/assets/d7ea41d5-aaa1-4a03-88ae-34e3514f97f3

Us with fixes:

https://github.com/user-attachments/assets/33db18c5-39e9-4bdf-9ab0-f9a98f43633e



Also lets us remove the +1's in the pvp stun length :D.