### PR TITLE
fix(engine): Reorganize interactions, movement, and run energy

### DIFF
--- a/src/engine/World.ts
+++ b/src/engine/World.ts
@@ -847,6 +847,9 @@ class World {
                 // - movement
                 player.processInteraction();
 
+                // - run energy
+                player.updateEnergy();
+
                 if ((player.masks & InfoProt.PLAYER_EXACT_MOVE.id) == 0) {
                     player.validateDistanceWalked();
                 }

--- a/src/engine/World.ts
+++ b/src/engine/World.ts
@@ -33,7 +33,7 @@ import { CrcBuffer32, makeCrcs, makeCrcsAsync } from '#/cache/CrcTable.js';
 import { preloadClient, preloadClientAsync } from '#/cache/PreloadedPacks.js';
 
 import { CoordGrid } from '#/engine/CoordGrid.js';
-import GameMap, {changeLocCollision, changeNpcCollision, changePlayerCollision} from '#/engine/GameMap.js';
+import GameMap, { changeLocCollision, changeNpcCollision, changePlayerCollision } from '#/engine/GameMap.js';
 import { Inventory } from '#/engine/Inventory.js';
 import WorldStat from '#/engine/WorldStat.js';
 
@@ -72,7 +72,21 @@ import Environment from '#/util/Environment.js';
 import { printDebug, printError, printInfo } from '#/util/Logger.js';
 import { createWorker } from '#/util/WorkerFactory.js';
 import HuntModeType from '#/engine/entity/hunt/HuntModeType.js';
-import { trackCycleBandwidthInBytes, trackCycleBandwidthOutBytes, trackCycleClientInTime, trackCycleClientOutTime, trackCycleLoginTime, trackCycleLogoutTime, trackCycleNpcTime, trackCyclePlayerTime, trackCycleTime, trackCycleWorldTime, trackCycleZoneTime, trackNpcCount, trackPlayerCount } from '#/server/Metrics.js';
+import {
+    trackCycleBandwidthInBytes,
+    trackCycleBandwidthOutBytes,
+    trackCycleClientInTime,
+    trackCycleClientOutTime,
+    trackCycleLoginTime,
+    trackCycleLogoutTime,
+    trackCycleNpcTime,
+    trackCyclePlayerTime,
+    trackCycleTime,
+    trackCycleWorldTime,
+    trackCycleZoneTime,
+    trackNpcCount,
+    trackPlayerCount
+} from '#/server/Metrics.js';
 import WalkTriggerSetting from '#/util/WalkTriggerSetting.js';
 import LinkList from '#/util/LinkList.js';
 import { fromBase37, toBase37, toSafeName } from '#/util/JString.js';
@@ -83,16 +97,12 @@ import LoggerEventType from '#/server/logger/LoggerEventType.js';
 import MoveSpeed from '#/engine/entity/MoveSpeed.js';
 import ScriptVarType from '#/cache/config/ScriptVarType.js';
 
-const priv = forge.pki.privateKeyFromPem(
-    Environment.STANDALONE_BUNDLE ?
-        (await (await fetch('data/config/private.pem')).text()) :
-        fs.readFileSync('data/config/private.pem', 'ascii')
-);
+const priv = forge.pki.privateKeyFromPem(Environment.STANDALONE_BUNDLE ? await (await fetch('data/config/private.pem')).text() : fs.readFileSync('data/config/private.pem', 'ascii'));
 
 type LogoutRequest = {
     save: Uint8Array;
     lastAttempt: number;
-}
+};
 
 class World {
     private loginThread = createWorker(Environment.STANDALONE_BUNDLE ? 'LoginThread.js' : './server/login/LoginThread.ts');
@@ -286,33 +296,35 @@ class World {
     }
 
     async loadAsync(): Promise<void> {
-        const count = (await Promise.all([
-            NpcType.loadAsync('data/pack'),
-            ObjType.loadAsync('data/pack'),
-            LocType.loadAsync('data/pack'),
-            FontType.loadAsync('data/pack'),
-            WordEnc.loadAsync('data/pack'),
-            VarPlayerType.loadAsync('data/pack'),
-            ParamType.loadAsync('data/pack'),
-            IdkType.loadAsync('data/pack'),
-            SeqFrame.loadAsync('data/pack'),
-            SeqType.loadAsync('data/pack'),
-            SpotanimType.loadAsync('data/pack'),
-            CategoryType.loadAsync('data/pack'),
-            EnumType.loadAsync('data/pack'),
-            StructType.loadAsync('data/pack'),
-            InvType.loadAsync('data/pack'),
-            MesanimType.loadAsync('data/pack'),
-            DbTableType.loadAsync('data/pack'),
-            DbRowType.loadAsync('data/pack'),
-            HuntType.loadAsync('data/pack'),
-            VarNpcType.loadAsync('data/pack'),
-            VarSharedType.loadAsync('data/pack'),
-            Component.loadAsync('data/pack'),
-            makeCrcsAsync(),
-            preloadClientAsync(),
-            ScriptProvider.loadAsync('data/pack'),
-        ])).at(-1);
+        const count = (
+            await Promise.all([
+                NpcType.loadAsync('data/pack'),
+                ObjType.loadAsync('data/pack'),
+                LocType.loadAsync('data/pack'),
+                FontType.loadAsync('data/pack'),
+                WordEnc.loadAsync('data/pack'),
+                VarPlayerType.loadAsync('data/pack'),
+                ParamType.loadAsync('data/pack'),
+                IdkType.loadAsync('data/pack'),
+                SeqFrame.loadAsync('data/pack'),
+                SeqType.loadAsync('data/pack'),
+                SpotanimType.loadAsync('data/pack'),
+                CategoryType.loadAsync('data/pack'),
+                EnumType.loadAsync('data/pack'),
+                StructType.loadAsync('data/pack'),
+                InvType.loadAsync('data/pack'),
+                MesanimType.loadAsync('data/pack'),
+                DbTableType.loadAsync('data/pack'),
+                DbRowType.loadAsync('data/pack'),
+                HuntType.loadAsync('data/pack'),
+                VarNpcType.loadAsync('data/pack'),
+                VarSharedType.loadAsync('data/pack'),
+                Component.loadAsync('data/pack'),
+                makeCrcsAsync(),
+                preloadClientAsync(),
+                ScriptProvider.loadAsync('data/pack')
+            ])
+        ).at(-1);
 
         this.invs.clear();
         for (let i = 0; i < InvType.count; i++) {
@@ -537,7 +549,9 @@ class World {
             if (Environment.NODE_DEBUG_PROFILE) {
                 printInfo(`tick ${this.currentTick}: ${this.cycleStats[WorldStat.CYCLE]}/${this.tickRate} ms, ${Math.trunc(process.memoryUsage().heapTotal / 1024 / 1024)} MB heap`);
                 printDebug(`${this.getTotalPlayers()}/${World.PLAYERS} players | ${this.getTotalNpcs()}/${World.NPCS} npcs | ${this.gameMap.getTotalZones()} zones | ${this.gameMap.getTotalLocs()} locs | ${this.gameMap.getTotalObjs()} objs`);
-                printDebug(`${this.cycleStats[WorldStat.WORLD]} ms world | ${this.cycleStats[WorldStat.CLIENT_IN]} ms client in | ${this.cycleStats[WorldStat.NPC]} ms npcs | ${this.cycleStats[WorldStat.PLAYER]} ms players | ${this.cycleStats[WorldStat.LOGOUT]} ms logout | ${this.cycleStats[WorldStat.LOGIN]} ms login | ${this.cycleStats[WorldStat.ZONE]} ms zones | ${this.cycleStats[WorldStat.CLIENT_OUT]} ms client out | ${this.cycleStats[WorldStat.CLEANUP]} ms cleanup`);
+                printDebug(
+                    `${this.cycleStats[WorldStat.WORLD]} ms world | ${this.cycleStats[WorldStat.CLIENT_IN]} ms client in | ${this.cycleStats[WorldStat.NPC]} ms npcs | ${this.cycleStats[WorldStat.PLAYER]} ms players | ${this.cycleStats[WorldStat.LOGOUT]} ms logout | ${this.cycleStats[WorldStat.LOGIN]} ms login | ${this.cycleStats[WorldStat.ZONE]} ms zones | ${this.cycleStats[WorldStat.CLIENT_OUT]} ms client out | ${this.cycleStats[WorldStat.CLEANUP]} ms cleanup`
+                );
             }
 
             this.currentTick++;
@@ -625,7 +639,6 @@ class World {
                     npc.huntAll();
                 }
             }
-
         }
 
         this.cycleStats[WorldStat.WORLD] = Date.now() - start;
@@ -651,7 +664,7 @@ class World {
                 }
 
                 if (isClientConnected(player) && player.decodeIn()) {
-                    const followingPlayer = (player.targetOp === ServerTriggerType.APPLAYER3 || player.targetOp === ServerTriggerType.OPPLAYER3);
+                    const followingPlayer = player.targetOp === ServerTriggerType.APPLAYER3 || player.targetOp === ServerTriggerType.OPPLAYER3;
                     if (player.userPath.length > 0 || player.opcalled) {
                         if (player.delayed) {
                             player.unsetMapFlag();
@@ -663,7 +676,8 @@ class World {
                             player.masks |= InfoProt.PLAYER_FACE_ENTITY.id;
                         }
 
-                        if ((!player.busy() && player.opcalled) || player.opucalled) { // opu in osrs doesnt have a busy check
+                        if ((!player.busy() && player.opcalled) || player.opucalled) {
+                            // opu in osrs doesnt have a busy check
                             player.moveClickRequest = false;
                         } else {
                             player.moveClickRequest = true;
@@ -683,13 +697,13 @@ class World {
                         }
                     }
 
-                    if (player.target instanceof Player && followingPlayer) {
-                        if (CoordGrid.distanceToSW(player, player.target) <= 25) {
-                            player.pathToPathingTarget();
-                        } else {
-                            player.clearWaypoints();
-                        }
-                    }
+                    // if (player.target instanceof Player && followingPlayer) {
+                    //     if (CoordGrid.distanceToSW(player, player.target) <= 25) {
+                    //         player.pathToPathingTarget();
+                    //     } else {
+                    //         player.clearWaypoints();
+                    //     }
+                    // }
                 }
 
                 if (this.currentTick - player.lastResponse >= World.TIMEOUT_SOCKET_LOGOUT) {
@@ -902,7 +916,7 @@ class World {
                 player.addSessionLog(LoggerEventType.ENGINE, 'Tried to log in - old session is mid-logout');
 
                 if (isClientConnected(player)) {
-                    player.client.send(Uint8Array.from([ 5 ]));
+                    player.client.send(Uint8Array.from([5]));
                     player.client.close();
                 }
 
@@ -923,7 +937,7 @@ class World {
 
                     if (other instanceof NetworkPlayer && player instanceof NetworkPlayer) {
                         other.client = player.client;
-                        other.client.send(Uint8Array.from([ 15 ]));
+                        other.client.send(Uint8Array.from([15]));
                     }
 
                     other.onReconnect();
@@ -940,7 +954,7 @@ class World {
 
                 if (player instanceof NetworkPlayer) {
                     player.addSessionLog(LoggerEventType.ENGINE, 'Tried to log in - already logged in');
-                    player.client.send(Uint8Array.from([ 5 ]));
+                    player.client.send(Uint8Array.from([5]));
                     player.client.close();
                 }
 
@@ -956,7 +970,6 @@ class World {
 
                 continue;
             }
-
 
             // normal login process
             let pid: number;
@@ -982,9 +995,9 @@ class World {
                 player.client.state = 1;
 
                 if (player.staffModLevel >= 1) {
-                    player.client.send(Uint8Array.from([ 18 ]));
+                    player.client.send(Uint8Array.from([18]));
                 } else {
-                    player.client.send(Uint8Array.from([ 2 ]));
+                    player.client.send(Uint8Array.from([2]));
                 }
             }
 
@@ -1395,7 +1408,7 @@ class World {
         zone.revealObj(obj, obj.receiver64);
         // objs next life cycle always starts from the last time they changed + the inputted duration.
         // accounting for reveal time here.
-        const nextLifecycle: number = (change !== -1 ? (Obj.REVEAL - (this.currentTick - change)) : 0) + this.currentTick + duration;
+        const nextLifecycle: number = (change !== -1 ? Obj.REVEAL - (this.currentTick - change) : 0) + this.currentTick + duration;
         obj.setLifeCycle(nextLifecycle);
         this.trackZone(nextLifecycle, zone);
         this.trackZone(this.currentTick, zone);
@@ -1437,7 +1450,7 @@ class World {
         this.friendThread.postMessage({
             type: 'player_friendslist_add',
             username: player.username,
-            target: targetUsername37,
+            target: targetUsername37
         });
     }
 
@@ -1446,7 +1459,7 @@ class World {
         this.friendThread.postMessage({
             type: 'player_friendslist_remove',
             username: player.username,
-            target: targetUsername37,
+            target: targetUsername37
         });
     }
 
@@ -1455,7 +1468,7 @@ class World {
         this.friendThread.postMessage({
             type: 'player_ignorelist_add',
             username: player.username,
-            target: targetUsername37,
+            target: targetUsername37
         });
     }
 
@@ -1464,7 +1477,7 @@ class World {
         this.friendThread.postMessage({
             type: 'player_ignorelist_remove',
             username: player.username,
-            target: targetUsername37,
+            target: targetUsername37
         });
     }
 
@@ -1476,7 +1489,7 @@ class World {
         this.friendThread.postMessage({
             type: 'player_chat_setmode',
             username: player.username,
-            chatModePrivate: player.privateChat,
+            chatModePrivate: player.privateChat
         });
     }
 
@@ -1510,7 +1523,7 @@ class World {
 
         this.friendThread.postMessage({
             type: 'player_logout',
-            username: player.username,
+            username: player.username
         });
     }
 
@@ -1523,7 +1536,7 @@ class World {
 
         if (isClientConnected(player)) {
             if (response !== -1) {
-                player.client.send(Uint8Array.from([ response ]));
+                player.client.send(Uint8Array.from([response]));
             }
 
             player.client.close();
@@ -1537,7 +1550,7 @@ class World {
             type: 'private_message',
             username: player.username,
             staffLvl: player.staffModLevel,
-            pmId: (Environment.NODE_ID << 24) + (Math.random() * 0xFF << 16) + (this.pmCount++),
+            pmId: (Environment.NODE_ID << 24) + ((Math.random() * 0xff) << 16) + this.pmCount++,
             target: targetUsername37,
             message: message,
             coord: player.coord
@@ -1639,7 +1652,7 @@ class World {
         return this.players.next();
     }
 
-    scaleByPlayerCount(rate : number): number {
+    scaleByPlayerCount(rate: number): number {
         // not sure if it caps at 2k player count or not
         const playerCount = Math.min(this.getTotalPlayers(), 2000);
         return (((4000 - playerCount) * rate) / 4000) | 0; // assuming scale works the same way as the runescript one
@@ -1730,22 +1743,22 @@ class World {
 
             if (reply === -1) {
                 // login server offline
-                client.send(Uint8Array.from([ 8 ]));
+                client.send(Uint8Array.from([8]));
                 client.close();
                 return;
             } else if (reply === 1) {
                 // invalid username or password
-                client.send(Uint8Array.from([ 3 ]));
+                client.send(Uint8Array.from([3]));
                 client.close();
                 return;
             } else if (reply === 3) {
                 // already logged in (on another world)
-                client.send(Uint8Array.from([ 5 ]));
+                client.send(Uint8Array.from([5]));
                 client.close();
                 return;
             } else if (reply === 5) {
                 // account has been disabled (banned)
-                client.send(Uint8Array.from([ 4 ]));
+                client.send(Uint8Array.from([4]));
                 client.close();
                 return;
             }
@@ -1780,7 +1793,7 @@ class World {
                 }
 
                 // bad save :( the player won't be happy
-                client.send(Uint8Array.from([ 13 ]));
+                client.send(Uint8Array.from([13]));
                 client.close();
 
                 // todo: maybe we can tell the login thread to swap for the last-good save?
@@ -1801,7 +1814,7 @@ class World {
         }
     }
 
-    onFriendMessage({ opcode, data }: { opcode: FriendsServerOpcodes, data: any }) {
+    onFriendMessage({ opcode, data }: { opcode: FriendsServerOpcodes; data: any }) {
         try {
             if (opcode === FriendsServerOpcodes.UPDATE_FRIENDLIST) {
                 const username37 = BigInt(data.username37);
@@ -1904,7 +1917,7 @@ class World {
         if (client.opcode === 16 || client.opcode === 18) {
             const rev = World.loginBuf.g1();
             if (rev !== 225) {
-                client.send(Uint8Array.from([ 6 ]));
+                client.send(Uint8Array.from([6]));
                 client.close();
                 return;
             }
@@ -1916,7 +1929,7 @@ class World {
             World.loginBuf.gdata(crcs, 0, crcs.length);
 
             if (CrcBuffer32 !== Packet.getcrc(crcs, 0, crcs.length)) {
-                client.send(Uint8Array.from([ 6 ]));
+                client.send(Uint8Array.from([6]));
                 client.close();
                 return;
             }
@@ -1926,7 +1939,7 @@ class World {
             if (World.loginBuf.g1() !== 10) {
                 // RSA error
                 // sending out of date intentionally
-                client.send(Uint8Array.from([ 6 ]));
+                client.send(Uint8Array.from([6]));
                 client.close();
                 return;
             }
@@ -1949,26 +1962,26 @@ class World {
             // todo: record login attempt?
 
             if (username.length < 1 || username.length > 12) {
-                client.send(Uint8Array.from([ 3 ]));
+                client.send(Uint8Array.from([3]));
                 client.close();
                 return;
             }
 
             if (password.length < 1 || password.length > 20) {
-                client.send(Uint8Array.from([ 3 ]));
+                client.send(Uint8Array.from([3]));
                 client.close();
                 return;
             }
 
             if (this.getTotalPlayers() > 2000) {
-                client.send(Uint8Array.from([ 7 ]));
+                client.send(Uint8Array.from([7]));
                 client.close();
                 return;
             }
 
             if (this.logoutRequests.has(username)) {
                 // still trying to log out from the last session on this world!
-                client.send(Uint8Array.from([ 5 ]));
+                client.send(Uint8Array.from([5]));
                 client.close();
                 return;
             }

--- a/src/engine/entity/PathingEntity.ts
+++ b/src/engine/entity/PathingEntity.ts
@@ -1,6 +1,6 @@
 import World from '#/engine/World.js';
 import ServerTriggerType from '#/engine/script/ServerTriggerType.js';
-import {CoordGrid} from '#/engine/CoordGrid.js';
+import { CoordGrid } from '#/engine/CoordGrid.js';
 
 import BlockWalk from '#/engine/entity/BlockWalk.js';
 import Entity from '#/engine/entity/Entity.js';
@@ -19,29 +19,16 @@ import LocType from '#/cache/config/LocType.js';
 
 import Environment from '#/util/Environment.js';
 
-import {CollisionFlag, CollisionType} from '@2004scape/rsmod-pathfinder';
+import { CollisionFlag, CollisionType } from '@2004scape/rsmod-pathfinder';
 
-import {
-    canTravel,
-    changeNpcCollision,
-    changePlayerCollision,
-    findNaivePath,
-    findPath,
-    findPathToEntity,
-    findPathToLoc,
-    isApproached,
-    isMapBlocked,
-    reachedEntity,
-    reachedLoc,
-    reachedObj
-} from '#/engine/GameMap.js';
+import { canTravel, changeNpcCollision, changePlayerCollision, findNaivePath, findPath, findPathToEntity, findPathToLoc, isApproached, isMapBlocked, reachedEntity, reachedLoc, reachedObj } from '#/engine/GameMap.js';
 import NonPathingEntity from '#/engine/entity/NonPathingEntity.js';
 import Visibility from '#/engine/entity/Visibility.js';
 
 type TargetSubject = {
-    type: number,
+    type: number;
     com: number;
-}
+};
 
 export type TargetOp = ServerTriggerType | NpcMode;
 
@@ -80,7 +67,7 @@ export default abstract class PathingEntity extends Entity {
     repathed: boolean = false;
     target: Entity | null = null;
     targetOp: TargetOp = -1;
-    targetSubject: TargetSubject = {type: -1, com: -1};
+    targetSubject: TargetSubject = { type: -1, com: -1 };
     apRange: number = 10;
     apRangeCalled: boolean = false;
 
@@ -112,19 +99,7 @@ export default abstract class PathingEntity extends Entity {
     graphicHeight: number = -1;
     graphicDelay: number = -1;
 
-    protected constructor(
-        level: number,
-        x: number,
-        z: number,
-        width: number,
-        length: number,
-        lifecycle: EntityLifeCycle,
-        moveRestrict: MoveRestrict,
-        blockWalk: BlockWalk,
-        moveStrategy: MoveStrategy,
-        coordmask: number,
-        entitymask: number
-    ) {
+    protected constructor(level: number, x: number, z: number, width: number, length: number, lifecycle: EntityLifeCycle, moveRestrict: MoveRestrict, blockWalk: BlockWalk, moveStrategy: MoveStrategy, coordmask: number, entitymask: number) {
         super(level, x, z, width, length, lifecycle);
         this.moveRestrict = moveRestrict;
         this.blockWalk = blockWalk;
@@ -166,7 +141,8 @@ export default abstract class PathingEntity extends Entity {
             if (this.lastCrawl && this.walkDir === -1) {
                 this.walkDir = this.validateAndAdvanceStep();
             }
-        } else if (this.walkDir === -1) { // either walk or run speed here.
+        } else if (this.walkDir === -1) {
+            // either walk or run speed here.
             this.walkDir = this.validateAndAdvanceStep();
             if (this.moveSpeed === MoveSpeed.RUN && this.walkDir !== -1 && this.runDir === -1) {
                 this.runDir = this.validateAndAdvanceStep();
@@ -480,13 +456,17 @@ export default abstract class PathingEntity extends Entity {
         if (!this.target) {
             return;
         }
-        
+
         if (!(this.target instanceof PathingEntity)) {
             this.pathToTarget();
             return;
         }
 
-        if (Environment.NODE_CLIENT_ROUTEFINDER && CoordGrid.intersects(this.x, this.z, this.width, this.length, this.target.x, this.target.z, this.target.width, this.target.length)) {
+        if (
+            !(this.targetOp === ServerTriggerType.APPLAYER3 || this.targetOp === ServerTriggerType.OPPLAYER3) &&
+            Environment.NODE_CLIENT_ROUTEFINDER &&
+            CoordGrid.intersects(this.x, this.z, this.width, this.length, this.target.x, this.target.z, this.target.width, this.target.length)
+        ) {
             this.queueWaypoints(findNaivePath(this.level, this.x, this.z, this.target.x, this.target.z, this.width, this.length, this.target.width, this.target.length, 0, CollisionType.NORMAL));
             return;
         }
@@ -543,7 +523,7 @@ export default abstract class PathingEntity extends Entity {
                 if (this.width > 1 && !CoordGrid.intersects(this.x, this.z, this.width, this.length, this.target.x, this.target.z, this.target.width, this.target.length)) {
                     // west/east
                     let dir = CoordGrid.face(this.x, 0, this.target.x, 0);
-                    const distanceToTarget = CoordGrid.distanceTo({x: this.x, z: this.z, width: this.width, length: this.length}, {x: this.target.x, z: this.target.z, width: this.target.width, length: this.target.length});
+                    const distanceToTarget = CoordGrid.distanceTo({ x: this.x, z: this.z, width: this.width, length: this.length }, { x: this.target.x, z: this.target.z, width: this.target.width, length: this.target.length });
                     if (canTravel(this.level, this.x, this.z, CoordGrid.deltaX(dir), 0, this.width, extraFlag, collisionStrategy) || distanceToTarget <= 1) {
                         this.queueWaypoint(CoordGrid.moveX(this.x, dir), this.z);
                         return;
@@ -582,15 +562,11 @@ export default abstract class PathingEntity extends Entity {
 
         this.target = target;
         this.targetOp = op;
-        this.targetSubject = subject ?? {type: -1, com: -1};
+        this.targetSubject = subject ?? { type: -1, com: -1 };
         this.apRange = 10;
         this.apRangeCalled = false;
 
-        this.focus(
-            CoordGrid.fine(target.x, target.width),
-            CoordGrid.fine(target.z, target.length),
-            target instanceof NonPathingEntity && interaction === Interaction.ENGINE
-        );
+        this.focus(CoordGrid.fine(target.x, target.width), CoordGrid.fine(target.z, target.length), target instanceof NonPathingEntity && interaction === Interaction.ENGINE);
 
         if (target instanceof Player) {
             const pid: number = target.pid + 32768;
@@ -617,7 +593,7 @@ export default abstract class PathingEntity extends Entity {
     clearInteraction(): void {
         this.target = null;
         this.targetOp = -1;
-        this.targetSubject = {type: -1, com: -1};
+        this.targetSubject = { type: -1, com: -1 };
         this.apRange = 10;
         this.apRangeCalled = false;
     }
@@ -692,7 +668,7 @@ export default abstract class PathingEntity extends Entity {
         const srcX: number = this.x;
         const srcZ: number = this.z;
 
-        const {x, z} = CoordGrid.unpackCoord(this.waypoints[this.waypointIndex]);
+        const { x, z } = CoordGrid.unpackCoord(this.waypoints[this.waypointIndex]);
         const dir: number = CoordGrid.face(srcX, srcZ, x, z);
         const dx: number = CoordGrid.deltaX(dir);
         const dz: number = CoordGrid.deltaZ(dir);

--- a/src/engine/entity/PathingEntity.ts
+++ b/src/engine/entity/PathingEntity.ts
@@ -53,6 +53,8 @@ export default abstract class PathingEntity extends Entity {
     jump: boolean = false;
     lastStepX: number = -1;
     lastStepZ: number = -1;
+    followX: number = -1;
+    followZ: number = -1;
     stepsTaken: number = 0;
     lastInt: number = -1; // resume_p_countdialog, ai_queue
     lastCrawl: boolean = false;
@@ -476,7 +478,7 @@ export default abstract class PathingEntity extends Entity {
         }
 
         if (this.targetOp === ServerTriggerType.APPLAYER3 || this.targetOp === ServerTriggerType.OPPLAYER3) {
-            this.queueWaypoint(this.target.lastStepX, this.target.lastStepZ);
+            this.queueWaypoint(this.target.followX, this.target.followZ);
             return;
         }
 

--- a/src/engine/entity/Player.ts
+++ b/src/engine/entity/Player.ts
@@ -999,6 +999,9 @@ export default class Player extends PathingEntity {
     }
 
     processInteraction() {
+        this.followX = this.lastStepX;
+        this.followZ = this.lastStepZ;
+
         if (this.target === null || !this.canAccess()) {
             this.updateMovement(false);
             return false;
@@ -1017,14 +1020,17 @@ export default class Player extends PathingEntity {
         // Follow interaction behaves different than standard ones
         if (this.targetOp === ServerTriggerType.APPLAYER3 || this.targetOp === ServerTriggerType.OPPLAYER3) {
             const walktrigger: number = this.walktrigger;
-            if (this.hasWaypoints()) {
-                this.processWalktrigger();
-            }
-            const moved: boolean = this.updateMovement(false);
-            if (!moved && walktrigger !== -1 && this.target instanceof Player && (this.x !== this.target.lastStepX || this.z !== this.target.lastStepZ)) {
+
+            this.pathToPathingTarget();
+            this.processWalktrigger();
+
+            if (!this.hasWaypoints()) {
                 this.clearInteraction();
                 this.unsetMapFlag();
+                return;
             }
+
+            this.updateMovement(false);
             return;
         }
 

--- a/src/engine/entity/Player.ts
+++ b/src/engine/entity/Player.ts
@@ -501,18 +501,18 @@ export default class Player extends PathingEntity {
 
     // ----
 
-    updateMovement(repathAllowed: boolean = true): boolean {
+    updateMovement(): boolean {
         // players cannot walk if they have a modal open *and* something in their queue, confirmed as far back as 2005
         if (this.moveClickRequest && this.busy() && (this.queue.head() != null || this.engineQueue.head() != null || this.walktrigger !== -1)) {
             this.recoverEnergy(false);
             return false;
         }
 
+        // todo: I think this code block should not exist
+        //       Even if we want behavior to match 2023+ osrs behavior, this block of code is likely redundant
+        //       -markb5
         if (Environment.NODE_WALKTRIGGER_SETTING === WalkTriggerSetting.PLAYERMOVEMENT && !this.target && this.hasWaypoints()) {
             this.processWalktrigger();
-        }
-        if (repathAllowed && this.target instanceof PathingEntity && !this.interacted && this.walktrigger === -1) {
-            this.pathToPathingTarget();
         }
         if (this.moveSpeed !== MoveSpeed.INSTANT) {
             this.moveSpeed = this.defaultMoveSpeed();
@@ -1003,7 +1003,7 @@ export default class Player extends PathingEntity {
         this.followZ = this.lastStepZ;
 
         if (this.target === null || !this.canAccess()) {
-            this.updateMovement(false);
+            this.updateMovement();
             return false;
         }
 
@@ -1030,7 +1030,7 @@ export default class Player extends PathingEntity {
                 return;
             }
 
-            this.updateMovement(false);
+            this.updateMovement();
             return;
         }
 
@@ -1051,6 +1051,7 @@ export default class Player extends PathingEntity {
 
         // Otherwise, a target still exists to try to interact with
         else if (this.target) {
+            this.pathToPathingTarget();
             this.processWalktrigger();
             moved = this.updateMovement();
             this.tryInteract(!moved);

--- a/src/engine/entity/Player.ts
+++ b/src/engine/entity/Player.ts
@@ -255,7 +255,6 @@ export default class Player extends PathingEntity {
     }[] = [];
     allowDesign: boolean = false;
     afkEventReady: boolean = false;
-    interactWalkTrigger: boolean = false;
     moveClickRequest: boolean = false;
 
     loggedOut: boolean = false; // pending logout processing
@@ -1034,9 +1033,8 @@ export default class Player extends PathingEntity {
             return;
         }
 
-        if (!this.interactWalkTrigger || this.hasWaypoints()) {
+        if (this.hasWaypoints()) {
             this.processWalktrigger();
-            this.interactWalkTrigger = true;
         }
 
         // Try an interaction

--- a/src/network/rs225/client/handler/MoveClickHandler.ts
+++ b/src/network/rs225/client/handler/MoveClickHandler.ts
@@ -38,7 +38,6 @@ export default class MoveClickHandler extends MessageHandler<MoveClick> {
         if (Environment.NODE_WALKTRIGGER_SETTING === WalkTriggerSetting.PLAYERPACKET) {
             player.pathToMoveClick(player.userPath, !Environment.NODE_CLIENT_ROUTEFINDER);
         }
-        player.interactWalkTrigger = false;
         if (!message.opClick) {
             player.clearPendingAction();
             if (player.runenergy < 100 && message.ctrlHeld === 1) {


### PR DESCRIPTION
Stacks on previous pull request: https://github.com/2004Scape/Server/pull/1238


This is mostly a significant code re-organization with very minor behavioral differences. The logic in the movement-interaction block of code is significantly de-duplicated and is now structured as simple as possible. This is likely my final commit to this portion of the code

These are some small behavioral differences that this PR accomplishes

1. Run energy logic is now handled _after_ the interaction attempt that happens after player movement. This means that if the interaction trigger p_delays the player, run energy will not increment or decrement. This is authentic to rs2 behavior
2. Previously, the logic would check if the player is in a different location than they started to determine that they 'moved'. This is not a robust way of handling this. It now checks if the player has taken more than 0 steps in the tick. This, also, is authentic to rs2