### PR TITLE
feat(engine): submit input reports to logger server

### DIFF
--- a/prisma/multiworld/migrations/20250210235403_input_tracking/migration.sql
+++ b/prisma/multiworld/migrations/20250210235403_input_tracking/migration.sql
@@ -1,0 +1,24 @@
+-- CreateTable
+CREATE TABLE `input_report` (
+    `id` INTEGER NOT NULL AUTO_INCREMENT,
+    `account_id` INTEGER NOT NULL,
+    `timestamp` DATETIME(3) NOT NULL,
+    `session_uuid` VARCHAR(191) NOT NULL,
+
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- CreateTable
+CREATE TABLE `input_report_event` (
+    `input_report_id` INTEGER NOT NULL,
+    `seq` INTEGER NOT NULL,
+    `input_type` INTEGER NOT NULL DEFAULT -1,
+    `delta` INTEGER NOT NULL,
+    `coord` INTEGER NOT NULL,
+    `mouse_x` INTEGER NULL,
+    `mouse_y` INTEGER NULL,
+    `key_code` INTEGER NULL,
+
+    PRIMARY KEY (`input_report_id`, `seq`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+

--- a/prisma/multiworld/schema.prisma
+++ b/prisma/multiworld/schema.prisma
@@ -174,3 +174,24 @@ model report {
     offender String
     reason   Int
 }
+
+model input_report {
+    id              Int @id @default(autoincrement())
+    account_id      Int
+    timestamp       DateTime
+    session_uuid    String
+}
+
+model input_report_event {
+    input_report_id Int
+    seq             Int
+    
+    input_type      Int    @default(-1)
+    delta           Int
+    coord           Int
+    mouse_x         Int?
+    mouse_y         Int?
+    key_code        Int?
+    
+    @@id([input_report_id, seq])
+}

--- a/prisma/singleworld/migrations/20250210135320_input_track/migration.sql
+++ b/prisma/singleworld/migrations/20250210135320_input_track/migration.sql
@@ -1,0 +1,24 @@
+-- CreateTable
+CREATE TABLE `input_report` (
+    `id` INTEGER NOT NULL AUTO_INCREMENT,
+    `account_id` INTEGER NOT NULL,
+    `timestamp` DATETIME(3) NOT NULL,
+    `session_uuid` VARCHAR(191) NOT NULL,
+
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- CreateTable
+CREATE TABLE `input_report_event` (
+    `input_report_id` INTEGER NOT NULL,
+    `seq` INTEGER NOT NULL,
+    `input_type` INTEGER NOT NULL DEFAULT -1,
+    `delta` INTEGER NOT NULL,
+    `coord` INTEGER NOT NULL,
+    `mouse_x` INTEGER NULL,
+    `mouse_y` INTEGER NULL,
+    `key_code` INTEGER NULL,
+
+    PRIMARY KEY (`input_report_id`, `seq`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+

--- a/prisma/singleworld/schema.prisma
+++ b/prisma/singleworld/schema.prisma
@@ -174,3 +174,24 @@ model report {
     offender String
     reason   Int
 }
+
+model input_report {
+    id              Int @id @default(autoincrement())
+    account_id      Int
+    timestamp       DateTime
+    session_uuid    String
+}
+
+model input_report_event {
+    input_report_id Int
+    seq             Int
+    
+    input_type      Int    @default(-1)
+    delta           Int
+    coord           Int
+    mouse_x         Int?
+    mouse_y         Int?
+    key_code        Int?
+    
+    @@id([input_report_id, seq])
+}

--- a/src/db/types.ts
+++ b/src/db/types.ts
@@ -69,6 +69,22 @@ export type login = {
     uid: number;
     ip: string | null;
 };
+export type input_report = {
+    id: Generated<number>;
+    account_id: number;
+    timestamp: Timestamp;
+    session_uuid: string;
+};
+export type input_report_event = {
+    input_report_id: number;
+    seq: number;
+    input_type: Generated<number>;
+    delta: number;
+    coord: number;
+    mouse_x: number | null;
+    mouse_y: number | null;
+    key_code: number | null;
+};
 export type newspost = {
     id: Generated<number>;
     category: number;
@@ -122,6 +138,8 @@ export type DB = {
     hiscore: hiscore;
     hiscore_large: hiscore_large;
     ignorelist: ignorelist;
+    input_report: input_report;
+    input_report_event: input_report_event;
     ipban: ipban;
     login: login;
     newspost: newspost;

--- a/src/engine/World.ts
+++ b/src/engine/World.ts
@@ -96,6 +96,7 @@ import Isaac from '#/io/Isaac.js';
 import LoggerEventType from '#/server/logger/LoggerEventType.js';
 import MoveSpeed from '#/engine/entity/MoveSpeed.js';
 import ScriptVarType from '#/cache/config/ScriptVarType.js';
+import InputTrackingEvent from './entity/tracking/InputEvent.js';
 
 const priv = forge.pki.privateKeyFromPem(Environment.STANDALONE_BUNDLE ? await (await fetch('data/config/private.pem')).text() : fs.readFileSync('data/config/private.pem', 'ascii'));
 
@@ -2073,6 +2074,17 @@ class World {
             coord: player.coord,
             offender,
             reason
+        });
+    }
+
+    submitInputTracking(username: string, session_uuid: string, coord: number, events: InputTrackingEvent[]) {
+        this.loggerThread.postMessage({
+            type: 'input_track',
+            username,
+            session_uuid,
+            timestamp: Date.now(),
+            coord,
+            events
         });
     }
 

--- a/src/engine/entity/tracking/InputEvent.ts
+++ b/src/engine/entity/tracking/InputEvent.ts
@@ -1,0 +1,20 @@
+import { InputTrackingEventType } from '#/network/rs225/client/handler/EventTrackingHandler.js';
+
+export default class InputTrackingEvent {
+
+    readonly type: InputTrackingEventType;
+    readonly seq: number;
+    readonly delta: number;
+    readonly mouseX?: number;
+    readonly mouseY?: number;
+    readonly keyPress?: number;
+
+    constructor(type: InputTrackingEventType, seq: number, delta: number, mouseX?: number, mouseY?: number, keyPress?: number) {
+        this.seq = seq;
+        this.type = type;
+        this.delta = delta;
+        this.mouseX = mouseX;
+        this.mouseY = mouseY;
+        this.keyPress = keyPress;
+    }
+}

--- a/src/server/logger/LoggerClient.ts
+++ b/src/server/logger/LoggerClient.ts
@@ -1,3 +1,4 @@
+import InputTrackingEvent from '#/engine/entity/tracking/InputEvent.js';
 import InternalClient from '#/server/InternalClient.js';
 
 import Environment from '#/util/Environment.js';
@@ -47,6 +48,25 @@ export default class LoggerClient extends InternalClient {
             coord,
             offender,
             reason
+        }));
+    }
+
+    public async inputTrack(username: string, session_uuid: string, timestamp: number, coord: number, events: InputTrackingEvent[]) {
+        await this.connect();
+
+        if (!this.ws || !this.wsr || !this.wsr.checkIfWsLive()) {
+            return;
+        }
+
+        this.ws.send(JSON.stringify({
+            type: 'input_track',
+            world: Environment.NODE_ID,
+            profile: Environment.NODE_PROFILE,
+            username,
+            session_uuid,
+            timestamp,
+            coord,
+            events
         }));
     }
 }

--- a/src/server/logger/LoggerThread.ts
+++ b/src/server/logger/LoggerThread.ts
@@ -58,6 +58,13 @@ async function handleRequests(_parentPort: ParentPort, msg: any) {
             }
             break;
         }
+        case 'input_track': {
+            if (Environment.LOGGER_SERVER) {
+                const { username, session_uuid, timestamp, coord, events } = msg;
+                await client.inputTrack(username, session_uuid, timestamp, coord, events);
+            }
+            break;
+        }
         // todo: store session's packet traffic for analysis
         default:
             console.error('Unknown message type: ' + msg.type);


### PR DESCRIPTION
- All events now report user as active (wasn't sure on intention here - can revert if needed)
- Adds input_report and input_report_event table, populated by logger server on input_track message
