### PR TITLE
fix(engine): Revert opu special case

### DIFF
--- a/src/engine/World.ts
+++ b/src/engine/World.ts
@@ -690,8 +690,7 @@ class World {
                             player.masks |= InfoProt.PLAYER_FACE_ENTITY.id;
                         }
 
-                        if ((!player.busy() && player.opcalled) || player.opucalled) {
-                            // opu in osrs doesnt have a busy check
+                        if (!player.busy() && player.opcalled) {
                             player.moveClickRequest = false;
                         } else {
                             player.moveClickRequest = true;

--- a/src/engine/entity/NetworkPlayer.ts
+++ b/src/engine/entity/NetworkPlayer.ts
@@ -49,7 +49,6 @@ export class NetworkPlayer extends Player {
 
     userPath: number[] = [];
     opcalled: boolean = false;
-    opucalled: boolean = false;
 
     constructor(username: string, username37: bigint, hash64: bigint, client: ClientSocket) {
         super(username, username37, hash64);
@@ -61,7 +60,6 @@ export class NetworkPlayer extends Player {
     decodeIn() {
         this.userPath = [];
         this.opcalled = false;
-        this.opucalled = false;
 
         if (!isClientConnected(this)) {
             return false;

--- a/src/network/rs225/client/handler/OpLocUHandler.ts
+++ b/src/network/rs225/client/handler/OpLocUHandler.ts
@@ -68,7 +68,6 @@ export default class OpLocUHandler extends MessageHandler<OpLocU> {
 
         player.setInteraction(Interaction.ENGINE, loc, ServerTriggerType.APLOCU);
         player.opcalled = true;
-        player.opucalled = true;
         return true;
     }
 }

--- a/src/network/rs225/client/handler/OpNpcTHandler.ts
+++ b/src/network/rs225/client/handler/OpNpcTHandler.ts
@@ -39,7 +39,6 @@ export default class OpNpcTHandler extends MessageHandler<OpNpcT> {
         player.clearPendingAction();
         player.setInteraction(Interaction.ENGINE, npc, ServerTriggerType.APNPCT, { type: npc.type, com: spellComId });
         player.opcalled = true;
-        player.opucalled = true;
         return true;
     }
 }

--- a/src/network/rs225/client/handler/OpNpcUHandler.ts
+++ b/src/network/rs225/client/handler/OpNpcUHandler.ts
@@ -64,7 +64,6 @@ export default class OpNpcUHandler extends MessageHandler<OpNpcU> {
 
         player.setInteraction(Interaction.ENGINE, npc, ServerTriggerType.APNPCU, { type: npc.type, com: -1 });
         player.opcalled = true;
-        player.opucalled = true;
         return true;
     }
 }

--- a/src/network/rs225/client/handler/OpObjTHandler.ts
+++ b/src/network/rs225/client/handler/OpObjTHandler.ts
@@ -43,7 +43,6 @@ export default class OpObjTHandler extends MessageHandler<OpObjT> {
         player.clearPendingAction();
         player.setInteraction(Interaction.ENGINE, obj, ServerTriggerType.APOBJT, { type: obj.type, com: spellComId });
         player.opcalled = true;
-        player.opucalled = true;
         return true;
     }
 }

--- a/src/network/rs225/client/handler/OpObjUHandler.ts
+++ b/src/network/rs225/client/handler/OpObjUHandler.ts
@@ -68,7 +68,6 @@ export default class OpObjUHandler extends MessageHandler<OpObjU> {
 
         player.setInteraction(Interaction.ENGINE, obj, ServerTriggerType.APOBJU);
         player.opcalled = true;
-        player.opucalled = true;
         return true;
     }
 }

--- a/src/network/rs225/client/handler/OpPlayerTHandler.ts
+++ b/src/network/rs225/client/handler/OpPlayerTHandler.ts
@@ -39,7 +39,6 @@ export default class OpPlayerTHandler extends MessageHandler<OpPlayerT> {
         player.clearPendingAction();
         player.setInteraction(Interaction.ENGINE, other, ServerTriggerType.APPLAYERT, { type: -1, com: spellComId });
         player.opcalled = true;
-        player.opucalled = true;
         return true;
     }
 }

--- a/src/network/rs225/client/handler/OpPlayerUHandler.ts
+++ b/src/network/rs225/client/handler/OpPlayerUHandler.ts
@@ -63,7 +63,6 @@ export default class OpPlayerUHandler extends MessageHandler<OpPlayerU> {
 
         player.setInteraction(Interaction.ENGINE, other, ServerTriggerType.APPLAYERU, { type: item, com: -1 });
         player.opcalled = true;
-        player.opucalled = true;
         return true;
     }
 }


### PR DESCRIPTION
They changed use item (and report option) in osrs at some point, allowing them to be used for interface walking. Was not the case originally.