### PR TITLE
fix(engine): fix run energy to recover while walking with run enabled

### DIFF
--- a/src/engine/entity/Player.ts
+++ b/src/engine/entity/Player.ts
@@ -542,7 +542,7 @@ export default class Player extends PathingEntity {
     }
 
     private recoverEnergy(moved: boolean): void {
-        if (!this.delayed && (!moved || this.moveSpeed !== MoveSpeed.RUN) && this.runenergy < 10000) {
+        if (!this.delayed && (!moved || this.stepsTaken < 2) && this.runenergy < 10000) {
             const recovered = (this.baseLevels[PlayerStat.AGILITY] / 9 | 0) + 8;
             this.runenergy = Math.min(this.runenergy + recovered, 10000);
         }


### PR DESCRIPTION
players previously would not gain run energy while following another player who is walking if they had run enabled. 

https://youtu.be/ZRzDMzTRMT8?t=376 shows a player with run energy enabled restoring run energy while pathing to another player who is walking. This behavior was inconsistent with both attacking and following other players on 2004Scape. Checking stepsTaken < 2 instead of MoveSpeed.RUN recovers energy at the same rate, while allowing for proper restoration while pathing towards others