### PR TITLE
fix(content): make cooking 1t faster

### DIFF
--- a/data/src/scripts/skill_cooking/scripts/cooking.rs2
+++ b/data/src/scripts/skill_cooking/scripts/cooking.rs2
@@ -127,7 +127,7 @@ switch_obj($uncooked_item) {
 // rsc delays for about 3 ticks.
 // This post says they removed unnecessary delays and "None of the above no longer take any more time than in Runescape 1."
 // https://oldschool.runescape.wiki/w/Update:Huge_Runescape_2_update
-p_delay(2);
+p_delay(1);
 inv_del(inv, $uncooked_item, 1);
 
 if ($passes_roll = true) {


### PR DESCRIPTION
From a [speed training guide](https://web.archive.org/web/20041013102610/http://runehq.com/viewspecialreports.php?id=00248) `5.Keep an eye out for the text messages instead of the animation. The animation takes longer than the action itself, and can save you quite some time, if you follow the messages instead.`

Currently our cooking is 4 ticks. At a range its not really noticeable that the 'animation takes longer than the action itself' at this 4t speed. Its only noticeable at 3 ticks.


I think also during the rs2 beta, cooking was slower than rsc (3 ticks). They made a [blog post](https://oldschool.runescape.wiki/w/Update:RS2_progress_report) that mentions cooking speeds: `We have also been working hard to tweak RS2 on the basis of your feedback. For instance we've been working to make sure the nice graphics and animations don't get in the way of the actual game. This means reducing the delay/lag on lots of animations, and removing a few annoying animations entirely - so things like cooking, taking items, dropping items, and other skills, are much faster to do (no longer slower to do than rs1). You will see some of these changes in next weeks update, and they really help the game flow a lot better.`

4t cooking:


https://github.com/user-attachments/assets/ae277bc6-576b-4f32-a6a6-06fdf0c6861f



3t cooking:

https://github.com/user-attachments/assets/4f7f0ea6-1235-45e1-8f2a-aeb2a0f1bdb2

