### PR TITLE
fix: fix migration for ignorelist after bad merge

### DIFF
--- a/prisma/singleworld/migrations/20250210220920_sort_friends_ignores/migration.sql
+++ b/prisma/singleworld/migrations/20250210220920_sort_friends_ignores/migration.sql
@@ -13,12 +13,12 @@ DROP TABLE "friendlist";
 ALTER TABLE "new_friendlist" RENAME TO "friendlist";
 CREATE TABLE "new_ignorelist" (
     "account_id" INTEGER NOT NULL,
-    "ignore_account_id" INTEGER NOT NULL,
+    "value" INTEGER NOT NULL,
     "created" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
 
-    PRIMARY KEY ("account_id", "ignore_account_id")
+    PRIMARY KEY ("account_id", "value")
 );
-INSERT INTO "new_ignorelist" ("account_id", "ignore_account_id") SELECT "account_id", "ignore_account_id" FROM "ignorelist";
+INSERT INTO "new_ignorelist" ("account_id", "value") SELECT "account_id", "value" FROM "ignorelist";
 DROP TABLE "ignorelist";
 ALTER TABLE "new_ignorelist" RENAME TO "ignorelist";
 PRAGMA foreign_keys=ON;


### PR DESCRIPTION
migration from #1256 needed a change after #1255 was merged

Raised this as its own PR in case this isn't how you want to do it @Pazaz - I didn't do a new migration because the old one will currently wipe player ignore lists if applied