### PR TITLE
feat(engine): only build appearance once if requested multiple times

### DIFF
--- a/src/engine/entity/Player.ts
+++ b/src/engine/entity/Player.ts
@@ -233,7 +233,7 @@ export default class Player extends PathingEntity {
     webClient: boolean = false;
     combatLevel: number = 3;
     headicons: number = 0;
-    buildAppearance: number = -1;
+    appearance: number = -1;
     lastAppearance: number = 0;
     baseLevels = new Uint8Array(21);
     lastStats: Int32Array = new Int32Array(21); // we track this so we know to flush stats only once a tick on changes
@@ -373,7 +373,7 @@ export default class Player extends PathingEntity {
         this.messageType = null;
         this.message = null;
         this.logMessage = null;
-        this.buildAppearance = -1;
+        this.appearance = -1;
     }
 
     // ----
@@ -1149,7 +1149,7 @@ export default class Player extends PathingEntity {
 
         const skippedSlots = [];
 
-        let worn = this.getInventory(this.buildAppearance);
+        let worn = this.getInventory(this.appearance);
         if (!worn) {
             worn = new Inventory(InvType.WORN, 0);
         }
@@ -1650,7 +1650,7 @@ export default class Player extends PathingEntity {
     }
 
     updateAppearance(inv: number): void {
-        this.buildAppearance = inv;
+        this.appearance = inv;
         this.masks |= InfoProt.PLAYER_APPEARANCE.id;
     }
 

--- a/src/engine/entity/Player.ts
+++ b/src/engine/entity/Player.ts
@@ -1625,7 +1625,7 @@ export default class Player extends PathingEntity {
 
         if (this.combatLevel != this.getCombatLevel()) {
             this.combatLevel = this.getCombatLevel();
-            this.updateAppearance(InvType.WORN);
+            this.buildAppearance(InvType.WORN);
         }
     }
 
@@ -1645,11 +1645,11 @@ export default class Player extends PathingEntity {
 
         if (this.getCombatLevel() != this.combatLevel) {
             this.combatLevel = this.getCombatLevel();
-            this.updateAppearance(InvType.WORN);
+            this.buildAppearance(InvType.WORN);
         }
     }
 
-    updateAppearance(inv: number): void {
+    buildAppearance(inv: number): void {
         this.appearance = inv;
         this.masks |= InfoProt.PLAYER_APPEARANCE.id;
     }

--- a/src/engine/renderer/PlayerRenderer.ts
+++ b/src/engine/renderer/PlayerRenderer.ts
@@ -42,8 +42,8 @@ export default class PlayerRenderer extends Renderer<Player>  {
         let lows: number = 0;
         let highs: number = 0;
 
-        if (masks & InfoProt.PLAYER_APPEARANCE.id && player.appearance) {
-            const length: number = this.cache(pid, new PlayerInfoAppearance(player.appearance), InfoProt.PLAYER_APPEARANCE);
+        if (masks & InfoProt.PLAYER_APPEARANCE.id) {
+            const length: number = this.cache(pid, new PlayerInfoAppearance(player.generateAppearance()), InfoProt.PLAYER_APPEARANCE);
             highs += length;
             lows += length;
         }

--- a/src/engine/script/handlers/PlayerOps.ts
+++ b/src/engine/script/handlers/PlayerOps.ts
@@ -166,7 +166,7 @@ const PlayerOps: CommandHandlers = {
     }),
 
     [ScriptOpcode.BUILDAPPEARANCE]: checkedHandler(ActivePlayer, state => {
-        state.activePlayer.generateAppearance(check(state.popInt(), InvTypeValid).id);
+        state.activePlayer.updateAppearance(check(state.popInt(), InvTypeValid).id);
     }),
 
     [ScriptOpcode.CAM_LOOKAT]: checkedHandler(ActivePlayer, state => {

--- a/src/engine/script/handlers/PlayerOps.ts
+++ b/src/engine/script/handlers/PlayerOps.ts
@@ -166,7 +166,7 @@ const PlayerOps: CommandHandlers = {
     }),
 
     [ScriptOpcode.BUILDAPPEARANCE]: checkedHandler(ActivePlayer, state => {
-        state.activePlayer.updateAppearance(check(state.popInt(), InvTypeValid).id);
+        state.activePlayer.buildAppearance(check(state.popInt(), InvTypeValid).id);
     }),
 
     [ScriptOpcode.CAM_LOOKAT]: checkedHandler(ActivePlayer, state => {


### PR DESCRIPTION
`buildappearance` is generating the byte array every time it is called. this can be optimized by just setting the inv and mask and build the byte array once instead.