### PR TITLE
fix(engine): resync invs and appearances on reconnect

### DIFF
--- a/src/engine/World.ts
+++ b/src/engine/World.ts
@@ -928,11 +928,12 @@ class World {
 
                     // force resyncing
                     // reload entity info (overkill? does the client have some logic around this?)
-                    other.buildArea.players.clear();
-                    other.buildArea.npcs.clear();
+                    other.buildArea.clear();
                     // rebuild scene (rebuildnormal won't run if you're in the same zone!)
                     other.originX = -1;
                     other.originZ = -1;
+                    // resync invs
+                    other.refreshInvs();
                     other.moveSpeed = MoveSpeed.INSTANT;
                     other.tele = true;
                     other.jump = true;

--- a/src/engine/entity/Player.ts
+++ b/src/engine/entity/Player.ts
@@ -1165,6 +1165,16 @@ export default class Player extends PathingEntity {
 
     // ----
 
+    refreshInvs() {
+        for (let i: number = 0; i < this.invListeners.length; i++) {
+            const listener = this.invListeners[i];
+            if (!listener) {
+                continue;
+            }
+            listener.firstSeen = true;
+        }
+    }
+
     getInventoryFromListener(listener: any) {
         if (listener.source === -1) {
             return World.getInventory(listener.type);


### PR DESCRIPTION
`BuildArea#clear` clears the following properties on the `Player`.
```ts
    clear(): void {
        this.players.clear();
        this.npcs.clear();
        this.loadedZones.clear();
        this.activeZones.clear();
        this.appearances.clear();
    }
```

Since you're going for rebuilding during reconnecting, might as well just clear the zones.
The client also clears out the appearance cache:
https://github.com/2004Scape/Client/blob/lastmain/client/src/main/java/client.java#L7695
![image](https://github.com/user-attachments/assets/e081ba06-54f4-4173-ad47-011618aa3fa5)

Also refresh all of the player inv listeners by doing `listener.firstSeen = true` on all of them. This will also refresh `weight`.