### PR TITLE
fix(engine): hard check for 0 count for inv_itemspace commands

### DIFF
--- a/src/engine/script/handlers/InvOps.ts
+++ b/src/engine/script/handlers/InvOps.ts
@@ -269,9 +269,13 @@ const InvOps: CommandHandlers = {
     [ScriptOpcode.INV_ITEMSPACE]: checkedHandler(ActivePlayer, state => {
         const [inv, obj, count, size] = state.popInts(4);
 
+        if (count === 0) {
+            state.pushInt(0);
+            return;
+        }
+
         const invType: InvType = check(inv, InvTypeValid);
         const objType: ObjType = check(obj, ObjTypeValid);
-        check(count, ObjStackValid);
 
         if (size < 0 || size > invType.size) {
             throw new Error(`$count is out of range: ${count}`);
@@ -284,9 +288,13 @@ const InvOps: CommandHandlers = {
     [ScriptOpcode.INV_ITEMSPACE2]: checkedHandler(ActivePlayer, state => {
         const [inv, obj, count, size] = state.popInts(4);
 
+        if (count === 0) {
+            state.pushInt(0);
+            return;
+        }
+
         const invType: InvType = check(inv, InvTypeValid);
         const objType: ObjType = check(obj, ObjTypeValid);
-        check(count, ObjStackValid);
 
         state.pushInt(state.activePlayer.invItemSpace(invType.id, objType.id, count, size));
     }),

--- a/src/engine/script/handlers/InvOps.ts
+++ b/src/engine/script/handlers/InvOps.ts
@@ -276,6 +276,7 @@ const InvOps: CommandHandlers = {
 
         const invType: InvType = check(inv, InvTypeValid);
         const objType: ObjType = check(obj, ObjTypeValid);
+        check(count, ObjStackValid);
 
         if (size < 0 || size > invType.size) {
             throw new Error(`$count is out of range: ${count}`);
@@ -295,6 +296,7 @@ const InvOps: CommandHandlers = {
 
         const invType: InvType = check(inv, InvTypeValid);
         const objType: ObjType = check(obj, ObjTypeValid);
+        check(count, ObjStackValid);
 
         state.pushInt(state.activePlayer.invItemSpace(invType.id, objType.id, count, size));
     }),


### PR DESCRIPTION
Since the change in `obj_count` now can return 0, this command is only used for `inv_itemspace` which was doing a bounds check of 1-2147483647. So we make a change for `inv_itemspace` and `inv_itemspace2` to return false if the inputted count is 0.