### PR TITLE
Fix dragon slayer softlock

### DIFF
--- a/data/src/scripts/areas/area_draynor/scripts/ned.rs2
+++ b/data/src/scripts/areas/area_draynor/scripts/ned.rs2
@@ -2,16 +2,16 @@
 // Treasure Trail
 if(map_members = true & inv_total(inv, trail_clue_easy_simple_exp021) = 1) {
     @trail_ned;
-} else if (%dragon_ned_hired > 0) {
-    // ned got the job
-    // looks like dragon slayer overrides neds standard dialogue https://youtu.be/kCMB4I_aJJM?t=129
-    @ned_dragon_slayer_hired;
 } else if (%dragon_progress = ^quest_dragon_sailed_to_crandor) {
     // really dont know if ned should still have this after the quest is finished. 
     // Osrs does and its kinda weird because you can ask him to sail you back, 
     // with him agreeing. Even though you cant access the ship anymore.
     // For now i'll just make it so he doesnt have it after the quest is finished.
     @ned_dragon_slayer_back_in_draynor_after_visiting_crandor;
+} else if (%dragon_ned_hired > 0) {
+    // ned got the job
+    // looks like dragon slayer overrides neds standard dialogue https://youtu.be/kCMB4I_aJJM?t=129
+    @ned_dragon_slayer_hired;
 } else {
     @standard_ned;
 }

--- a/data/src/scripts/areas/area_draynor/scripts/ned.rs2
+++ b/data/src/scripts/areas/area_draynor/scripts/ned.rs2
@@ -184,7 +184,7 @@ if ($choice = 1) {
         ~chatnpc("<p,neutral>I said I would and old Ned is a man of his word!"); // osrs
         ~chatnpc("<p,quiz>So where's your ship?");
         @ned_so_wheres_your_ship;
-    } else if (%dragon_progress = ^quest_dragon_ned_given_map) {
+    } else if ((%dragon_progress = ^quest_dragon_ned_given_map | %dragon_progress = ^quest_dragon_sailed_to_crandor)) {
         ~chatnpc("<p,neutral>I said I would and old Ned is a man of his word! I'll meet you on board the Lady Lumbridge in Port Sarim.");
         return;
     }


### PR DESCRIPTION
A player (bog) died while fighting elvarg and could not get back to crandor.

![bug](https://github.com/user-attachments/assets/42ea50fe-3fee-4efc-badc-449aa69d0ef5)

I think there were two issues

1. A dialogue issue where Ned asks for a map, despite you handing it to him. This is because we check only for `quest_dragon_ned_given_map` however once sailed to crandor you're set to `quest_dragon_sailed_to_crandor`

2. The dialogue handler for ned would default to `@ned_dragon_slayer_hired` which does not allow the player to re-hire ned. I changed it so that the dialogue handler will first check to see if you have been to crandor. 

Now players should be able to re-hire ned, fix the ship, and meet him in port sarim.

