### PR TITLE
feat(engine): search for nearby players using different algorithms

### DIFF
--- a/src/engine/entity/BuildArea.ts
+++ b/src/engine/entity/BuildArea.ts
@@ -59,6 +59,27 @@ export default class BuildArea {
         }
     }
 
+    rebuildNpcs(): void {
+        // optimization to avoid sending 3 bits * observed npcs when everything has to be removed anyways
+        this.npcs.clear();
+    }
+
+    rebuildPlayers(pid: number, level: number, x: number, z: number): void {
+        // optimization to avoid sending 3 bits * observed players when everything has to be removed anyways
+        this.players.clear();
+        this.lastResize = 0;
+        this.viewDistance = BuildArea.PREFERRED_VIEW_DISTANCE;
+        // pre calc if we can go ahead and shorten view distance
+        let count: number = 0;
+        for (const _ of this.getNearbyPlayersByClosest(pid, level, x, z)) {
+            count++;
+            if (count >= BuildArea.PREFERRED_PLAYERS) {
+                this.viewDistance--;
+                break;
+            }
+        }
+    }
+
     hasAppearance(pid: number, tick: number): boolean {
         const appearance: number | undefined = this.appearances.get(pid);
         if (typeof appearance === 'undefined') {
@@ -72,6 +93,14 @@ export default class BuildArea {
     }
 
     *getNearbyPlayers(pid: number, level: number, x: number, z: number): IterableIterator<Player> {
+        if (this.viewDistance < BuildArea.PREFERRED_VIEW_DISTANCE) {
+            yield *this.getNearbyPlayersByClosest(pid, level, x, z);
+        } else {
+            yield *this.getNearbyPlayersByZones(pid, level, x, z);
+        }
+    }
+
+    private *getNearbyPlayersByClosest(pid: number, level: number, x: number, z: number): IterableIterator<Player> {
         const radius = this.viewDistance * 2;
         const min = -radius >> 1;
         const max = radius >> 1;
@@ -90,13 +119,7 @@ export default class BuildArea {
                         if (this.players.size >= BuildArea.PREFERRED_PLAYERS) {
                             return;
                         }
-                        if (
-                            player.pid !== -1 &&
-                            player.pid !== pid &&
-                            CoordGrid.isWithinDistanceSW({ x: x + dx, z: z + dz }, player, this.viewDistance) &&
-                            !this.players.has(player) &&
-                            player.level === level
-                        ) {
+                        if (this.filterPlayer(player, pid, level, x, z)) {
                             yield player;
                         }
                     }
@@ -114,6 +137,29 @@ export default class BuildArea {
         }
     }
 
+    private *getNearbyPlayersByZones(pid: number, level: number, x: number, z: number): IterableIterator<Player> {
+        const startX: number = CoordGrid.zone(x - this.viewDistance);
+        const startZ: number = CoordGrid.zone(z - this.viewDistance);
+        const endX: number = CoordGrid.zone(x + this.viewDistance);
+        const endZ: number = CoordGrid.zone(z + this.viewDistance);
+
+        for (let zx = startX; zx <= endX; zx++) {
+            const zoneX: number = zx << 3;
+            for (let zz = startZ; zz <= endZ; zz++) {
+                const zoneZ: number = zz << 3;
+                for (const player of World.gameMap.getZone(zoneX, zoneZ, level).getAllPlayersSafe()) {
+                    if (this.players.size >= BuildArea.PREFERRED_PLAYERS) {
+                        return;
+                    }
+                    if (!this.filterPlayer(player, pid, level, x, z)) {
+                        continue;
+                    }
+                    yield player;
+                }
+            }
+        }
+    }
+
     *getNearbyNpcs(level: number, x: number, z: number): IterableIterator<Npc> {
         const startX: number = CoordGrid.zone(x - BuildArea.PREFERRED_VIEW_DISTANCE);
         const startZ: number = CoordGrid.zone(z - BuildArea.PREFERRED_VIEW_DISTANCE);
@@ -128,12 +174,20 @@ export default class BuildArea {
                     if (this.npcs.size >= BuildArea.PREFERRED_NPCS) {
                         return;
                     }
-                    if (!CoordGrid.isWithinDistanceSW({ x, z }, npc, BuildArea.PREFERRED_VIEW_DISTANCE) || npc.nid === -1 || this.npcs.has(npc) || npc.level !== level) {
+                    if (!this.filterNpc(npc, level, x, z)) {
                         continue;
                     }
                     yield npc;
                 }
             }
         }
+    }
+
+    private filterPlayer(player: Player, pid: number, level: number, x: number, z: number): boolean {
+        return !(!CoordGrid.isWithinDistanceSW({ x, z }, player, this.viewDistance) || player.pid === -1 || player.pid === pid || this.players.has(player) || player.level !== level);
+    }
+
+    private filterNpc(npc: Npc, level: number, x: number, z: number): boolean {
+        return !(!CoordGrid.isWithinDistanceSW({ x, z }, npc, BuildArea.PREFERRED_VIEW_DISTANCE) || npc.nid === -1 || this.npcs.has(npc) || npc.level !== level);
     }
 }

--- a/src/engine/entity/BuildArea.ts
+++ b/src/engine/entity/BuildArea.ts
@@ -138,10 +138,11 @@ export default class BuildArea {
     }
 
     private *getNearbyPlayersByZones(pid: number, level: number, x: number, z: number): IterableIterator<Player> {
-        const startX: number = CoordGrid.zone(x - this.viewDistance);
-        const startZ: number = CoordGrid.zone(z - this.viewDistance);
-        const endX: number = CoordGrid.zone(x + this.viewDistance);
-        const endZ: number = CoordGrid.zone(z + this.viewDistance);
+        const distance: number = BuildArea.PREFERRED_VIEW_DISTANCE;
+        const startX: number = CoordGrid.zone(x - distance);
+        const startZ: number = CoordGrid.zone(z - distance);
+        const endX: number = CoordGrid.zone(x + distance);
+        const endZ: number = CoordGrid.zone(z + distance);
 
         for (let zx = startX; zx <= endX; zx++) {
             const zoneX: number = zx << 3;
@@ -161,10 +162,11 @@ export default class BuildArea {
     }
 
     *getNearbyNpcs(level: number, x: number, z: number): IterableIterator<Npc> {
-        const startX: number = CoordGrid.zone(x - BuildArea.PREFERRED_VIEW_DISTANCE);
-        const startZ: number = CoordGrid.zone(z - BuildArea.PREFERRED_VIEW_DISTANCE);
-        const endX: number = CoordGrid.zone(x + BuildArea.PREFERRED_VIEW_DISTANCE);
-        const endZ: number = CoordGrid.zone(z + BuildArea.PREFERRED_VIEW_DISTANCE);
+        const distance: number = BuildArea.PREFERRED_VIEW_DISTANCE;
+        const startX: number = CoordGrid.zone(x - distance);
+        const startZ: number = CoordGrid.zone(z - distance);
+        const endX: number = CoordGrid.zone(x + distance);
+        const endZ: number = CoordGrid.zone(z + distance);
 
         for (let zx = startX; zx <= endX; zx++) {
             const zoneX: number = zx << 3;

--- a/src/network/rs225/server/codec/NpcInfoEncoder.ts
+++ b/src/network/rs225/server/codec/NpcInfoEncoder.ts
@@ -24,8 +24,7 @@ export default class NpcInfoEncoder extends MessageEncoder<NpcInfo> {
         const buildArea: BuildArea = message.player.buildArea;
 
         if (message.changedLevel || message.deltaX > buildArea.viewDistance || message.deltaZ > buildArea.viewDistance) {
-            // optimization to avoid sending 3 bits * observed npcs when everything has to be removed anyways
-            buildArea.npcs.clear();
+            buildArea.rebuildNpcs();
         }
 
         const updates: Packet = Packet.alloc(1);

--- a/src/network/rs225/server/codec/PlayerInfoEncoder.ts
+++ b/src/network/rs225/server/codec/PlayerInfoEncoder.ts
@@ -21,13 +21,11 @@ export default class PlayerInfoEncoder extends MessageEncoder<PlayerInfo> {
     prot = ServerProt.PLAYER_INFO;
 
     encode(buf: Packet, message: PlayerInfo): void {
-        const buildArea: BuildArea = message.player.buildArea;
+        const player = message.player;
+        const buildArea: BuildArea = player.buildArea;
 
         if (message.changedLevel || message.deltaX > buildArea.viewDistance || message.deltaZ > buildArea.viewDistance) {
-            // optimization to avoid sending 3 bits * observed players when everything has to be removed anyways
-            buildArea.players.clear();
-            buildArea.lastResize = 0;
-            buildArea.viewDistance = BuildArea.PREFERRED_VIEW_DISTANCE;
+            buildArea.rebuildPlayers(player.pid, player.level, player.x, player.z);
         } else {
             buildArea.resize();
         }


### PR DESCRIPTION
Searching for nearby players is done in a spiraling pattern around the player today. This search is particularly only useful when your view distance of players gets smaller and smaller, as player density increases to 250+. 

I add an additional way to search for players by zone lookup, when your view distance is currently unchanged. I've found this to be less work then doing a full spiral loop every tick, when the area is not dense.

![image](https://github.com/user-attachments/assets/58fe8e50-1b15-4751-98c1-26896cfc9e55)

And this is what I get for an extremely packed area.

![image](https://github.com/user-attachments/assets/a9c90ab6-8751-4c1c-906e-de8fea4d2dfc)

I also made it so when you teleport into a dense area of players, this will automatically decrease your view distance and switch to search by nearby.