### PR TITLE
fix(content): trading not accounting for stackable objs correctly

### DIFF
--- a/data/src/scripts/interface_trade/scripts/trade.rs2
+++ b/data/src/scripts/interface_trade/scripts/trade.rs2
@@ -148,36 +148,70 @@ if (.finduid(%tradepartner) = true) {
 
 [proc,enough_trade_space]()(boolean)
 // check if contents of tempinv fits in other player's inv
+def_int $space = .inv_freespace(inv);
+def_int $fails = 0;
 def_int $size = inv_size(tempinv);
 def_int $slot = 0;
 while ($slot < $size) {
     def_obj $obj = inv_getobj(tempinv, $slot);
-    def_int $num = inv_getnum(tempinv, $slot);
-
     if ($obj ! null) {
-        if (.inv_itemspace(inv, $obj, $num, sub(.inv_size(inv), $slot)) = false) {
-            return(false);
+        if (oc_stackable($obj) = true) {
+            def_int $total = .inv_total(inv, $obj);
+            if ($total > 0) {
+                if (calc(^max_32bit_int - $total - inv_getnum(tempinv, $slot)) < 0) {
+                    return(false);
+                }
+            } else {
+                $space = sub($space, 1);
+                if ($space < 0) {
+                    $fails = add($fails, 1);
+                }
+            }
+        } else {
+            $space = sub($space, 1);
+            if ($space < 0) {
+                $fails = add($fails, 1);
+            }
         }
     }
-
     $slot = add($slot, 1);
+}
+if ($fails > 0) {
+    return(false);
 }
 return(true);
 
 [proc,.enough_trade_space]()(boolean)
+def_int $space = inv_freespace(inv);
+def_int $fails = 0;
 def_int $size = .inv_size(tempinv);
 def_int $slot = 0;
 while ($slot < $size) {
     def_obj $obj = .inv_getobj(tempinv, $slot);
-    def_int $num = .inv_getnum(tempinv, $slot);
-
     if ($obj ! null) {
-        if (inv_itemspace(inv, $obj, $num, sub(inv_size(inv), $slot)) = false) {
-            return(false);
+        if (oc_stackable($obj) = true) {
+            def_int $total = inv_total(inv, $obj);
+            if ($total > 0) {
+                if (calc(^max_32bit_int - $total - .inv_getnum(tempinv, $slot)) < 0) {
+                    return(false);
+                }
+            } else {
+                $space = sub($space, 1);
+                if ($space < 0) {
+                    $fails = add($fails, 1);
+                }
+            }
+        } else {
+            $space = sub($space, 1);
+            if ($space < 0) {
+                $fails = add($fails, 1);
+            }
         }
     }
-
     $slot = add($slot, 1);
+}
+if ($fails > 0) {
+    return(false);
 }
 return(true);
 

--- a/data/src/scripts/interface_trade/scripts/trade.rs2
+++ b/data/src/scripts/interface_trade/scripts/trade.rs2
@@ -149,7 +149,6 @@ if (.finduid(%tradepartner) = true) {
 [proc,enough_trade_space]()(boolean)
 // check if contents of tempinv fits in other player's inv
 def_int $space = .inv_freespace(inv);
-def_int $fails = 0;
 def_int $size = inv_size(tempinv);
 def_int $slot = 0;
 while ($slot < $size) {
@@ -164,26 +163,22 @@ while ($slot < $size) {
             } else {
                 $space = sub($space, 1);
                 if ($space < 0) {
-                    $fails = add($fails, 1);
+                    return(false);
                 }
             }
         } else {
             $space = sub($space, 1);
             if ($space < 0) {
-                $fails = add($fails, 1);
+                return(false);
             }
         }
     }
     $slot = add($slot, 1);
 }
-if ($fails > 0) {
-    return(false);
-}
 return(true);
 
 [proc,.enough_trade_space]()(boolean)
 def_int $space = inv_freespace(inv);
-def_int $fails = 0;
 def_int $size = .inv_size(tempinv);
 def_int $slot = 0;
 while ($slot < $size) {
@@ -198,20 +193,17 @@ while ($slot < $size) {
             } else {
                 $space = sub($space, 1);
                 if ($space < 0) {
-                    $fails = add($fails, 1);
+                    return(false);
                 }
             }
         } else {
             $space = sub($space, 1);
             if ($space < 0) {
-                $fails = add($fails, 1);
+                return(false);
             }
         }
     }
     $slot = add($slot, 1);
-}
-if ($fails > 0) {
-    return(false);
 }
 return(true);
 


### PR DESCRIPTION
Doing `sub(.inv_size(inv), $slot)` does not work if the obj is stackable, for `inv_itemspace`.

### Before
![idk 229](https://github.com/user-attachments/assets/02e4c0c2-bcb3-45b2-b59c-659226243ec4)

### After
![idk 230](https://github.com/user-attachments/assets/3738d1e6-949f-4066-8bac-e08ec2bd31ea)
