### PR TITLE
feat(engine): precalculate info bits where possible

### DIFF
--- a/src/engine/World.ts
+++ b/src/engine/World.ts
@@ -1031,9 +1031,6 @@ class World {
     private processInfo(): void {
         // TODO: benchmark this?
         for (const player of this.players) {
-            player.convertMovementDir();
-            player.reorient();
-
             const grid = this.playerGrid;
             const coord = CoordGrid.packCoord(player.level, player.x, player.z);
             const players = grid.get(coord) ?? [];
@@ -1042,13 +1039,17 @@ class World {
                 grid.set(coord, players);
             }
 
+            player.convertMovementDir();
+            player.reorient();
             this.playerRenderer.computeInfo(player);
+            this.playerRenderer.computeBits(player);
         }
 
         for (const npc of this.npcs) {
             npc.convertMovementDir();
             npc.reorient();
             this.npcRenderer.computeInfo(npc);
+            this.npcRenderer.computeBits(npc);
         }
     }
 

--- a/src/engine/renderer/NpcRenderer.ts
+++ b/src/engine/renderer/NpcRenderer.ts
@@ -9,6 +9,7 @@ import NpcInfoChangeType from '#/network/server/model/NpcInfoChangeType.js';
 import NpcInfoSpotanim from '#/network/server/model/NpcInfoSpotanim.js';
 import NpcInfoFaceCoord from '#/network/server/model/NpcInfoFaceCoord.js';
 import NpcStat from '#/engine/entity/NpcStat.js';
+import Packet from '#/io/Packet.js';
 
 export default class NpcRenderer extends Renderer<Npc> {
     constructor() {
@@ -68,14 +69,33 @@ export default class NpcRenderer extends Renderer<Npc> {
         }
     }
 
+    computeBits(entity: Npc): void {
+        if (entity.nid === -1) {
+            return;
+        }
+
+        const bytes: number = this.highdefinitions(entity.nid);
+        const extend: boolean = bytes > 0;
+        const { nid, walkDir, runDir } = entity;
+        if (runDir !== -1) {
+            this.run(nid, walkDir, runDir, extend, bytes);
+        } else if (walkDir !== -1) {
+            this.walk(nid, walkDir, extend, bytes);
+        } else if (extend) {
+            this.extend(nid, bytes);
+        } else {
+            this.idle(nid, bytes);
+        }
+    }
+
     removeTemporary() {
         super.removeTemporary();
-        this.caches.get(InfoProt.NPC_ANIM)?.clear();
-        this.caches.get(InfoProt.NPC_FACE_ENTITY)?.clear();
-        this.caches.get(InfoProt.NPC_SAY)?.clear();
-        this.caches.get(InfoProt.NPC_DAMAGE)?.clear();
-        this.caches.get(InfoProt.NPC_CHANGE_TYPE)?.clear();
-        this.caches.get(InfoProt.NPC_SPOTANIM)?.clear();
-        this.caches.get(InfoProt.NPC_FACE_COORD)?.clear();
+        this.infos.get(InfoProt.NPC_ANIM)?.clear();
+        this.infos.get(InfoProt.NPC_FACE_ENTITY)?.clear();
+        this.infos.get(InfoProt.NPC_SAY)?.clear();
+        this.infos.get(InfoProt.NPC_DAMAGE)?.clear();
+        this.infos.get(InfoProt.NPC_CHANGE_TYPE)?.clear();
+        this.infos.get(InfoProt.NPC_SPOTANIM)?.clear();
+        this.infos.get(InfoProt.NPC_FACE_COORD)?.clear();
     }
 }

--- a/src/engine/renderer/NpcRenderer.ts
+++ b/src/engine/renderer/NpcRenderer.ts
@@ -77,13 +77,13 @@ export default class NpcRenderer extends Renderer<Npc> {
         const extend: boolean = bytes > 0;
         const { nid, walkDir, runDir } = entity;
         if (runDir !== -1) {
-            this.run(nid, walkDir, runDir, extend, bytes);
+            this.run(nid, walkDir, runDir, bytes);
         } else if (walkDir !== -1) {
-            this.walk(nid, walkDir, extend, bytes);
+            this.walk(nid, walkDir, bytes);
         } else if (extend) {
             this.extend(nid, bytes);
         } else {
-            this.idle(nid, bytes);
+            this.idle(nid);
         }
     }
 

--- a/src/engine/renderer/NpcRenderer.ts
+++ b/src/engine/renderer/NpcRenderer.ts
@@ -9,7 +9,6 @@ import NpcInfoChangeType from '#/network/server/model/NpcInfoChangeType.js';
 import NpcInfoSpotanim from '#/network/server/model/NpcInfoSpotanim.js';
 import NpcInfoFaceCoord from '#/network/server/model/NpcInfoFaceCoord.js';
 import NpcStat from '#/engine/entity/NpcStat.js';
-import Packet from '#/io/Packet.js';
 
 export default class NpcRenderer extends Renderer<Npc> {
     constructor() {

--- a/src/engine/renderer/PlayerRenderer.ts
+++ b/src/engine/renderer/PlayerRenderer.ts
@@ -90,13 +90,13 @@ export default class PlayerRenderer extends Renderer<Player>  {
         const extend: boolean = bytes > 0;
         const { pid, walkDir, runDir } = entity;
         if (runDir !== -1) {
-            this.run(pid, walkDir, runDir, extend, bytes);
+            this.run(pid, walkDir, runDir, bytes);
         } else if (walkDir !== -1) {
-            this.walk(pid, walkDir, extend, bytes);
+            this.walk(pid, walkDir, bytes);
         } else if (extend) {
             this.extend(pid, bytes);
         } else {
-            this.idle(pid, bytes);
+            this.idle(pid);
         }
     }
 

--- a/src/engine/renderer/Renderer.ts
+++ b/src/engine/renderer/Renderer.ts
@@ -5,19 +5,39 @@ import ServerProtRepository from '#/network/rs225/server/prot/ServerProtReposito
 import Packet from '#/io/Packet.js';
 import InfoProt from '#/network/rs225/server/prot/InfoProt.js';
 
+interface Bits {
+    n: number;
+    value: number;
+    bytes: number;
+}
+
 export default abstract class Renderer<T extends Entity> {
-    protected readonly caches: Map<InfoProt, Map<number, Uint8Array>>;
+    public static readonly PLAYER_ADD_BITS: number = 23;
+    public static readonly NPC_ADD_BITS: number = 35;
+
+    private static readonly TELEPORT_BITS: number = 21;
+    private static readonly RUN_BITS: number = 10;
+    private static readonly WALK_BITS: number = 7;
+    private static readonly EXTEND_BITS: number = 3;
+    private static readonly REMOVE_BITS: number = 3;
+    private static readonly IDLE_BITS: number = 1;
+
+    protected readonly infos: Map<InfoProt, Map<number, Uint8Array>>;
 
     protected readonly highs: Map<number, number>;
     protected readonly lows: Map<number, number>;
 
-    protected constructor(caches: Map<InfoProt, Map<number, Uint8Array>>) {
-        this.caches = caches;
+    private readonly bits: Map<number, Bits>;
+
+    protected constructor(infos: Map<InfoProt, Map<number, Uint8Array>>) {
+        this.infos = infos;
         this.highs = new Map();
         this.lows = new Map();
+        this.bits = new Map();
     }
 
     abstract computeInfo(entity: T): void;
+    abstract computeBits(entity: T): void;
 
     write1(buf: Packet, masks: number): void {
         buf.p1(masks & 0xff);
@@ -34,7 +54,7 @@ export default abstract class Renderer<T extends Entity> {
     }
 
     cache(id: number, message: InfoMessage, prot: InfoProt): number {
-        const cache = this.caches.get(prot);
+        const cache = this.infos.get(prot);
         if (typeof cache === 'undefined') {
             throw new Error('[Renderer] tried to cache to empty!');
         }
@@ -44,16 +64,29 @@ export default abstract class Renderer<T extends Entity> {
         return this.encodeInfo(cache, id, message);
     }
 
+    cacheBits(id: number, bits: Bits): void {
+        this.bits.set(id, bits);
+    }
+
     write(buf: Packet, id: number, prot: InfoProt): void {
-        const cache: Map<number, Uint8Array> | undefined = this.caches.get(prot);
+        const cache: Map<number, Uint8Array> | undefined = this.infos.get(prot);
         if (typeof cache === 'undefined') {
             throw new Error('[Renderer] tried to write a buf not cached!');
         }
         this.writeBlock(buf, cache, id);
     }
 
+    writeBits(buf: Packet, id: number): number {
+        const bits: Bits | undefined = this.bits.get(id);
+        if (typeof bits === 'undefined') {
+            throw new Error('[Renderer] tried to write a bits buf not cached!');
+        }
+        buf.pBit(bits.n, bits.value);
+        return bits.bytes;
+    }
+
     has(id: number, prot: InfoProt): boolean {
-        const cache: Map<number, Uint8Array> | undefined = this.caches.get(prot);
+        const cache: Map<number, Uint8Array> | undefined = this.infos.get(prot);
         return cache ? cache.has(id) : false;
     }
 
@@ -67,11 +100,60 @@ export default abstract class Renderer<T extends Entity> {
 
     removeTemporary() {
         this.highs.clear();
+        this.bits.clear();
     }
 
     removePermanent(id: number) {
         this.highs.delete(id);
         this.lows.delete(id);
+    }
+
+    teleport(buf: Packet, y: number, x: number, z: number, jump: boolean, extend: boolean,): void {
+        buf.pBit(Renderer.TELEPORT_BITS, (1 << 20) | (3 << 18) | ((y & 0x3) << 16) | ((x & 0x7f) << 9) | ((z & 0x7f) << 2) | ((jump ? 1 : 0) << 1) | (extend ? 1 : 0));
+    }
+
+    remove(buf: Packet): void {
+        buf.pBit(Renderer.REMOVE_BITS, (1 << 2) | 3);
+    }
+
+    addPlayer(buf: Packet, pid: number, x: number, z: number, jump: boolean): void {
+        buf.pBit(Renderer.PLAYER_ADD_BITS, ((pid & 0x7ff) << 12) | ((x & 0x1f) << 7) | ((z & 0x1f) << 2) | ((jump ? 1 : 0) << 1) | 1);
+    }
+
+    addNpc(buf: Packet, nid: number, type: number, x: number, z: number): void {
+        buf.pBit(Renderer.NPC_ADD_BITS, ((nid & 0x1fff) << 22) | ((type & 0x7ff) << 11) | ((x & 0x1f) << 6) | ((z & 0x1f) << 1) | 1);
+    }
+
+    protected run(id: number, walkDir: number, runDir: number, extend: boolean, bytes: number): void {
+        this.cacheBits(id, {
+            n: Renderer.RUN_BITS,
+            value: (1 << 9) | (2 << 7) | ((walkDir & 0x7) << 4) | ((runDir & 0x7) << 1) | (extend ? 1 : 0),
+            bytes: bytes,
+        });
+    }
+
+    protected walk(id: number, walkDir: number, extend: boolean, bytes: number): void {
+        this.cacheBits(id, {
+            n: Renderer.WALK_BITS,
+            value: (1 << 6) | (1 << 4) | ((walkDir & 0x7) << 1) | (extend ? 1 : 0),
+            bytes: bytes,
+        });
+    }
+
+    protected extend(id: number, bytes: number): void {
+        this.cacheBits(id, {
+            n: Renderer.EXTEND_BITS,
+            value: 1 << 2,
+            bytes: bytes,
+        });
+    }
+
+    protected idle(id: number, bytes: number): void {
+        this.cacheBits(id, {
+            n: Renderer.IDLE_BITS,
+            value: 0,
+            bytes: bytes,
+        });
     }
 
     protected encodeInfo<T extends InfoMessage>(messages: Map<number, Uint8Array>, id: number, message: T): number {

--- a/src/network/rs225/server/codec/PlayerInfoEncoder.ts
+++ b/src/network/rs225/server/codec/PlayerInfoEncoder.ts
@@ -10,12 +10,9 @@ import PlayerInfoFaceEntity from '#/network/server/model/PlayerInfoFaceEntity.js
 import PlayerInfoFaceCoord from '#/network/server/model/PlayerInfoFaceCoord.js';
 import PlayerRenderer from '#/engine/renderer/PlayerRenderer.js';
 import Visibility from '#/engine/entity/Visibility.js';
+import Renderer from '#/engine/renderer/Renderer.js';
 
 export default class PlayerInfoEncoder extends MessageEncoder<PlayerInfo> {
-    private static readonly BITS_NEW: number = 11 + 5 + 5 + 1 + 1;
-    private static readonly BITS_RUN: number = 1 + 2 + 3 + 3 + 1;
-    private static readonly BITS_WALK: number = 1 + 2 + 3 + 1;
-    private static readonly BITS_EXTENDED: number = 1 + 2;
     private static readonly BYTES_LIMIT: number = 4997;
 
     prot = ServerProt.PLAYER_INFO;
@@ -53,20 +50,14 @@ export default class PlayerInfoEncoder extends MessageEncoder<PlayerInfo> {
 
     private writeLocalPlayer(buf: Packet, updates: Packet, message: PlayerInfo): number {
         const { renderer, player } = message;
-        const { pid, tele, runDir, walkDir } = player;
-        const length: number = renderer.highdefinitions(pid);
-        const extend: boolean = length > 0;
-        if (tele) {
-            const { x, z, level, originX, originZ, jump } = player;
-            this.teleport(buf, updates, renderer, player, player, CoordGrid.local(x, originX), level, CoordGrid.local(z, originZ), jump, extend);
-        } else if (runDir !== -1) {
-            this.run(buf, updates, renderer, player, player, walkDir, runDir, extend);
-        } else if (walkDir !== -1) {
-            this.walk(buf, updates, renderer, player, player, walkDir, extend);
-        } else if (extend) {
-            this.extend(buf, updates, renderer, player, player);
+        let length: number;
+        if (player.tele) {
+            length = renderer.writeTeleport(buf, player.pid, player.x, player.level, player.z, player.originX, player.originZ, player.jump);
         } else {
-            this.idle(buf);
+            length = renderer.writeBits(buf, player.pid);
+        }
+        if (length > 0) {
+            this.highdefinition(updates, renderer, player, player);
         }
         return length;
     }
@@ -80,22 +71,15 @@ export default class PlayerInfoEncoder extends MessageEncoder<PlayerInfo> {
             const pid: number = other.pid;
             if (pid === -1 || other.tele || other.level !== player.level || !CoordGrid.isWithinDistanceSW(player, other, buildArea.viewDistance) || !other.checkLifeCycle(currentTick) || other.visibility === Visibility.HARD) {
                 // if the player was teleported, they need to be removed and re-added
-                this.remove(buf, player, other);
+                renderer.remove(buf);
+                buildArea.players.delete(other);
                 continue;
             }
-            const length: number = renderer.highdefinitions(pid);
-            const extend: boolean = length > 0;
-            const { walkDir, runDir } = other;
-            if (runDir !== -1) {
-                this.run(buf, updates, renderer, player, other, walkDir, runDir, extend && this.willFit(bytes, buf, PlayerInfoEncoder.BITS_RUN, length));
-            } else if (walkDir !== -1) {
-                this.walk(buf, updates, renderer, player, other, walkDir, extend && this.willFit(bytes, buf, PlayerInfoEncoder.BITS_WALK, length));
-            } else if (extend && this.willFit(bytes, buf, PlayerInfoEncoder.BITS_EXTENDED, length)) {
-                this.extend(buf, updates, renderer, player, other);
-            } else {
-                this.idle(buf);
+            const length: number = renderer.writeBits(buf, pid);
+            if (length > 0) {
+                this.highdefinition(updates, renderer, player, other);
+                bytes += length;
             }
-            bytes += length;
         }
         return bytes;
     }
@@ -111,79 +95,15 @@ export default class PlayerInfoEncoder extends MessageEncoder<PlayerInfo> {
             const pid: number = other.pid;
             const length: number = renderer.lowdefinitions(pid) + renderer.highdefinitions(pid);
             // bits to add player + extended info size + bits to break loop (11)
-            if (!this.willFit(bytes, buf, PlayerInfoEncoder.BITS_NEW + 11, length)) {
+            if (!this.willFit(bytes, buf, Renderer.PLAYER_ADD_BITS + 11, length)) {
                 // more players get added next tick
                 break;
             }
-            this.add(buf, updates, renderer, player, other, pid, other.x - x, other.z - z, other.jump);
+            renderer.addPlayer(buf, pid, other.x - x, other.z - z, other.jump);
+            this.lowdefinition(updates, renderer, player, other);
+            buildArea.players.add(other);
             bytes += length;
         }
-    }
-
-    private add(buf: Packet, updates: Packet, renderer: PlayerRenderer, player: Player, other: Player, pid: number, x: number, z: number, jump: boolean): void {
-        buf.pBit(11, pid);
-        buf.pBit(5, x);
-        buf.pBit(5, z);
-        buf.pBit(1, jump ? 1 : 0);
-        buf.pBit(1, 1); // extend
-        this.lowdefinition(updates, renderer, player, other);
-        player.buildArea.players.add(other);
-    }
-
-    private remove(buf: Packet, player: Player, other: Player): void {
-        buf.pBit(1, 1);
-        buf.pBit(2, 3);
-        player.buildArea.players.delete(other);
-    }
-
-    private teleport(buf: Packet, updates: Packet, renderer: PlayerRenderer, player: Player, other: Player, x: number, y: number, z: number, jump: boolean, extend: boolean): void {
-        buf.pBit(1, 1);
-        buf.pBit(2, 3);
-        buf.pBit(2, y);
-        buf.pBit(7, x);
-        buf.pBit(7, z);
-        buf.pBit(1, jump ? 1 : 0);
-        if (extend) {
-            buf.pBit(1, 1);
-            this.highdefinition(updates, renderer, player, other);
-        } else {
-            buf.pBit(1, 0);
-        }
-    }
-
-    private run(buf: Packet, updates: Packet, renderer: PlayerRenderer, player: Player, other: Player, walkDir: number, runDir: number, extend: boolean): void {
-        buf.pBit(1, 1);
-        buf.pBit(2, 2);
-        buf.pBit(3, walkDir);
-        buf.pBit(3, runDir);
-        if (extend) {
-            buf.pBit(1, 1);
-            this.highdefinition(updates, renderer, player, other);
-        } else {
-            buf.pBit(1, 0);
-        }
-    }
-
-    private walk(buf: Packet, updates: Packet, renderer: PlayerRenderer, player: Player, other: Player, walkDir: number, extend: boolean): void {
-        buf.pBit(1, 1);
-        buf.pBit(2, 1);
-        buf.pBit(3, walkDir);
-        if (extend) {
-            buf.pBit(1, 1);
-            this.highdefinition(updates, renderer, player, other);
-        } else {
-            buf.pBit(1, 0);
-        }
-    }
-
-    private extend(buf: Packet, updates: Packet, renderer: PlayerRenderer, player: Player, other: Player): void {
-        buf.pBit(1, 1);
-        buf.pBit(2, 0);
-        this.highdefinition(updates, renderer, player, other);
-    }
-
-    private idle(buf: Packet): void {
-        buf.pBit(1, 0);
     }
 
     private highdefinition(updates: Packet, renderer: PlayerRenderer, player: Player, other: Player): void {


### PR DESCRIPTION
Instead of doing:
```ts
            const length: number = renderer.highdefinitions(pid);
            const extend: boolean = length > 0;
            const { walkDir, runDir } = other;
            if (runDir !== -1) {
                this.run(buf, updates, renderer, player, other, walkDir, runDir, extend && this.willFit(bytes, buf, PlayerInfoEncoder.BITS_RUN, length));
            } else if (walkDir !== -1) {
                this.walk(buf, updates, renderer, player, other, walkDir, extend && this.willFit(bytes, buf, PlayerInfoEncoder.BITS_WALK, length));
            } else if (extend && this.willFit(bytes, buf, PlayerInfoEncoder.BITS_EXTENDED, length)) {
                this.extend(buf, updates, renderer, player, other);
            } else {
                this.idle(buf);
            }
```
For every local player/npc, for every player, we can do this logic once per player, store the bits, then all players can lookup from that during the loop.

I renamed `caches` to `infos` in `Renderer`.