### PR TITLE
fix(content): changes to chompy bird tracking, ranged xp reward

### DIFF
--- a/data/src/scripts/quests/quest_chompybird/configs/quest_chompybird.constant
+++ b/data/src/scripts/quests/quest_chompybird/configs/quest_chompybird.constant
@@ -26,7 +26,3 @@
 // 0 = not set, 1 = tomato, 2 = doogle leaves
 ^chompybird_varbit_fycie_flavour_start = 4
 ^chompybird_varbit_fycie_flavour_end = 5
-
-// max value 16384 (guess)
-^chompybird_varbit_kills_start = 6
-^chompybird_varbit_kills_end = 20

--- a/data/src/scripts/quests/quest_chompybird/scripts/chompy_bird.rs2
+++ b/data/src/scripts/quests/quest_chompybird/scripts/chompy_bird.rs2
@@ -126,8 +126,8 @@ if (
 
 def_obj $ammo = inv_getobj(worn, ^wearpos_quiver);
 if ($ammo = null) {
-    // todo confirm for 2004
-    mes("There is no ammo left in your quiver.");
+    // https://youtu.be/Qc-4z_z2JLk?si=Bh2bAhDlFQxedAqg&t=446
+    mes("There is no ammo left in your quiver");
     return;
 }
 
@@ -214,11 +214,10 @@ inv_moveitem(worn, ranged_quiver_inv, $ammo, 1);
 return(~npc_projectile(coord, npc_uid, oc_param($ammo, proj_travel), 40, 36, 41, 15, 5, 11, 5));
 
 [ai_queue3,chompy_bird]
-gosub(npc_death);
-
-if(npc_findhero = true) {
+if(npc_findhero = true) { // happens before npc_death
     queue(chompybird_kill, 0);
 }
+gosub(npc_death);
 
 // todo confirm duration
 npc_add(npc_coord, chompy_bird_corpse, 100);
@@ -226,6 +225,17 @@ npc_add(npc_coord, chompy_bird_corpse, 100);
 [queue,chompybird_kill]
 if (%chompybird_progress = ^chompybird_rantz_gave_player_bow) {
     %chompybird_progress = ^chompybird_player_killed_chompy;
+    return;
 }
-def_int $kills = getbit_range(%chompybird_kills, ^chompybird_varbit_kills_start, ^chompybird_varbit_kills_end);
-%chompybird_kills = setbit_range_toint(%chompybird_kills, calc($kills + 1), ^chompybird_varbit_kills_start, ^chompybird_varbit_kills_end);
+if(%chompybird_kills >= 100000) { 
+    return; 
+}
+// https://youtu.be/7ze4YEvQwHM?si=AYdN3zfe62SP4emb&t=215
+mes("You scratch a notch on your bow for the chompy bird kill.");
+%chompybird_kills = calc(%chompybird_kills + 1);
+if(%chompybird_kills = 4000) {
+    stat_advance(ranged, 300000);
+    mes("You've been awarded ranged experience for your relentless pursuit of chompies!");
+    // https://youtu.be/cQ_HQgUodI0?si=NMThWxkpJozNbe57&t=121
+    ~objbox(chompy_bird_obj, "@blu@**** Congratulations! 4000 Chompies! ****|@dre@~ You're an Expert Dragon Archer! ~|This is the highest honour that can be bestowed on any chompy bird hunter.", 250, 0, ^objbox_height); 
+}

--- a/data/src/scripts/quests/quest_chompybird/scripts/ogre_bow.rs2
+++ b/data/src/scripts/quests/quest_chompybird/scripts/ogre_bow.rs2
@@ -3,7 +3,7 @@ if (%chompybird_progress < ^chompybird_complete) {
     mes("You've scratched up no kills yet! You've got to complete the quest first!");
     return;
 }
-def_int $kills = getbit_range(%chompybird_kills, ^chompybird_varbit_kills_start, ^chompybird_varbit_kills_end);
+def_int $kills = %chompybird_kills;
 def_string $rank = ~add_article(~get_chompy_rank($kills));
 mes("You've scratched up a total of <tostring($kills)> chompy bird kills so far!");
 mes("~ You're <$rank>! ~");

--- a/data/src/scripts/quests/quest_chompybird/scripts/quest_chompybird.rs2
+++ b/data/src/scripts/quests/quest_chompybird/scripts/quest_chompybird.rs2
@@ -38,7 +38,9 @@ inv_add(inv, ogre_bellows_3, 1);
 
 
 [queue,quest_chompybird_complete]
+// https://x.com/JagexAsh/status/1820722879937343844, 294 is probably cleared entirely after quest
 %chompybird_progress = ^chompybird_complete;
+%chompybird_kills = 0;
 stat_advance(fletching, 262);
 stat_advance(cooking, 1470);
 stat_advance(ranged, 735);

--- a/data/src/scripts/skill_fletching/scripts/ogre_arrows.rs2
+++ b/data/src/scripts/skill_fletching/scripts/ogre_arrows.rs2
@@ -135,7 +135,7 @@ inv_del(inv, wolfbone_arrowheads, $arrow_count);
 inv_add(inv, ogre_arrow, $arrow_count);
 
 // todo tbc exact mechanism
-if (%chompybird_progress ! ^chompybird_not_started) {
+if (%chompybird_progress ! ^chompybird_not_started & %chompybird_progress ! ^chompybird_complete) {
     %chompybird_kills = setbit(%chompybird_kills, ^chompybird_varbit_made_arrows);
 }
 


### PR DESCRIPTION
fixes https://github.com/2004Scape/Server/issues/801

* Add ranged xp reward to chompy bird hunting (once you hit 4000), can't confirm it existed for sure before https://oldschool.runescape.wiki/w/Update:Quest_Journals_and_Chompy_Hats, but since tracking did exist (and the reward isn't mentioned as an update anywhere), it seems likely
* reset `chompybird_kills` after quest completion, and cap at 100k (https://x.com/jamesmonger/status/1819334219308343466)

![image](https://github.com/user-attachments/assets/71b51d25-eda2-4d9d-b3a6-ae4b65e02297)
