### PR TITLE
fix(content): Fix message received when woodcutting without axe

### DIFF
--- a/data/src/scripts/skill_woodcutting/scripts/woodcut.rs2
+++ b/data/src/scripts/skill_woodcutting/scripts/woodcut.rs2
@@ -210,7 +210,7 @@ if (($obj1 = bronze_axe | inv_total(inv, bronze_axe) > 0)) {
 // mes("You need an axe to chop down this tree."); // this message was added in 2005 when they fixed axe wc reqs
 // https://imgur.com/Cj7w6y9
 // https://imgur.com/fnmlJ7R
-mes("You do not have an axe which you have the woodcutting level to use.");
+mes("You do not have an axe which you have the level to use.");
 return(null);
 
 [proc,woodcutting_successchance](dbrow $data, namedobj $axe)(int, int)


### PR DESCRIPTION
Previously, the message was "You do not have an axe which you have the woodcutting level to use.".

This doesn't seem authentic according to images I have seen, including those commented in the code. It does not mention 'woodcutting' in the message authentically.