### PR TITLE
fix(content): heros quest grip walking bug

### DIFF
--- a/data/src/scripts/drop tables/scripts/grip.rs2
+++ b/data/src/scripts/drop tables/scripts/grip.rs2
@@ -11,3 +11,6 @@ if (p_finduid(uid) = true & %hero_progress = ^hero_phoenix_talked_charlie) {
 
 // Key appears for anyone
 obj_addall(npc_coord, npc_param(death_drop), 1, ^lootdrop_duration);
+
+[ai_queue10,grip]
+npc_setmode(null);

--- a/data/src/scripts/drop tables/scripts/grip.rs2
+++ b/data/src/scripts/drop tables/scripts/grip.rs2
@@ -11,6 +11,3 @@ if (p_finduid(uid) = true & %hero_progress = ^hero_phoenix_talked_charlie) {
 
 // Key appears for anyone
 obj_addall(npc_coord, npc_param(death_drop), 1, ^lootdrop_duration);
-
-[ai_queue10,grip]
-npc_setmode(null);

--- a/data/src/scripts/quests/quest_hero/scripts/locs/brimhaven_scarface_mansion.rs2
+++ b/data/src/scripts/quests/quest_hero/scripts/locs/brimhaven_scarface_mansion.rs2
@@ -24,6 +24,7 @@ if (npc_find(coord, pirate_guard, 4, 0) = true) {
         npc_setmode(none);
         npc_walk(0_43_49_25_62);
         npc_say("Stay out of my drinks cabinet!");
+        p_delay(6);
         npc_queue(10, 0, 1);
       }
     case 2 :

--- a/data/src/scripts/quests/quest_hero/scripts/locs/brimhaven_scarface_mansion.rs2
+++ b/data/src/scripts/quests/quest_hero/scripts/locs/brimhaven_scarface_mansion.rs2
@@ -21,6 +21,7 @@ if (npc_find(coord, pirate_guard, 4, 0) = true) {
     case 1 :
       ~chatplayer("<p,neutral>He won't notice me having a quick look.");
       if (npc_find(coord, grip, 12, 0) = true) {
+        npc_setmode(none);
         npc_walk(0_43_49_25_62);
         npc_say("Stay out of my drinks cabinet!");
         npc_queue(10, 0, 1);

--- a/data/src/scripts/quests/quest_hero/scripts/npcs/grip.rs2
+++ b/data/src/scripts/quests/quest_hero/scripts/npcs/grip.rs2
@@ -63,3 +63,6 @@ if (%hero_progress >= ^hero_phoenix_talked_charlie & %phoenixgang_progress >= ^p
 ~chatplayer("<p,neutral>I can't attack the head guard here! There are too many witnesses around to see me do it! I'd have the whole of Brimhaven after me! Besides, if he dies I want the promotion!");
 // todo - I think theres a ~mesbox("") after the chatplayer, but I can't find the source anymore, something about find another player to help
 return(false);
+
+[ai_queue10,grip]
+npc_setmode(null);


### PR DESCRIPTION
Grip was getting distracted before getting into the room to be shot at. This fixes that.

Player delay added to the situation like in OSRS, delay of 7 ticks measured with RSProx.