### PR TITLE
fix(engine): send reboot timer on reconnect

### DIFF
--- a/src/engine/World.ts
+++ b/src/engine/World.ts
@@ -1697,6 +1697,14 @@ class World {
         }
     }
 
+    get isPendingShutdown(): boolean {
+        return this.shutdownTicksRemaining > -1;
+    }
+
+    get shutdownTicksRemaining(): number {
+        return this.shutdownTick - this.currentTick;
+    }
+
     broadcastMes(message: string): void {
         for (const player of this.players) {
             if (message.includes('\n')) {

--- a/src/engine/entity/Player.ts
+++ b/src/engine/entity/Player.ts
@@ -77,6 +77,7 @@ import { ChatModePrivate, ChatModePublic, ChatModeTradeDuel } from '#/util/ChatM
 import LoggerEventType from '#/server/logger/LoggerEventType.js';
 import InputTracking from '#/engine/entity/tracking/InputTracking.js';
 import Visibility from './Visibility.js';
+import UpdateRebootTimer from '#/network/server/model/UpdateRebootTimer.js';
 
 const levelExperience = new Int32Array(99);
 
@@ -401,6 +402,11 @@ export default class Player extends PathingEntity {
         // force resyncing
         // reload entity info (overkill? does the client have some logic around this?)
         this.buildArea.clear(true);
+        // in case of pending update
+        if (World.isPendingShutdown) {
+            const ticksBeforeShutdown = World.shutdownTicksRemaining;
+            this.write(new UpdateRebootTimer(ticksBeforeShutdown));
+        }
         // rebuild scene (rebuildnormal won't run if you're in the same zone!)
         this.originX = -1;
         this.originZ = -1;


### PR DESCRIPTION
This ensures that, if there is a pending server shutdown ("system update") when a client reconnects, that the number of ticks remaining will be sent. Otherwise, on reconnection, the client loses the timer.