### PR TITLE
fix(content): correct Sedridor typo

### DIFF
--- a/data/src/scripts/areas/area_wizard_tower/scripts/sedridor.rs2
+++ b/data/src/scripts/areas/area_wizard_tower/scripts/sedridor.rs2
@@ -153,7 +153,7 @@ if(inv_total(inv, notes) = 0) {
 ~chatnpc("<p,neutral>When this Tower was burnt down the secret of creating runes was lost to us for all time... except it wasn't. Some months ago, while searching these ruins for information from old days,");
 ~chatnpc("<p,neutral>I came upon a scroll, almost destroyed, that detailed a magical rock deep in the icefields of the North, closed off from access by anything other than magical means.");
 ~chatnpc("<p,neutral>This rock was called the 'Rune Essence' by the|magicians who studied its powers. Apparently, by simply|breaking a chunk from it, a Rune Stone could be|fashioned very quickly and easily at certain");
-~chatnpc("<p,neutral>elemental altars that were scattered across the land|back then. Now, this is an intersting little piece of|history, but not much use to us as modern wizards|without access to the Rune Essence,");
+~chatnpc("<p,neutral>elemental altars that were scattered across the land|back then. Now, this is an interesting little piece of|history, but not much use to us as modern wizards|without access to the Rune Essence,");
 ~chatnpc("<p,neutral>or these elemental altars. This is where you and|Aubury come into this story. A few weeks back,|Aubury discovered in a standard delivery of runes|to his store, a parchment detailing a");
 ~chatnpc("<p,neutral>teleportation spell that he had never come across before. To his shock, when cast it took him to a strange rock he had never encountered before... yet that felt strangely familiar...");
 ~chatnpc("<p,neutral>As I'm sure you have now guessed, he had discovered a portal leading to the mythical Rune Essence. As soon as he told me of this spell I saw the importance of his find,");


### PR DESCRIPTION
Fix typo in sedridor typo

2008 source: https://www.youtube.com/watch?v=rCC0CJQoXAE
Transcript source: https://runescape.wiki/w/Transcript:Rune_Mysteries_(historical)

I don't see any evidence that this typo is authentic