### PR TITLE
fix(engine): dont clear zones on reconnect instead

### DIFF
--- a/src/engine/World.ts
+++ b/src/engine/World.ts
@@ -926,17 +926,7 @@ class World {
                         other.client.send(Uint8Array.from([ 15 ]));
                     }
 
-                    // force resyncing
-                    // reload entity info (overkill? does the client have some logic around this?)
-                    other.buildArea.clear();
-                    // rebuild scene (rebuildnormal won't run if you're in the same zone!)
-                    other.originX = -1;
-                    other.originZ = -1;
-                    // resync invs
-                    other.refreshInvs();
-                    other.moveSpeed = MoveSpeed.INSTANT;
-                    other.tele = true;
-                    other.jump = true;
+                    other.onReconnect();
 
                     continue player;
                 }

--- a/src/engine/entity/BuildArea.ts
+++ b/src/engine/entity/BuildArea.ts
@@ -29,11 +29,13 @@ export default class BuildArea {
         this.appearances = new Map();
     }
 
-    clear(): void {
+    clear(reconnecting: boolean): void {
+        if (!reconnecting) {
+            this.activeZones.clear();
+            this.loadedZones.clear();
+        }
         this.players.clear();
         this.npcs.clear();
-        this.loadedZones.clear();
-        this.activeZones.clear();
         this.appearances.clear();
     }
 

--- a/src/engine/entity/Player.ts
+++ b/src/engine/entity/Player.ts
@@ -353,7 +353,7 @@ export default class Player extends PathingEntity {
         this.cameraPackets.clear();
         this.timers.clear();
         this.heroPoints.clear();
-        this.buildArea.clear();
+        this.buildArea.clear(false);
     }
 
     resetEntity(respawn: boolean) {
@@ -395,6 +395,20 @@ export default class Player extends PathingEntity {
 
         this.lastStepX = this.x - 1;
         this.lastStepZ = this.z;
+    }
+
+    onReconnect() {
+        // force resyncing
+        // reload entity info (overkill? does the client have some logic around this?)
+        this.buildArea.clear(true);
+        // rebuild scene (rebuildnormal won't run if you're in the same zone!)
+        this.originX = -1;
+        this.originZ = -1;
+        // resync invs
+        this.refreshInvs();
+        this.moveSpeed = MoveSpeed.INSTANT;
+        this.tele = true;
+        this.jump = true;
     }
 
     triggerMapzone(x: number, z: number) {


### PR DESCRIPTION
- We need to keep the active zones atleast. I'm basically reverting the last PR on the zones bit.
- Create a `onReconnect` fn to clean it up a little.