### PR TITLE
fix(content): missing if_close when crafting jewelry under level req

### DIFF
--- a/data/src/scripts/skill_crafting/scripts/jewellery/jewellery.rs2
+++ b/data/src/scripts/skill_crafting/scripts/jewellery/jewellery.rs2
@@ -191,6 +191,7 @@ if ($jewelry_obj = obj_1691 | $jewelry_obj = obj_1672 | $jewelry_obj = obj_1653)
 def_struct $struct = oc_param($jewelry_obj, crafting_jewelry_struct);
 def_int $level = struct_param($struct, levelrequired);
 if (stat(crafting) < $level) {
+    if_close;
     ~mesbox("You need at least level <tostring($level)> Crafting to make that.");
     return;
 }


### PR DESCRIPTION
if_close strikes again, this caused the mesbox to never appear and was confusing players as to why nothing was happened when they clicked objs on the crafting interface

https://discord.com/channels/953326730632904844/1339032158249160716 && https://lostcity.rs/t/cannot-make-a-sapphire-amulet-unstrung/978