### PR TITLE
fix(engine): lineofsight and lineofwalk commands returning true for members zones in F2P

### DIFF
--- a/src/engine/script/handlers/ServerOps.ts
+++ b/src/engine/script/handlers/ServerOps.ts
@@ -21,7 +21,7 @@ import HuntVis from '#/engine/entity/hunt/HuntVis.js';
 
 import Environment from '#/util/Environment.js';
 
-import { LocLayer, LocAngle, isZoneAllocated } from '@2004scape/rsmod-pathfinder';
+import { LocLayer, LocAngle } from '@2004scape/rsmod-pathfinder';
 
 import {
     isIndoors,

--- a/src/engine/script/handlers/ServerOps.ts
+++ b/src/engine/script/handlers/ServerOps.ts
@@ -21,7 +21,7 @@ import HuntVis from '#/engine/entity/hunt/HuntVis.js';
 
 import Environment from '#/util/Environment.js';
 
-import {LocLayer, LocAngle} from '@2004scape/rsmod-pathfinder';
+import { LocLayer, LocAngle, isZoneAllocated } from '@2004scape/rsmod-pathfinder';
 
 import {
     isIndoors,
@@ -155,6 +155,11 @@ const ServerOps: CommandHandlers = {
         const to: CoordGrid = check(c2, CoordValid);
 
         if (from.level !== to.level) {
+            state.pushInt(0);
+            return;
+        }
+
+        if (!Environment.NODE_MEMBERS && !World.gameMap.isFreeToPlay(to.x, to.z)) {
             state.pushInt(0);
             return;
         }
@@ -296,6 +301,11 @@ const ServerOps: CommandHandlers = {
         const to: CoordGrid = check(c2, CoordValid);
 
         if (from.level !== to.level) {
+            state.pushInt(0);
+            return;
+        }
+
+        if (!Environment.NODE_MEMBERS && !World.gameMap.isFreeToPlay(to.x, to.z)) {
             state.pushInt(0);
             return;
         }


### PR DESCRIPTION
To fix being able to get out into members areas.
To be clear, the members areas are unloaded and you cannot actually do anything while on a F2P world.

![image](https://github.com/user-attachments/assets/9575ffe0-4abf-4faf-9750-8e86685fa94d)
