### PR TITLE
fix(content): Fix issues with demon slayer authenticity

### DIFF
--- a/data/src/scripts/areas/area_varrock/scripts/captain_rovin.rs2
+++ b/data/src/scripts/areas/area_varrock/scripts/captain_rovin.rs2
@@ -41,7 +41,7 @@ if ($option = 1) {
         ~chatnpc("<p,quiz>Yes you are right. Here you go.");
         if_close();
         p_delay(2);
-        mes("Captain rovin hands you a key.");
+        mes("Captain Rovin hands you a key.");
         inv_add(inv, demon_rovin_key, 1);
     } else if ($important_option = 2) {
         ~chatplayer("<p,sad>Erm I forgot.");

--- a/data/src/scripts/quests/quest_demon/scripts/delrith.rs2
+++ b/data/src/scripts/quests/quest_demon/scripts/delrith.rs2
@@ -51,9 +51,11 @@ if (npc_find(coord, delrith, 8, 0) = true) {
     npc_setmode(none); // stop fighting
 }
 
+// https://www.youtube.com/watch?v=rjQprrDDUfE
+
 p_stopaction;
 p_delay(1);
-~chatplayer("<p,neutral>Now what was that incantation again?");
+~chatplayer("<p,angry>Now what was that incantation again?");
 def_int $option = ~p_choice4("Carlem Gabindo Purchai Zaree Camerinthum", 1, "Purchai Zaree Gabindo Carlem Camerinthum", 2, "Purchai Camerinthum Aber Gabindo Carlem", 3, "Carlem Aber Camerinthum Purchai Gabindo", 4);
 
 if ($option = 1) {
@@ -72,25 +74,20 @@ if ($option = 1) {
 
 [label,demon_slayer_wrong_incantation]
 if_close;
-mes("As you chant, Delrith is sucked towards the vortex.");
-p_delay(1);
-mes("Suddenly, the vortex closes!");
-p_delay(1);
-
+~mesbox("As you chant, Delrith is sucked towards the vortex....");
 if (npc_find(coord, weakened_delrith, 8, 0) = true) {
-    @restore_delrith;
+    // On restore Delrith does not keep attacking you in 2004
+    // https://www.youtube.com/watch?v=rjQprrDDUfE
+    npc_changetype(delrith);
+    npc_statheal(hitpoints, npc_basestat(hitpoints), 0);
+    ~mesbox("Suddenly the vortex collapses. That was the wrong incantation");
     return;
 }
 
-[label,restore_delrith]
-npc_changetype(delrith);
-npc_statheal(hitpoints, npc_basestat(hitpoints), 0);
-npc_setmode(opplayer2);
-mes("That was the wrong incantation");
-
 [label,demon_slayer_correct_incantation]
+// Between 20 feb and 6 march 2006 this becomes 2 separate message boxes
+// https://www.youtube.com/watch?v=w7uLKC_rYfc
 ~mesbox("As you chant, Delrith is sucked towards the vortex...|Back to the dark dimension from which he came...");
-if_close;
 
 if (npc_find(coord, weakened_delrith, 8, 0) = true) {
     gosub(npc_death);

--- a/data/src/scripts/quests/quest_demon/scripts/demon_slayer.rs2
+++ b/data/src/scripts/quests/quest_demon/scripts/demon_slayer.rs2
@@ -24,7 +24,6 @@ if (last_useitem ! bucket_water) {
 mes("You pour the liquid down the drain.");
 inv_del(inv, bucket_water, 1);
 inv_add(inv, bucket_empty, 1);
-p_delay(2);
 mes("Ok, I think I've washed the key down to the sewer.");
 p_delay(2);
 mes("I'd better go down and get it before someone else finds it.");

--- a/data/src/scripts/quests/quest_demon/scripts/demon_slayer.rs2
+++ b/data/src/scripts/quests/quest_demon/scripts/demon_slayer.rs2
@@ -10,10 +10,14 @@ session_log(^log_adventure, "Quest complete: Demon Slayer");
 ~mesbox("This is the drainpipe running from the kitchen sink to the sewer.");
 if (%demon_progress < ^demon_key_hunt) {
     ~mesbox("I can see a key but I can't quite reach it...");
+} else if ((%demon_progress > ^demon_silverlight) | inv_total(inv, demon_prysin_key) > 0 | inv_total(bank, demon_prysin_key) > 0){
+    // OSRS could do with a 2004 source
+    ~mesbox("Nothing interesting seems to have been dropped down here today.");
 } else {
-    ~mesbox("I can see a key just inside the drain.|That must be the one Sir Prysin dropped.");
+    ~mesbox("I can see a key just inside the drain.|That must be the key Sir Prysin dropped.");
+    ~mesbox("I don't seem to be able to quite reach it.|It's stuck part way down.");
+    ~mesbox("I wonder if I can dislodge it somehow|and knock it down into the sewer.");
 }
-~mesbox("I don't seem to be able to reach it. I wonder if I can dislodge it somehow and knock it down into the sewer.");
 
 // For using bucket on drain
 [oplocu,varrock_palace_sewer_drain]
@@ -24,12 +28,16 @@ if (last_useitem ! bucket_water) {
 mes("You pour the liquid down the drain.");
 inv_del(inv, bucket_water, 1);
 inv_add(inv, bucket_empty, 1);
-mes("Ok, I think I've washed the key down to the sewer.");
-p_delay(2);
-mes("I'd better go down and get it before someone else finds it.");
-// Tele to 3227 9898 0
-// todo: this should be instanced per player
-obj_add(0_50_154_25_41, demon_prysin_key, 1, 300); // Guessing Duration is ticks?
+if ((%demon_progress > ^demon_silverlight) | inv_total(inv, demon_prysin_key) > 0 | inv_total(bank, demon_prysin_key) > 0) {
+    // do nothing
+} else {
+    mes("Ok, I think I've washed the key down to the sewer.");
+    p_delay(2);
+    mes("I'd better go down and get it before someone else finds it.");
+    // Tele to 3227 9898 0
+    // todo: this should be instanced per player
+    obj_add(0_50_154_25_41, demon_prysin_key, 1, 300); // Guessing Duration is ticks?
+} 
 
 
 [proc,demon_has_prysin_key]()(boolean)

--- a/data/src/scripts/quests/quest_demon/scripts/demon_slayer.rs2
+++ b/data/src/scripts/quests/quest_demon/scripts/demon_slayer.rs2
@@ -22,13 +22,12 @@ if (last_useitem ! bucket_water) {
     return;
 }
 mes("You pour the liquid down the drain.");
+inv_del(inv, bucket_water, 1);
+inv_add(inv, bucket_empty, 1);
 p_delay(2);
 mes("Ok, I think I've washed the key down to the sewer.");
 p_delay(2);
 mes("I'd better go down and get it before someone else finds it.");
-p_delay(2);
-inv_del(inv, bucket_water, 1);
-inv_add(inv, bucket_empty, 1);
 // Tele to 3227 9898 0
 // todo: this should be instanced per player
 obj_add(0_50_154_25_41, demon_prysin_key, 1, 300); // Guessing Duration is ticks?


### PR DESCRIPTION
Source for name: https://youtu.be/-QCLVYNZfYo?si=ECm_o7WIuJ8M2-tE&t=213

I don't have a source for the water bucket. It can be rolled back if it was authentic the old way. Now the bucket is replaced when the player gets a message that they have poured the water down.