### PR TITLE
fix(content): thessalia dialogue, bunny_ears, scythe

### DIFF
--- a/data/src/pack/varp.pack
+++ b/data/src/pack/varp.pack
@@ -5,8 +5,8 @@
 4=mcannon_coord
 5=grail_progress
 6=coal_truck
-7=varp_7
-8=varp_8
+7=bunny_ears_unlocked
+8=scythe_unlocked
 9=beehive_free
 10=cog_progress
 11=fishingcompo_progress

--- a/data/src/scripts/_test/scripts/cheats/cheat_reset.rs2
+++ b/data/src/scripts/_test/scripts/cheats/cheat_reset.rs2
@@ -110,6 +110,8 @@ if (p_finduid(uid) = true) {
     %tutorial_progress = 0;
     %chompybird_progress = 0;
     %chompybird_kills = 0;
+    %bunny_ears_unlocked = 0;
+    %scythe_unlocked = 0;
 
     p_logout;
 } else {

--- a/data/src/scripts/_unpack/all.varp
+++ b/data/src/scripts/_unpack/all.varp
@@ -1,6 +1,8 @@
-[varp_7]
+[bunny_ears_unlocked]
+scope=perm
 
-[varp_8]
+[scythe_unlocked]
+scope=perm
 
 [damagetype]
 protect=no

--- a/data/src/scripts/areas/area_varrock/scripts/thessalia.rs2
+++ b/data/src/scripts/areas/area_varrock/scripts/thessalia.rs2
@@ -1,14 +1,81 @@
 // source: https://www.youtube.com/watch?v=VK_A2Vf9VE8
-// todo: options to retrieve scythe/bunny ears
 
 [opnpc1,thessalia]
-~chatnpc("<p,happy>Do you want to buy any fine clothes?");
-@multi2("What have you got?", thessalia_b1_s1, "No, thank you.", thessalia_b1_s2);
+if (%bunny_ears_unlocked = 0 & %scythe_unlocked = 0) { // player has not unlocked bunny_ears or scythe
+    @thessalia_want_to_buy;
+} else if (%bunny_ears_unlocked = 1 & %scythe_unlocked = 1) { // player unlocked both
+    if ((inv_total(inv, bunny_ears) >= 1 | inv_total(bank, bunny_ears) >= 1 | inv_total(worn, bunny_ears) >= 1) &
+        (inv_total(inv, scythe) >= 1 | inv_total(bank, scythe) >= 1 | inv_total(worn, scythe) >= 1)) { // player unlocked both, and has both
+        @thessalia_want_to_buy;
+    } else if (inv_total(inv, bunny_ears) >= 1 | inv_total(bank, bunny_ears) >= 1 | inv_total(worn, bunny_ears) >= 1) { // player unlocked both, but lost scythe
+        ~chatnpc("<p,happy>Do you want to buy any fine clothes? Or would you like your scythe back?");
+        @thessalia_lost_scythe;
+    } else if (inv_total(inv, scythe) >= 1 | inv_total(bank, scythe) >= 1 | inv_total(worn, scythe) >= 1) { // player unlocked both, but lost bunny_ears
+        ~chatnpc("<p,happy>Do you want to buy any fine clothes? Or would you like your bunny ears back?");
+        @thessalia_lost_bunny_ears;
+    } else { // player unlocked both, but lost both
+        ~chatnpc("<p,happy>Do you want to buy any fine clothes? Or would you like your scythe and bunny ears back?");
+        @thessalia_lost_bunny_ears_and_scythe;
+    }
+} else if (%bunny_ears_unlocked = 1 & %scythe_unlocked = 0) { // player unlocked bunny_ears, not scythe
+    if (inv_total(inv, bunny_ears) >= 1 | inv_total(bank, bunny_ears) >= 1 | inv_total(worn, bunny_ears) >= 1) { //player unlocked bunny_ears, and has bunny_ears
+        @thessalia_want_to_buy;
+    } else { // player unlocked bunny_ears, but lost bunny ears
+        ~chatnpc("<p,quiz>Do you want to buy any fine clothes? Or would you like your bunny ears back?");
+        @thessalia_lost_bunny_ears;
+    }
+} else if (%bunny_ears_unlocked = 0 & %scythe_unlocked = 1) { // player unlocked scythe, not bunny_ears
+    if (inv_total(inv, scythe) >= 1 | inv_total(bank, scythe) >= 1 | inv_total(worn, scythe) >= 1) { // player unlocked scythe, and has scythe
+        @thessalia_want_to_buy;
+    } else { // player unlocked scythe, but lost scythe
+        ~chatnpc("<p,happy>Do you want to buy any fine clothes? Or would you like your scythe back?");
+        @thessalia_lost_scythe;
+    }
+}
+
+[label,thessalia_want_to_buy]
+~chatnpc("<p,quiz>Do you want to buy any fine clothes?");
+@thessalia_what_have_you_got;
+
+[label,thessalia_what_have_you_got]
+@multi2("What have you got?", thessalia_b1_s1,
+        "No, thank you.", thessalia_b1_s2);
+
+[label,thessalia_lost_bunny_ears]
+@multi3("What have you got?", thessalia_b1_s1,
+        "No, thank you.", thessalia_b1_s2,
+        "Can I have my bunny ears back?", thessalia_return_bunny_ears);
+
+[label,thessalia_lost_scythe]
+@multi3("What have you got?", thessalia_b1_s1,
+        "No, thank you.", thessalia_b1_s2,
+        "Can I have my scythe back?", thessalia_return_scythe);
+
+[label,thessalia_lost_bunny_ears_and_scythe] 
+@multi4("What have you got?", thessalia_b1_s1,
+        "No, thank you.", thessalia_b1_s2,
+        "Can I have my scythe back?", thessalia_return_scythe,
+        "Can I have my bunny ears back?", thessalia_return_bunny_ears);
+
+[label,thessalia_return_scythe]
+~chatplayer("<p,quiz>Can I have my scythe back?");
+~chatnpc("<p,happy>Certainly. Here you go.");
+inv_add(inv, scythe, 1);
+~chatnpc("<p,quiz>Now, would you like to buy any clothes?");
+@thessalia_what_have_you_got;
+
+[label,thessalia_return_bunny_ears]
+~chatplayer("<p,quiz>Can I have my bunny ears back?");
+~chatnpc("<p,happy>Certainly. Here you go.");
+inv_add(inv, bunny_ears, 1);
+~chatnpc("<p,quiz>Now, would you like to buy any clothes?");
+@thessalia_what_have_you_got;
 
 [label,thessalia_b1_s1]
 ~chatplayer("<p,quiz>What have you got?"); 
 ~chatnpc("<p,happy>Well, I have a number of fine pieces of clothing on sale or, if you prefer I can offer you an exclusive, total clothing makeover?");
-@multi2("Tell me more about this makeover.", thessalia_b2_s1, "I'd just like to buy some clothes.", thessalia_b2_s2);
+@multi2("Tell me more about this makeover.", thessalia_b2_s1,
+        "I'd just like to buy some clothes.", thessalia_b2_s2);
 
 [label,thessalia_b1_s2]
 ~chatplayer("<p,neutral>No, thank you.");
@@ -20,7 +87,10 @@
 ~chatnpc("<p,happy>Here at Thessalia's fine clothing boutique, we offer a unique service where we will totally revamp your outfit to your choosing, for... wait for it...");
 ~chatnpc("<p,happy>A fee of only 500 gold coins! Tired of always wearing the same old outfit, day in, day out? This is the service for you!");
 ~chatnpc("<p,happy>So what do you say? Interested? We can change either your top, or your legwear for only 500 gold an item!");
-@multi4("I'd like to change my top please.", thessalia_b3_s1, "I'd like to change my legwear please.", thessalia_b3_s2, "I'd just like to buy some clothes.", thessalia_b2_s2, "No, thank you.", thessalia_b1_s2);
+@multi4("I'd like to change my top please.", thessalia_b3_s1,
+        "I'd like to change my legwear please.", thessalia_b3_s2,
+        "I'd just like to buy some clothes.", thessalia_b2_s2,
+        "No, thank you.", thessalia_b1_s2);
 
 [label,thessalia_b3_s1]
 %option1 = 0;

--- a/data/src/scripts/player/scripts/untradeable_holiday_items.rs2
+++ b/data/src/scripts/player/scripts/untradeable_holiday_items.rs2
@@ -1,0 +1,22 @@
+// this file may be better somewhere else, but is currently used to track untradeable holiday items
+
+// message: https://runescape.wiki/w/Scythe
+[opobj3,scythe]
+if (inv_total(inv, scythe) >= 1 | inv_total(bank, scythe) >= 1 | inv_total(worn, scythe) >= 1) {
+    mes("You already have a scythe, you don't need another one.");
+    return;
+} else {
+    %scythe_unlocked = 1; //currently the only place this is set. if they are introduced to the game in another way, this needs setting elsewhere
+    @pickup_obj(obj_coord, obj_type, obj_count);
+}
+
+// RSC message: https://classic.runescape.wiki/w/Bunny_ears#/media/File:Collecting_Bunny_Ears_(only_have_one_head).jpg
+[opobj3,bunny_ears]
+if (inv_total(inv, bunny_ears) >= 1 | inv_total(bank, bunny_ears) >= 1 | inv_total(worn, bunny_ears) >= 1) {
+    mes("You don't need another set of bunny ears.");
+    mes("You only have one head.");
+    return;
+} else {
+    %bunny_ears_unlocked = 1; //currently the only place this is set. if they are introduced to the game in another way, this needs setting elsewhere
+    @pickup_obj(obj_coord, obj_type, obj_count);
+}

--- a/data/src/scripts/skill_magic/scripts/spells/telegrab.rs2
+++ b/data/src/scripts/skill_magic/scripts/spells/telegrab.rs2
@@ -32,7 +32,7 @@ if((oc_category(obj_type) = trail_clue_easy | oc_category(obj_type) = trail_clue
 }
 // These use a different mes compared to obj's with the telegrab_disabled param (maybe make a 2nd param)
 if(obj_type = holy_grail | obj_type = ghost_skull | obj_type = ice_arrow | obj_type = boy_ball | obj_type = Ethenea | obj_type = liquid_honey | obj_type = sulphuric_broline | obj_type = plague_sample | (oc_category(obj_type) = cog)
-    | obj_type = orb_of_light1 | obj_type = orb_of_light2 | obj_type = orb_of_light3 | obj_type = orb_of_light4 | obj_type = fire_feather | obj_type = grips_keyring) {
+    | obj_type = orb_of_light1 | obj_type = orb_of_light2 | obj_type = orb_of_light3 | obj_type = orb_of_light4 | obj_type = fire_feather | obj_type = grips_keyring | obj_type = bunny_ears | obj_type = scythe) {
     mes("I can't use Telekinetic Grab on this object.");
     return;
 }


### PR DESCRIPTION
### **untradeable_holiday_items.rs2:**
New file, as there doesn't seem to be anywhere else appropriate. Any suggestions welcome. It's in `data\src\scripts\player\scripts` which also contains `pickup.rs2`, `cracker.rs2`, which are semi-related and is personal to the player. Is there a better place for this? I considered renaming `cracker.rs2` to `holiday_items.rs2`, and merge together to reduce clutter and cover any future items (`rubber_chicken` hype??).

The intention is, which is tested as working:

- `scythe`:
- - If you try pick up a `scythe`, and you don't already have one, pick it up and set `%scythe_unlocked = 1`
- - If you try pick up a `scythe`, and you do already have one, don't allow it

- `bunny_ears`:
- - If you try pick up `bunny_ears`, and you don't already them, pick it up and set `%bunny_ears_unlocked = 1`
- - If you try pick up a `bunny_ears`, and you do already have one, don't allow it

Example, picking up a `scythe` after resetting the varp:
![image](https://github.com/user-attachments/assets/29f6fed1-397f-4aea-9572-fc51ec3cb16f)


Setting these varps means the items are retrievable from Thessalia once you've unlocked them. If they are introduced in any other way, other than picking them up off the ground, these varps need to be set in a different way.

__________

### **varp.pack / all.varp**
I'm not sure how to create a new varp without getting an error. I noticed in a recent PR that existing varps were replaced and used. So for this I replaced varp_7 and varp_8. If this should be done differently please let me know.
Example varp_133 and varp_138 replacement: https://github.com/2004Scape/Server/commit/7d2c20a49ace073d274d48d4ed22b9372efe5643#diff-9073420bf978748137737c1955094de93363739ad59d436e43a8165cc6fa34dd



 which is why I used varp_7 and varp_8

__________

### **cheat_reset.rs2**
Clear the new `%bunny_ears_unlocked` and `%scythe_unlocked varps`

__________

### **telegrab.rs2:**
Cannot telegrab Bunny ears or Scythe:
https://classic.runescape.wiki/w/Scythe
https://classic.runescape.wiki/w/Bunny_ears

__________

### **thessalia.rs2:**
Dialogue is different in RSC, but the rest of the dialogue currently matches OSRS so I went with that:
https://oldschool.runescape.wiki/w/Transcript:Thessalia

Facial animations also updated