### PR TITLE
fix(content): if_close trigger fixes

### DIFF
--- a/data/src/scripts/_unpack/all.inv
+++ b/data/src/scripts/_unpack/all.inv
@@ -1,6 +1,7 @@
 [trawler_catch]
 size=40
 stackall=yes
+protect=no
 
 [inv_55]
 size=1

--- a/data/src/scripts/interface_bank/scripts/bank.rs2
+++ b/data/src/scripts/interface_bank/scripts/bank.rs2
@@ -18,6 +18,10 @@ if_openmain_side(bank_main, bank_side);
 [label,closebank]
 inv_stoptransmit(bank_side:inv);
 inv_stoptransmit(bank_main:inv);
+queue(reorganize_bank, 0); // confirmed queued
+
+[queue,reorganize_bank]
+~reorganize_bank;
 
 [label,bank_withdraw](int $slot, int $requested_number)
 // Check if the slot was empty.

--- a/data/src/scripts/minigames/game_partyroom/configs/partyroom.inv
+++ b/data/src/scripts/minigames/game_partyroom/configs/partyroom.inv
@@ -4,3 +4,4 @@ size=216
 
 [partyroomoffer]
 size=8
+protect=no

--- a/data/src/scripts/minigames/game_partyroom/scripts/partyroom_chest.rs2
+++ b/data/src/scripts/minigames/game_partyroom/scripts/partyroom_chest.rs2
@@ -11,10 +11,6 @@ if_openmain_side(party_drop_chest, party_drop_chest_side);
 inv_stoptransmit(party_drop_chest_side:inv);
 inv_stoptransmit(party_drop_chest:inv);
 inv_stoptransmit(party_drop_chest:playerinv);
-if(p_finduid(uid) = true) ~moveallinv(partyroomoffer, inv);
-else queue(move_party_room_offer, 0);
-
-[queue,move_party_room_offer]
 ~moveallinv(partyroomoffer, inv);
 
 [oploc3,loc_2418]

--- a/data/src/scripts/minigames/game_trawler/scripts/trawler_win.rs2
+++ b/data/src/scripts/minigames/game_trawler/scripts/trawler_win.rs2
@@ -77,13 +77,6 @@ while ($i < %trawler_catch) {
 
 
 [if_close,trawler_catch]
-if(p_finduid(uid) = true) {
-    @drop_trawler_catch;
-} else {
-    queue(queue_drop_trawler_catch, 0);
-}
-
-[label,drop_trawler_catch]
 def_int $i = 0;
 while ($i < inv_size(trawler_catch)) {
     if (inv_getobj(trawler_catch, $i) ! null) {
@@ -92,8 +85,6 @@ while ($i < inv_size(trawler_catch)) {
     $i = add($i, 1);
 }
 inv_stoptransmit(trawler_catch:inv);
-
-[queue,queue_drop_trawler_catch] @drop_trawler_catch;
 
 // osrs drops on ground on full inv
 [inv_button1,trawler_catch:inv] 


### PR DESCRIPTION
Bank reorganise being queued was confirmed by leaving an empty slot before closing bank, then banking an item with imp-in-a-box without letting queue run. This put the banked item in the empty slot. Doing the same test but letting queue run first resulted in the banked item being placed at the end.