### PR TITLE
fix(engine): I can't reach that! behavior fix + remove unused old code

### DIFF
--- a/src/engine/World.ts
+++ b/src/engine/World.ts
@@ -696,14 +696,6 @@ class World {
                             }
                         }
                     }
-
-                    // if (player.target instanceof Player && followingPlayer) {
-                    //     if (CoordGrid.distanceToSW(player, player.target) <= 25) {
-                    //         player.pathToPathingTarget();
-                    //     } else {
-                    //         player.clearWaypoints();
-                    //     }
-                    // }
                 }
 
                 if (this.currentTick - player.lastResponse >= World.TIMEOUT_SOCKET_LOGOUT) {

--- a/src/engine/entity/Player.ts
+++ b/src/engine/entity/Player.ts
@@ -1060,19 +1060,19 @@ export default class Player extends PathingEntity {
             this.updateMovement();
 
             // If there's a target and p_access is available, try to interact after moving
-            if (this.target && this.canAccess()) {
+            if (this.target && this.canAccess() && !followOp) {
                 interacted = this.tryInteract(this.stepsTaken === 0);
+
+                // If Player did not interact, has no path, and did not move this cycle, terminate the interaction
+                if (!interacted && !this.hasWaypoints() && this.stepsTaken === 0) {
+                    this.messageGame("I can't reach that!");
+                    this.clearInteraction();
+                }
             }
         }
 
-        // If Player did not interact, has no path, and did not move this cycle, terminate the interaction
-        if (!interacted && !this.hasWaypoints() && this.stepsTaken === 0 && this.target && !followOp) {
-            this.messageGame("I can't reach that!");
-            this.clearInteraction();
-        }
-
         // If a script called p_op*, then nextTarget is prepped for next cycle
-        else if (this.nextTarget) {
+        if (this.nextTarget) {
             this.target = this.nextTarget;
         }
 


### PR DESCRIPTION
I can't reach that! was firing prematurely if player p_access was blocked. It is now moved into the portion of the code that requires p_access

Further, a few unused codes were removed