### PR TITLE
fix(content): check if rock golem sw tile has LOW with player

### DIFF
--- a/data/src/scripts/macro events/scripts/macro_events.rs2
+++ b/data/src/scripts/macro events/scripts/macro_events.rs2
@@ -222,7 +222,10 @@ while ($i < 50) {
     $nw = movecoord($sw, 1, 0, 0);
     $se = movecoord($sw, 0, 0, 1);
     $ne = movecoord($sw, 1, 0, 1);
-    if (map_blocked($sw) = false & map_blocked($nw) = false & map_blocked($se) = false & map_blocked($ne) = false & lineofwalk($sw, $ne) = true & $sw ! coord & $se ! coord & $nw ! coord & $ne ! coord){
+    if (map_blocked($sw) = false & map_blocked($nw) = false & map_blocked($se) = false & map_blocked($ne) = false
+        & $sw ! coord & $se ! coord & $nw ! coord & $ne ! coord
+        & lineofwalk($sw, coord) = true
+        ){
         return($sw);
     }
     $i = calc($i + 1);


### PR DESCRIPTION
No good way to confirm this is how it works but it seems like something they'd do. Notably it only checks LOW with the sw tile, I could add LOW check for all 4 tiles but we have like no source for this. This is probably fine?