### PR TITLE
fix(content): npc on 0 hp when meleeing behavior

### DIFF
--- a/data/src/scripts/skill_combat/scripts/npc/npc_combat_melee.rs2
+++ b/data/src/scripts/skill_combat/scripts/npc/npc_combat_melee.rs2
@@ -35,10 +35,14 @@ if (randominc($attack_roll) > randominc($defence_roll)) {
 //~damage_self($damage);
 if_close; // close the player interface when taking a hit.
 // not sure if this is correct
+~npc_set_attack_vars;
+if (npc_stat(hitpoints) = 0) {
+    return; // melee npc's on 0 health play the hit animation but dont actually damage you
+    // but ranged/mage npcs do! This is unique to melee!
+}
 queue(damage_player, 0, $damage);
 if (npc_param(poison_severity) > 0 & $damage > 0) {
     queue(poison_player, 0, npc_param(poison_severity));
 }
 queue(playerhit_n_retaliate, 0, npc_uid); // this should be a queue* command
 %npc_action_delay = add(map_clock, $delay);
-~npc_set_attack_vars;


### PR DESCRIPTION
in osrs melee npcs cant deal damage when they're at 0 hp. Still sets the attack vars though