### PR TITLE
fix: Changed fishing synths to be only on start of the action

### DIFF
--- a/data/src/scripts/skill_fishing/scripts/fishing_spots/cage_harpoon_fishing.rs2
+++ b/data/src/scripts/skill_fishing/scripts/fishing_spots/cage_harpoon_fishing.rs2
@@ -53,7 +53,6 @@ if (%action_delay = calc(map_clock + 3)) {
 if (%action_delay = map_clock) { 
     ~fish_roll(raw_lobster, null, lobster_pot, null);
     anim(human_lobster, 0);
-    sound_synth(fishing_cast, 0, 20);
 }
 if (afk_event = ^true & npc_param(is_whirlpool) = ^false) {
     @macro_event_fishing(lobster_pot);

--- a/data/src/scripts/skill_fishing/scripts/fishing_spots/lure_bait_fishing.rs2
+++ b/data/src/scripts/skill_fishing/scripts/fishing_spots/lure_bait_fishing.rs2
@@ -71,7 +71,7 @@ if (inv_freespace(inv) = 0 & inv_total(inv, feather) > 1) {
 }
 if (%skill_anim = calc(map_clock + 4)) {
     // anim(human_fishing_casting, 0);
-    // sound_synth(fishing_cast, 0, 39);
+    sound_synth(fishing_cast, 0, 39);
     mes("You attempt to catch a fish.");
 }
 if (%action_delay < map_clock) {
@@ -107,7 +107,6 @@ if (%action_delay < map_clock) {
 if (%skill_anim < map_clock) {
     %skill_anim = calc(map_clock + 5);
     anim(human_fishing_casting, 0);
-    sound_synth(fishing_cast, 0, 39);
 }
 mes("You cast out your line...");
 p_opnpc(5);
@@ -135,7 +134,7 @@ if (inv_freespace(inv) = 0 & inv_total(inv, fishing_bait) > 1) {
 }
 if (%skill_anim = calc(map_clock + 4)) {
     // anim(human_fishing_casting, 0);
-    // sound_synth(fishing_cast, 0, 39);
+    sound_synth(fishing_cast, 0, 39);
     mes("You attempt to catch a fish.");
 }
 if (%action_delay < map_clock) {

--- a/data/src/scripts/skill_fishing/scripts/fishing_spots/net_bait_fishing.rs2
+++ b/data/src/scripts/skill_fishing/scripts/fishing_spots/net_bait_fishing.rs2
@@ -52,7 +52,6 @@ if (%action_delay = calc(map_clock + 3)) {
         ~fish_roll(raw_shrimps, null, net, null);
     }
     anim(human_smallnet, 0);
-    sound_synth(fishing_cast, 0, 15);
 }
 
 if (afk_event = ^true & npc_param(is_whirlpool) = ^false) {
@@ -80,14 +79,10 @@ if (%action_delay = map_clock) {
         ~fish_roll(raw_shrimps, null, net, null);
     }
 }
-// play anim every 6 ticks, and sound every 3 ticks
+// play anim every 6 ticks
 if (%skill_anim < map_clock) {
     %skill_anim = calc(map_clock + 5);
     anim(human_smallnet, 0);
-    sound_synth(fishing_cast, 0, 15);
-} else
-if (%skill_anim = calc(map_clock + 2)) {
-    sound_synth(fishing_cast, 0, 15);
 }
 p_opnpc(4);
 

--- a/data/src/scripts/skill_fishing/scripts/fishing_spots/net_harpoon_fishing.rs2
+++ b/data/src/scripts/skill_fishing/scripts/fishing_spots/net_harpoon_fishing.rs2
@@ -36,7 +36,6 @@ if (%action_delay = calc(map_clock + 4)) {
 } else if (%action_delay = map_clock) { 
     ~fish_roll(raw_shark, null, harpoon, null);
     anim(human_harpoon, 0);
-    sound_synth(fishing_cast, 0, 30);
 }
 
 if (afk_event = ^true & npc_param(is_whirlpool) = ^false) {
@@ -72,13 +71,6 @@ if (%skill_anim < map_clock) {
     %skill_anim = calc(map_clock + 7);
     %skill_sound = calc(map_clock + 7);
     anim(human_harpoon, 0);
-}
-// play skill sound every 7 and 4 ticks
-if (%skill_sound = calc(map_clock + 6)) {
-    sound_synth(fishing_cast, 0, 0);
-} else
-if (%skill_sound = calc(map_clock + 3)) {
-    sound_synth(fishing_cast, 0, 10);
 }
 p_opnpc(5);
 
@@ -144,14 +136,10 @@ if (%action_delay < map_clock) {
 if (%action_delay = map_clock) {
     ~fish_roll_big_net;
 }
-// play anim every 6 ticks, and sound every 3 ticks
+// play anim every 6 ticks
 if (%skill_anim < map_clock) {
     %skill_anim = calc(map_clock + 5);
     anim(human_largenet, 0);
-    sound_synth(fishing_cast, 0, 15);
-} else
-if (%skill_anim = calc(map_clock + 2)) {
-    sound_synth(fishing_cast, 0, 15);
 }
 p_opnpc(4);
 


### PR DESCRIPTION
Fishing synths should only play once when you start the action. This saw more changes after https://oldschool.runescape.wiki/w/Update:Area_Sounds