### PR TITLE
fix(engine): Refactor and organize player interactions, match interaction behavior closer to documented rs2 mechanics

### DIFF
--- a/src/engine/entity/Player.ts
+++ b/src/engine/entity/Player.ts
@@ -1,7 +1,7 @@
 import 'dotenv/config';
 
 import Packet from '#/io/Packet.js';
-import {toDisplayName} from '#/util/JString.js';
+import { toDisplayName } from '#/util/JString.js';
 
 import FontType from '#/cache/config/FontType.js';
 import Component from '#/cache/config/Component.js';
@@ -13,27 +13,27 @@ import ScriptVarType from '#/cache/config/ScriptVarType.js';
 import SeqType from '#/cache/config/SeqType.js';
 import VarPlayerType from '#/cache/config/VarPlayerType.js';
 import ParamType from '#/cache/config/ParamType.js';
-import {ParamHelper} from '#/cache/config/ParamHelper.js';
+import { ParamHelper } from '#/cache/config/ParamHelper.js';
 
 import BlockWalk from '#/engine/entity/BlockWalk.js';
-import {EntityTimer, PlayerTimerType} from '#/engine/entity/EntityTimer.js';
-import {EntityQueueRequest, PlayerQueueType, QueueType, ScriptArgument} from '#/engine/entity/EntityQueueRequest.js';
+import { EntityTimer, PlayerTimerType } from '#/engine/entity/EntityTimer.js';
+import { EntityQueueRequest, PlayerQueueType, QueueType, ScriptArgument } from '#/engine/entity/EntityQueueRequest.js';
 import Loc from '#/engine/entity/Loc.js';
 import Npc from '#/engine/entity/Npc.js';
 import MoveRestrict from '#/engine/entity/MoveRestrict.js';
 import Obj from '#/engine/entity/Obj.js';
 import PathingEntity from '#/engine/entity/PathingEntity.js';
-import {CoordGrid} from '#/engine/CoordGrid.js';
+import { CoordGrid } from '#/engine/CoordGrid.js';
 import CameraInfo from '#/engine/entity/CameraInfo.js';
 import MoveSpeed from '#/engine/entity/MoveSpeed.js';
 import EntityLifeCycle from '#/engine/entity/EntityLifeCycle.js';
-import {PlayerStat, PlayerStatEnabled, PlayerStatFree} from '#/engine/entity/PlayerStat.js';
+import { PlayerStat, PlayerStatEnabled, PlayerStatFree } from '#/engine/entity/PlayerStat.js';
 import MoveStrategy from '#/engine/entity/MoveStrategy.js';
 import BuildArea from '#/engine/entity/BuildArea.js';
 import HeroPoints from '#/engine/entity/HeroPoints.js';
-import {isClientConnected} from '#/engine/entity/NetworkPlayer.js';
+import { isClientConnected } from '#/engine/entity/NetworkPlayer.js';
 
-import {Inventory} from '#/engine/Inventory.js';
+import { Inventory } from '#/engine/Inventory.js';
 import World from '#/engine/World.js';
 
 import ScriptFile from '#/engine/script/ScriptFile.js';
@@ -46,9 +46,9 @@ import ScriptPointer from '#/engine/script/ScriptPointer.js';
 import LinkList from '#/util/LinkList.js';
 import DoublyLinkList from '#/util/DoublyLinkList.js';
 
-import {CollisionFlag} from '@2004scape/rsmod-pathfinder';
+import { CollisionFlag } from '@2004scape/rsmod-pathfinder';
 
-import {PRELOADED, PRELOADED_CRC} from '#/cache/PreloadedPacks.js';
+import { PRELOADED, PRELOADED_CRC } from '#/cache/PreloadedPacks.js';
 
 import OutgoingMessage from '#/network/server/OutgoingMessage.js';
 import IfClose from '#/network/server/model/IfClose.js';
@@ -413,8 +413,8 @@ export default class Player extends PathingEntity {
     triggerZone(level: number, x: number, z: number) {
         const mx = x >> 6;
         const mz = z >> 6;
-        const lx = (x & 0x3f) >> 3 << 3;
-        const lz = (z & 0x3f) >> 3 << 3;
+        const lx = ((x & 0x3f) >> 3) << 3;
+        const lz = ((z & 0x3f) >> 3) << 3;
         const trigger = ScriptProvider.getByName(`[zone,${level}_${mx}_${mz}_${lx}_${lz}]`);
         if (trigger) {
             this.enqueueScript(trigger, PlayerQueueType.ENGINE);
@@ -424,8 +424,8 @@ export default class Player extends PathingEntity {
     triggerZoneExit(level: number, x: number, z: number) {
         const mx = x >> 6;
         const mz = z >> 6;
-        const lx = (x & 0x3f) >> 3 << 3;
-        const lz = (z & 0x3f) >> 3 << 3;
+        const lx = ((x & 0x3f) >> 3) << 3;
+        const lz = ((z & 0x3f) >> 3) << 3;
         const trigger = ScriptProvider.getByName(`[zoneexit,${level}_${mx}_${mz}_${lx}_${lz}]`);
         if (trigger) {
             this.enqueueScript(trigger, PlayerQueueType.ENGINE);
@@ -543,7 +543,7 @@ export default class Player extends PathingEntity {
 
     private recoverEnergy(moved: boolean): void {
         if (!this.delayed && (!moved || this.moveSpeed !== MoveSpeed.RUN) && this.runenergy < 10000) {
-            const recovered = (this.baseLevels[PlayerStat.AGILITY] / 9 | 0) + 8;
+            const recovered = ((this.baseLevels[PlayerStat.AGILITY] / 9) | 0) + 8;
             this.runenergy = Math.min(this.runenergy + recovered, 10000);
         }
     }
@@ -668,7 +668,6 @@ export default class Player extends PathingEntity {
                 }
             }
         }
-
     }
 
     processQueues() {
@@ -837,10 +836,10 @@ export default class Player extends PathingEntity {
     }
     // https://youtu.be/_NmFftkMm0I?si=xSgb8GCydgUXUayR&t=79
     // to allow p_walk (sets player destination tile) during walktriggers
-    // we process walktriggers from regular movement in client input, 
+    // we process walktriggers from regular movement in client input,
     // and for each interaction.
     processWalktrigger() {
-        if (this.walktrigger !== -1 && (!this.protect && !this.delayed)) {
+        if (this.walktrigger !== -1 && !this.protect && !this.delayed) {
             const trigger = ScriptProvider.get(this.walktrigger);
             this.walktrigger = -1;
             if (trigger) {
@@ -850,77 +849,55 @@ export default class Player extends PathingEntity {
         }
     }
 
-    processInteraction() {
-        if (this.target === null || !this.canAccess()) {
-            this.updateMovement(false);
-            return;
-        }
+    defaultOp() {
+        const opTrigger = this.getOpTrigger();
+        const apTrigger = this.getApTrigger();
 
-        if (this.target.level !== this.level || (this.target instanceof Player && this.target.visibility !== Visibility.DEFAULT)) {
-            this.clearInteraction();
-            this.unsetMapFlag(); // assuming its right
-            return;
-        }
-
-        if (this.target instanceof Npc && (typeof World.getNpc(this.target.nid) === 'undefined' || this.target.delayed)) {
-            this.clearInteraction();
-            this.unsetMapFlag();
-            return;
-        }
-
-        // this is effectively checking if the npc did a changetype
-        if (this.target instanceof Npc && this.targetSubject.type !== -1 && World.getNpcByUid((this.targetSubject.type << 16) | this.target.nid) === null) {
-            this.clearInteraction();
-            this.unsetMapFlag();
-            return;
-        }
-
-        if (this.target instanceof Obj && World.getObj(this.target.x, this.target.z, this.level, this.target.type, this.hash64) === null) {
-            this.clearInteraction();
-            this.unsetMapFlag();
-            return;
-        }
-
-        if (this.target instanceof Loc && World.getLoc(this.target.x, this.target.z, this.level, this.target.type) === null) {
-            this.clearInteraction();
-            this.unsetMapFlag();
-            return;
-        }
-
-        if (this.target instanceof Player && World.getPlayerByUid(this.target.uid) === null) {
-            this.clearInteraction();
-            this.unsetMapFlag();
-            return;
-        }
-        if (this.targetOp === ServerTriggerType.APPLAYER3 || this.targetOp === ServerTriggerType.OPPLAYER3) {
-            const walktrigger: number = this.walktrigger;
-            if (this.hasWaypoints()) {
-                this.processWalktrigger();
-            }    
-            const moved: boolean = this.updateMovement(false);    
-            if (!moved && walktrigger !== -1 && this.target instanceof Player && (this.x !== this.target.lastStepX || this.z !== this.target.lastStepZ)) {
-                this.clearInteraction();
-                this.unsetMapFlag();
+        if (!Environment.NODE_PRODUCTION && !opTrigger && !apTrigger) {
+            let debugname = '_';
+            if (this.target instanceof Npc) {
+                debugname = NpcType.get(this.target.type)?.debugname ?? this.target.type.toString();
+            } else if (this.target instanceof Loc) {
+                debugname = LocType.get(this.target.type)?.debugname ?? this.target.type.toString();
+            } else if (this.target instanceof Obj) {
+                debugname = ObjType.get(this.target.type)?.debugname ?? this.target.type.toString();
+            } else if ((this.targetSubject.com !== -1 && this.targetOp === ServerTriggerType.APNPCT) || this.targetOp === ServerTriggerType.APPLAYERT || this.targetOp === ServerTriggerType.APLOCT || this.targetOp === ServerTriggerType.APOBJT) {
+                debugname = Component.get(this.targetSubject.com)?.comName ?? this.targetSubject.toString();
+            } else if (this.targetSubject.type !== -1) {
+                debugname = ObjType.get(this.targetSubject.type)?.debugname ?? this.targetSubject.toString();
             }
-            return;
+
+            this.messageGame(`No trigger for [${ServerTriggerType[this.targetOp + 7].toLowerCase()},${debugname}]`);
         }
-        if (!this.interactWalkTrigger || this.hasWaypoints()) {
-            this.processWalktrigger();
-            this.interactWalkTrigger = true;
+
+        this.target = null;
+        this.messageGame('Nothing interesting happens.');
+        this.interacted = true;
+        this.clearWaypoints();
+    }
+
+    tryInteraction(allowOpScenery: boolean) {
+        if (this.target === null || !this.canAccess()) {
+            return;
         }
 
         const opTrigger = this.getOpTrigger();
         const apTrigger = this.getApTrigger();
 
-        if (opTrigger && this.target instanceof PathingEntity && this.inOperableDistance(this.target)) {
+        // Try op
+        if (opTrigger && (this.target instanceof PathingEntity || allowOpScenery) && this.inOperableDistance(this.target)) {
             const target = this.target;
             this.target = null;
-            this.clearWaypoints(); 
+            this.clearWaypoints();
 
             this.executeScript(ScriptRunner.init(opTrigger, this, target), true);
             this.interacted = true;
+        }
 
-        } else if (apTrigger && this.inApproachDistance(this.apRange, this.target)) {
+        // Try ap
+        else if (apTrigger && this.inApproachDistance(this.apRange, this.target)) {
+            this.apRangeCalled = false;
+
             const target = this.target;
             this.target = null;
             const wayPoints = this.waypoints;
@@ -935,39 +912,93 @@ export default class Player extends PathingEntity {
                 this.waypointIndex = waypointIndex;
                 this.target = target;
             } else {
-                if (this.target === target) { // if p_opnpc was called
-                    this.clearWaypoints(); 
+                if (this.target === target) {
+                    // if p_opnpc was called
+                    this.clearWaypoints();
                 }
                 this.interacted = true;
             }
-
-        } else if (this.target instanceof PathingEntity && this.inOperableDistance(this.target)) {
-            if (Environment.NODE_DEBUG && !opTrigger && !apTrigger) {
-                let debugname = '_';
-                if (this.target instanceof Npc) {
-                    if (this.targetSubject.com !== -1 && this.targetOp === ServerTriggerType.APNPCT || this.targetOp === ServerTriggerType.OPNPCT) {
-                        debugname = Component.get(this.targetSubject.com)?.comName ?? this.targetSubject.toString();
-                    } else {
-                        debugname = NpcType.get(this.target.type)?.debugname ?? this.target.type.toString();
-                    }
-                } else if (this.target instanceof Loc) {
-                    debugname = LocType.get(this.target.type)?.debugname ?? this.target.type.toString();
-                } else if (this.target instanceof Obj) {
-                    debugname = ObjType.get(this.target.type)?.debugname ?? this.target.type.toString();
-                } else if (this.targetSubject.com !== -1 && this.targetOp === ServerTriggerType.APNPCT || this.targetOp === ServerTriggerType.APPLAYERT || this.targetOp === ServerTriggerType.APLOCT || this.targetOp === ServerTriggerType.APOBJT) {
-                    debugname = Component.get(this.targetSubject.com)?.comName ?? this.targetSubject.toString();
-                } else if (this.targetSubject.type !== -1) {
-                    debugname = ObjType.get(this.targetSubject.type)?.debugname ?? this.targetSubject.toString();
-                }
-
-                this.messageGame(`No trigger for [${ServerTriggerType[this.targetOp + 7].toLowerCase()},${debugname}]`);
-            }
-
-            this.target = null;
-            this.messageGame('Nothing interesting happens.');
-            this.interacted = true;
-            this.clearWaypoints();
+        } else if (this.inApproachDistance(this.apRange, this.target)) {
+            this.apRange = -1;
         }
+
+        // Try default op
+        else if (this.target && (this.target instanceof PathingEntity || allowOpScenery) && this.inOperableDistance(this.target)) {
+            this.defaultOp();
+        }
+    }
+
+    validateTarget(): boolean {
+        // Validate that the target is on the same floor and that it's not a player who is invisible
+        if (this.target.level !== this.level || (this.target instanceof Player && this.target.visibility !== Visibility.DEFAULT)) {
+            return false;
+        }
+
+        // For Npc targets, validate that the Npc is found in the world and that it's not delayed
+        if (this.target instanceof Npc && (typeof World.getNpc(this.target.nid) === 'undefined' || this.target.delayed)) {
+            return false;
+        }
+
+        // this is effectively checking if the npc did a changetype
+        if (this.target instanceof Npc && this.targetSubject.type !== -1 && World.getNpcByUid((this.targetSubject.type << 16) | this.target.nid) === null) {
+            return false;
+        }
+
+        // For Obj targets, validate that the Obj still exists in the World
+        if (this.target instanceof Obj && World.getObj(this.target.x, this.target.z, this.level, this.target.type, this.hash64) === null) {
+            return false;
+        }
+
+        // For Loc targets, validate that the Loc still exists in the world
+        if (this.target instanceof Loc && World.getLoc(this.target.x, this.target.z, this.level, this.target.type) === null) {
+            return false;
+        }
+
+        // For Player targets, validate that the Player still exists in the world
+        if (this.target instanceof Player && World.getPlayerByUid(this.target.uid) === null) {
+            return false;
+        }
+
+        return true;
+    }
+
+    processInteraction() {
+        if (this.target === null || !this.canAccess()) {
+            this.updateMovement(false);
+            return false;
+        }
+
+        if (!this.validateTarget()) {
+            this.clearInteraction();
+            this.unsetMapFlag();
+            return;
+        }
+
+        const opTrigger = this.getOpTrigger();
+
+        // opplayer3 is `Follow`
+        // Follow interaction behaves different than standard ones
+        if (this.targetOp === ServerTriggerType.APPLAYER3 || this.targetOp === ServerTriggerType.OPPLAYER3) {
+            const walktrigger: number = this.walktrigger;
+            if (this.hasWaypoints()) {
+                this.processWalktrigger();
+            }
+            const moved: boolean = this.updateMovement(false);
+            if (!moved && walktrigger !== -1 && this.target instanceof Player && (this.x !== this.target.lastStepX || this.z !== this.target.lastStepZ)) {
+                this.clearInteraction();
+                this.unsetMapFlag();
+            }
+            return;
+        }
+
+        if (!this.interactWalkTrigger || this.hasWaypoints()) {
+            this.processWalktrigger();
+            this.interactWalkTrigger = true;
+        }
+
+        // Try an interaction
+        this.tryInteraction(false);
+
         let moved = false;
         if (this.interacted && !this.apRangeCalled) {
             this.recoverEnergy(false);
@@ -975,61 +1006,8 @@ export default class Player extends PathingEntity {
             this.interacted = false;
             this.processWalktrigger();
             moved = this.updateMovement();
-            if (opTrigger && (this.target instanceof PathingEntity || !moved) && this.inOperableDistance(this.target)) {
 
-                const target = this.target;
-                this.target = null;
-                this.clearWaypoints(); 
-
-                this.executeScript(ScriptRunner.init(opTrigger, this, target), true);
-                this.interacted = true;
-
-            } else if (apTrigger && this.inApproachDistance(this.apRange, this.target)) {
-                this.apRangeCalled = false;
-
-                const target = this.target;
-                this.target = null;
-                const wayPoints = this.waypoints;
-                const waypointIndex = this.waypointIndex;
-                this.clearWaypoints();
-
-                this.executeScript(ScriptRunner.init(apTrigger, this, target), true);
-
-                // if aprange was called then we did not interact.
-                if (this.apRangeCalled) {
-                    this.target = target;
-                    this.waypoints = wayPoints;
-                    this.waypointIndex = waypointIndex;
-                } else {
-                    if (this.target === target) { // if p_opnpc was called
-                        this.clearWaypoints();
-                    }
-                    this.interacted = true;
-                }
-
-            } else if ((this.target instanceof PathingEntity || !moved) && this.inOperableDistance(this.target)) {
-                if (!Environment.NODE_PRODUCTION && !opTrigger && !apTrigger) {
-                    let debugname = '_';
-                    if (this.target instanceof Npc) {
-                        debugname = NpcType.get(this.target.type)?.debugname ?? this.target.type.toString();
-                    } else if (this.target instanceof Loc) {
-                        debugname = LocType.get(this.target.type)?.debugname ?? this.target.type.toString();
-                    } else if (this.target instanceof Obj) {
-                        debugname = ObjType.get(this.target.type)?.debugname ?? this.target.type.toString();
-                    } else if (this.targetSubject.com !== -1 && this.targetOp === ServerTriggerType.APNPCT || this.targetOp === ServerTriggerType.APPLAYERT || this.targetOp === ServerTriggerType.APLOCT || this.targetOp === ServerTriggerType.APOBJT) {
-                        debugname = Component.get(this.targetSubject.com)?.comName ?? this.targetSubject.toString();
-                    } else if (this.targetSubject.type !== -1) {
-                        debugname = ObjType.get(this.targetSubject.type)?.debugname ?? this.targetSubject.toString();
-                    }
-
-                    this.messageGame(`No trigger for [${ServerTriggerType[this.targetOp + 7].toLowerCase()},${debugname}]`);
-                }
-
-                this.target = null;
-                this.messageGame('Nothing interesting happens.');
-                this.interacted = true;
-                this.clearWaypoints();
-            }
+            this.tryInteraction(!moved);
         }
 
         if (!this.interacted && !this.hasWaypoints() && !moved) {
@@ -1040,7 +1018,7 @@ export default class Player extends PathingEntity {
         if (this.interacted && !this.apRangeCalled && this.target === null) {
             this.clearInteraction();
         }
-        
+
         if (!this.hasWaypoints()) {
             this.unsetMapFlag();
         }

--- a/src/engine/entity/Player.ts
+++ b/src/engine/entity/Player.ts
@@ -948,6 +948,8 @@ export default class Player extends PathingEntity {
     }
 
     validateTarget(): boolean {
+        // todo: all of these validation checks should be checking against the entity itself rather than trying to look up a similar entity from the World
+
         // Validate that the target is on the same floor and that it's not a player who is invisible
         if (this.target?.level !== this.level || (this.target instanceof Player && this.target.visibility !== Visibility.DEFAULT)) {
             return false;


### PR DESCRIPTION
The logic block for handling when a player interacts with an entity is refactored and reorganized. It should now also match documented behavior better.

# Example 1 - default ap behavior

## OSRS behavior example

The first Nothing interesting happens message is given the cycle after player moves

https://github.com/user-attachments/assets/4f8fa8ee-2b1f-49eb-afd9-88f5795579ed


## Previous 2004scape behavior

The first Nothing interesting happens message is given the same cycle as player's movement

https://github.com/user-attachments/assets/00647ce3-0062-4a0c-9b28-bde331adf264


## New 2004scape behavior

The first Nothing interesting happens message is given the cycle after player moves

https://github.com/user-attachments/assets/387754af-67c9-4bcf-8218-31e17ec5f7e3


# Example 2 - Triple interact due to p_aprange() call

## OSRS behavior example

3 interacts due to how p_aprange() is handled

https://github.com/user-attachments/assets/65f63e31-c8dd-4bd7-b250-61da479e4970


## Previous 2004scape behavior

Only 2 interacts due to imprecise p_aprange() handling

https://github.com/user-attachments/assets/5d25751a-3cf2-4446-a563-5e559d7d10a0


## New 2004scape behavior

3 interacts due to precise p_aprange() handling

https://github.com/user-attachments/assets/fa3e9ec9-0c99-4ce2-a0d4-442a472826e6

