### PR TITLE
fix(engine): real fix for new acc dc

### DIFF
--- a/src/engine/World.ts
+++ b/src/engine/World.ts
@@ -696,7 +696,7 @@ class World {
                     // x-logged / timed out for 60s: logout
                     player.loggedOut = true;
                 } else if (this.currentTick - player.lastResponse >= World.TIMEOUT_SOCKET_IDLE) {
-                    // x-logged / timed out for 10s: attempt logout
+                    // x-logged / timed out for 30s: attempt logout
                     player.tryLogout = true;
                 }
 

--- a/src/engine/World.ts
+++ b/src/engine/World.ts
@@ -994,7 +994,6 @@ class World {
             player.uid = ((Number(player.username37 & 0x1fffffn) << 11) | player.pid) >>> 0;
             player.tele = true;
             player.moveClickRequest = false;
-            player.lastResponse = this.currentTick;
 
             this.gameMap.getZone(player.x, player.z, player.level).enter(player);
             player.onLogin();

--- a/src/engine/entity/PlayerLoading.ts
+++ b/src/engine/entity/PlayerLoading.ts
@@ -42,6 +42,8 @@ export class PlayerLoading {
             ? new NetworkPlayer(safeName, name37, hash64, client)
             : new Player(safeName, name37, hash64);
 
+        player.lastResponse = World.currentTick;
+
         if (sav.data.length < 2) {
             for (let i = 0; i < 21; i++) {
                 player.stats[i] = 0;
@@ -150,7 +152,6 @@ export class PlayerLoading {
         }
 
         player.combatLevel = player.getCombatLevel();
-        player.lastResponse = World.currentTick;
 
         return player;
     }


### PR DESCRIPTION
The problem was just the playerloading.load returning before lastResponse is set if no save, this works now until it reaches 30 sec as intended.

This fix is not needed anymore so removed it again: https://github.com/2004Scape/Server/pull/1215