### PR TITLE
feat: add `configure-dev-stack` setup step to run supporting servers for dev

### DIFF
--- a/tools/server/setup.ts
+++ b/tools/server/setup.ts
@@ -64,6 +64,10 @@ function setDatabase(host: string, port: number, name: string, user: string, pas
     fs.appendFileSync('.env', `DB_HOST=${host}\nDB_PORT=${port}\nDB_NAME=${name}\nDB_USER=${user}\nDB_PASS=${pass}\n`);
 }
 
+function setWebsiteRegistration(state: boolean) {
+    fs.appendFileSync('.env', `WEBSITE_REGISTRATION=${state}\n`);
+}
+
 // ----
 
 async function promptWebPort() {
@@ -241,7 +245,7 @@ async function promptWebsiteRegistration() {
         default: true
     });
 
-    fs.appendFileSync('.env', `WEBSITE_REGISTRATION=${!autoregister}\n`);
+    setWebsiteRegistration(!autoregister);
 }
 
 // ----
@@ -341,7 +345,7 @@ async function configureMulti() {
     fs.copyFileSync('.env.example', '.env');
     fs.appendFileSync('.env', '\n## SETUP SCRIPT\n');
 
-    fs.appendFileSync('.env', 'WEBSITE_REGISTRATION=true\n');
+    setWebsiteRegistration(true);
     setNodeProduction(true);
 
     await promptNodeId();

--- a/tools/server/setup.ts
+++ b/tools/server/setup.ts
@@ -59,6 +59,12 @@ function setLoggerServer(state: boolean, host?: string, port?: number) {
     }
 }
 
+function setLocalSupportServers() {
+    setLoginServer(true, 'localhost', 43500);
+    setFriendServer(true, 'localhost', 45099);
+    setLoggerServer(true, 'localhost', 43501);
+}
+
 function setDatabase(host: string, port: number, name: string, user: string, pass: string) {
     fs.appendFileSync('.env', `DATABASE_URL=mysql://${user}:${pass}@${host}:${port}/${name}\n`);
     fs.appendFileSync('.env', `DB_HOST=${host}\nDB_PORT=${port}\nDB_NAME=${name}\nDB_USER=${user}\nDB_PASS=${pass}\n`);
@@ -330,9 +336,7 @@ async function configureSingle() {
     fs.appendFileSync('.env', 'DB_BACKEND=sqlite\n');
     await promptWebsiteRegistration();
 
-    setLoginServer(true, 'localhost', 43500);
-    setFriendServer(true, 'localhost', 45099);
-    setLoggerServer(true, 'localhost', 43501);
+    setLocalSupportServers();
 
     fs.appendFileSync('.env', 'EASY_STARTUP=true\n');
     child_process.execSync('npm run sqlite:migrate', {

--- a/tools/server/setup.ts
+++ b/tools/server/setup.ts
@@ -65,6 +65,10 @@ function setLocalSupportServers() {
     setLoggerServer(true, 'localhost', 43501);
 }
 
+function setDbBackend(backend: 'sqlite' | 'mysql') {    
+    fs.appendFileSync('.env', `DB_BACKEND=${backend}\n`);
+}
+
 function setDatabase(host: string, port: number, name: string, user: string, pass: string) {
     fs.appendFileSync('.env', `DATABASE_URL=mysql://${user}:${pass}@${host}:${port}/${name}\n`);
     fs.appendFileSync('.env', `DB_HOST=${host}\nDB_PORT=${port}\nDB_NAME=${name}\nDB_USER=${user}\nDB_PASS=${pass}\n`);
@@ -355,6 +359,7 @@ async function configureMulti() {
     await promptNodeId();
     await promptNodeXpRate();
     await promptNodeMembers();
+    setDbBackend('mysql');
     await promptDatabase();
     await promptLogin();
     await promptWebsiteRegistration();


### PR DESCRIPTION
Very similar to "configure single" but in dev mode but I thought this probably deserves its own top-level menu item