### PR TITLE
fix(content): Remove "gay" from chat filter

### DIFF
--- a/data/src/wordenc/badenc.txt
+++ b/data/src/wordenc/badenc.txt
@@ -122,7 +122,6 @@ fuq
 fux
 gangrap
 gangrape
-gay
 gecities
 gecity
 genital


### PR DESCRIPTION
Remove "gay" from chat filter:  While aiming for an authentic 2005 experience, censoring "gay" has unintended negative consequences, reinforcing harmful connotations.  This change allows for more inclusive communication.