### PR TITLE
fix(content): prevent alching cats, allow alch for biohazard/upass objs, fix typo

### DIFF
--- a/data/src/scripts/quests/quest_arena/scripts/local.rs2
+++ b/data/src/scripts/quests/quest_arena/scripts/local.rs2
@@ -9,17 +9,17 @@ switch_int(%arena_progress) {
         ~chatnpc("<p,shock>Hey you're the guy from the arena! How'd you get out!");
     case ^arena_entered_ogre_fight :
         ~chatplayer("<p,neutral>Hello.");
-        if(inv_total(worn, khazard_helmet) > 0 & inv_total(worn, khazard_armour) > 0) {
+        if(~wearing_khazard_armour = false) {
             ~chatnpc("<p,happy>Hello stranger. Khazard's got some great fights lined up this week. I can't wait.");
             return;
         }
-        ~chatnpc("<p,sad>Please, I havn't done anything");
+        ~chatnpc("<p,sad>Please, I haven't done anything");
         ~chatplayer("<p,confused>What?");
         ~chatnpc("<p,sad>I love General Khazard, please believe me.");
     case ^arena_started, ^arena_obtained_armour, ^arena_spoken_drunkguard, ^arena_given_khali_brew :
         // mesanims from rs3, lines up with this fortunately: https://web.archive.org/web/20051025134523im_/http://runeweb.net/rathofdoom/quests/fightarena/2.png
         ~chatplayer("<p,neutral>Hello.");
-        if(inv_total(worn, khazard_helmet) > 0 & inv_total(worn, khazard_armour) > 0) {
+        if(~wearing_khazard_armour = true) {
             ~chatnpc("<p,happy>I heard the Servil family are fighting soon. Should be very entertaining.");
             return;
         }

--- a/data/src/scripts/quests/quest_biohazard/configs/quest_biohazard.obj
+++ b/data/src/scripts/quests/quest_biohazard/configs/quest_biohazard.obj
@@ -10,7 +10,6 @@ desc=An expensive colourless liquid.
 2dyan=1996
 2dxan=84
 weight=30g
-param=no_alchemy,1
 tradeable=no
 
 [liquid_honey]
@@ -26,7 +25,6 @@ desc=This isn't worth much.
 2dyan=1996
 2dxan=84
 weight=30g
-param=no_alchemy,1
 tradeable=no
 
 [sulphuric_broline]
@@ -42,7 +40,6 @@ desc=It's highly poisonous.
 2dyan=1996
 2dxan=84
 weight=30g
-param=no_alchemy,1
 tradeable=no
 
 [plague_sample]
@@ -56,7 +53,6 @@ model=model_2788_obj
 2dxan=136
 weight=50g
 members=yes
-param=no_alchemy,1
 tradeable=no
 
 [touch_paper]
@@ -71,7 +67,6 @@ model=model_2781_obj
 2dxan=288
 weight=10g
 members=yes
-param=no_alchemy,1
 tradeable=no
 
 [distillator]
@@ -86,7 +81,6 @@ model=model_2613_obj
 2dyan=684
 2dxan=304
 weight=20g
-param=no_alchemy,1
 tradeable=no
 
 [lathas_amulet]
@@ -119,7 +113,6 @@ model=model_2678_obj
 2dxan=116
 weight=50g
 members=yes
-param=no_alchemy,1
 tradeable=no
 
 [biohazard_key]
@@ -134,7 +127,6 @@ model=model_2372_obj
 2dxan=328
 weight=10g
 members=yes
-param=no_alchemy,1
 tradeable=no
 
 [pigeon_cage]
@@ -150,7 +142,6 @@ model=model_2479_obj
 iop1=Open
 weight=2kg
 members=yes
-param=no_alchemy,1
 tradeable=no
 
 [pigeon_cage_empty]
@@ -163,7 +154,6 @@ model=model_2663_obj
 2dxan=192
 weight=500g
 members=yes
-param=no_alchemy,1
 tradeable=no
 
 [priest_gown_top]

--- a/data/src/scripts/quests/quest_upass/configs/upass.obj
+++ b/data/src/scripts/quests/quest_upass/configs/upass.obj
@@ -24,7 +24,6 @@ model=model_loc_3361_8
 2dxan=100
 weight=1lb
 members=yes
-param=no_alchemy,1
 param=orb_bit,^upass_orb1_bit
 tradeable=no
 
@@ -38,7 +37,6 @@ model=model_loc_3361_8
 2dxan=100
 weight=1lb
 members=yes
-param=no_alchemy,1
 param=orb_bit,^upass_orb2_bit
 tradeable=no
 
@@ -52,7 +50,6 @@ model=model_loc_3361_8
 2dxan=100
 weight=1lb
 members=yes
-param=no_alchemy,1
 param=orb_bit,^upass_orb3_bit
 tradeable=no
 
@@ -66,7 +63,6 @@ model=model_loc_3361_8
 2dxan=100
 weight=1lb
 members=yes
-param=no_alchemy,1
 param=orb_bit,^upass_orb4_bit
 tradeable=no
 

--- a/data/src/scripts/skill_magic/scripts/spells/alchemy.rs2
+++ b/data/src/scripts/skill_magic/scripts/spells/alchemy.rs2
@@ -92,6 +92,14 @@ switch_obj($item) {
         mes("Coins are already made of gold.");
         return(false);
     case default :
+        if(oc_category($item) = kitten) {
+            mes("You can't do that to a defenceless kitten!");
+            return(false);
+        }
+        if(oc_category($item) = cat) { // you can alch witches cat (RS3)
+            mes("You can't do that to a defenceless cat!");
+            return(false);
+        }
         if (oc_param($item, no_alchemy) = ^true) {
             mes("You cannot use alchemy on that item.");
             return(false);


### PR DESCRIPTION
- Prevent alching kittens/cats (witches cat is an exception)
- allow alching on biohazard/upass objs (this was an osrs change)
- fix incorrect dialogue for the local (fight arena)