### PR TITLE
fix(engine): Use new Entity validation everywhere

### DIFF
--- a/src/engine/World.ts
+++ b/src/engine/World.ts
@@ -911,11 +911,11 @@ class World {
                         printError('LOGOUT TRIGGER IS BROKEN!');
                         continue;
                     }
-    
+
                     const state = ScriptRunner.init(script, player);
                     state.pointerAdd(ScriptPointer.ProtectedActivePlayer);
                     ScriptRunner.execute(state);
-    
+
                     this.removePlayer(player);
                 }
             }
@@ -1300,6 +1300,7 @@ class World {
 
         npc.x = npc.startX;
         npc.z = npc.startZ;
+        npc.isActive = true;
 
         const zone = this.gameMap.getZone(npc.x, npc.z, npc.level);
         zone.enter(npc);
@@ -1324,6 +1325,7 @@ class World {
         const zone = this.gameMap.getZone(npc.x, npc.z, npc.level);
         const adjustedDuration = this.scaleByPlayerCount(duration);
         zone.leave(npc);
+        npc.isActive = false;
 
         switch (npc.blockWalk) {
             case BlockWalk.NPC:
@@ -1522,6 +1524,7 @@ class World {
 
     addPlayer(player: Player): void {
         this.newPlayers.add(player);
+        player.isActive = true;
     }
 
     sendPrivateChatModeToFriendsServer(player: Player): void {
@@ -1556,6 +1559,8 @@ class World {
         this.players.remove(player.pid);
         changeNpcCollision(player.width, player.x, player.z, player.level, false);
         player.cleanup();
+
+        player.isActive = false;
 
         player.addSessionLog(LoggerEventType.MODERATOR, 'Logged out');
         this.flushPlayer(player);

--- a/src/engine/entity/Entity.ts
+++ b/src/engine/entity/Entity.ts
@@ -1,11 +1,11 @@
 import EntityLifeCycle from '#/engine/entity/EntityLifeCycle.js';
 import World from '#/engine/World.js';
-
 export default abstract class Entity {
     // constructor
     level: number;
     x: number;
     z: number;
+    isActive: boolean;
     readonly width: number;
     readonly length: number;
     readonly lifecycle: EntityLifeCycle;
@@ -21,9 +21,14 @@ export default abstract class Entity {
         this.width = width;
         this.length = length;
         this.lifecycle = lifecycle;
+        this.isActive = false;
     }
 
     abstract resetEntity(respawn: boolean): void;
+
+    isValid(hash64?: bigint): boolean {
+        return this.isActive;
+    }
 
     updateLifeCycle(tick: number): boolean {
         return this.lifecycleTick === tick && this.lifecycle !== EntityLifeCycle.FOREVER;

--- a/src/engine/entity/Loc.ts
+++ b/src/engine/entity/Loc.ts
@@ -8,7 +8,7 @@ export default class Loc extends NonPathingEntity {
     constructor(level: number, x: number, z: number, width: number, length: number, lifecycle: EntityLifeCycle, type: number, shape: number, angle: number) {
         super(level, x, z, width, length, lifecycle);
         // 16383, 31, 3
-        this.info = (type & 0x3fff) | (shape & 0x1f) << 14 | (angle & 0x3) << 19;
+        this.info = (type & 0x3fff) | ((shape & 0x1f) << 14) | ((angle & 0x3) << 19);
     }
 
     get type(): number {

--- a/src/engine/entity/Npc.ts
+++ b/src/engine/entity/Npc.ts
@@ -643,7 +643,7 @@ export default class Npc extends PathingEntity {
     }
 
     aiMode(): void {
-        if (!this.target || !this.validateTarget() || this.delayed || this.target.level !== this.level ) {
+        if (!this.target || !this.validateTarget() || this.delayed || this.target.level !== this.level) {
             this.defaultMode();
             return;
         }
@@ -1007,5 +1007,12 @@ export default class Npc extends PathingEntity {
 
         const npcType: NpcType = NpcType.get(type);
         this.setTimer(npcType.timer);
+    }
+
+    isValid(hash64?: bigint): boolean {
+        if (this.delayed) {
+            return false;
+        }
+        return super.isValid();
     }
 }

--- a/src/engine/entity/Obj.ts
+++ b/src/engine/entity/Obj.ts
@@ -14,6 +14,7 @@ export default class Obj extends NonPathingEntity {
 
     // runtime
     receiver64: bigint = Obj.NO_RECEIVER;
+    isRevealed: boolean = false;
     reveal: number = -1;
     lastChange: number = -1;
 
@@ -21,5 +22,17 @@ export default class Obj extends NonPathingEntity {
         super(level, x, z, 1, 1, lifecycle);
         this.type = type;
         this.count = count;
+    }
+
+    isValid(hash64?: bigint): boolean {
+        if (!this.isRevealed && hash64 && hash64 !== this.receiver64) {
+            return false;
+        }
+
+        if (this.count < 1) {
+            return false;
+        }
+
+        return super.isValid();
     }
 }

--- a/src/engine/entity/PathingEntity.ts
+++ b/src/engine/entity/PathingEntity.ts
@@ -557,9 +557,10 @@ export default abstract class PathingEntity extends Entity {
         }
     }
 
-    setInteraction(interaction: Interaction, target: Entity, op: TargetOp, subject?: TargetSubject): void {
-        if (target instanceof Player && target.visibility === Visibility.HARD) {
-            return;
+    setInteraction(interaction: Interaction, target: Entity, op: TargetOp, subject?: TargetSubject): boolean {
+        if (!target.isValid(this instanceof Player ? this.hash64 : undefined)) {
+            console.log('interaction could not be set');
+            return false;
         }
 
         this.target = target;
@@ -590,6 +591,8 @@ export default abstract class PathingEntity extends Entity {
         if (interaction === Interaction.SCRIPT) {
             this.pathToTarget();
         }
+
+        return true;
     }
 
     clearInteraction(): void {

--- a/src/engine/entity/PathingEntity.ts
+++ b/src/engine/entity/PathingEntity.ts
@@ -559,7 +559,6 @@ export default abstract class PathingEntity extends Entity {
 
     setInteraction(interaction: Interaction, target: Entity, op: TargetOp, subject?: TargetSubject): boolean {
         if (!target.isValid(this instanceof Player ? this.hash64 : undefined)) {
-            console.log('interaction could not be set');
             return false;
         }
 

--- a/src/engine/entity/Player.ts
+++ b/src/engine/entity/Player.ts
@@ -334,6 +334,7 @@ export default class Player extends PathingEntity {
         this.lastStats.fill(-1);
         this.lastLevels.fill(-1);
         this.input = new InputTracking(this);
+        this.isActive = true;
 
         for (let i = 0; i < this.vars.length; i++) {
             const varp = VarPlayerType.get(i);
@@ -998,15 +999,8 @@ export default class Player extends PathingEntity {
     }
 
     validateTarget(): boolean {
-        // todo: all of these validation checks should be checking against the entity itself rather than trying to look up a similar entity from the World
-
         // Validate that the target is on the same floor
         if (this.target?.level !== this.level) {
-            return false;
-        }
-
-        // For Npc targets, validate that the Npc is found in the world and that it's not delayed
-        if (this.target instanceof Npc && (typeof World.getNpc(this.target.nid) === 'undefined' || this.target.delayed)) {
             return false;
         }
 
@@ -1015,22 +1009,7 @@ export default class Player extends PathingEntity {
             return false;
         }
 
-        // For Obj targets, validate that the Obj still exists in the World
-        if (this.target instanceof Obj && World.getObj(this.target.x, this.target.z, this.level, this.target.type, this.hash64) === null) {
-            return false;
-        }
-
-        // For Loc targets, validate that the Loc still exists in the world
-        if (this.target instanceof Loc && World.getLoc(this.target.x, this.target.z, this.level, this.target.type) === null) {
-            return false;
-        }
-
-        // For Player targets, validate that the Player still exists in the world and is not in the process of logging out or invisible
-        if (this.target instanceof Player && (World.getPlayerByUid(this.target.uid) === null || this.target.loggingOut || this.target.visibility !== Visibility.DEFAULT)) {
-            return false;
-        }
-
-        return true;
+        return this.target.isValid(this.hash64);
     }
 
     processInteraction() {
@@ -1967,5 +1946,19 @@ export default class Player extends PathingEntity {
 
     messageGame(msg: string) {
         this.write(new MessageGame(msg));
+    }
+
+    isValid(hash64?: bigint): boolean {
+        if (this.loggingOut) {
+            console.log('player is loggingOut');
+            return false;
+        }
+
+        if (this.visibility !== Visibility.DEFAULT) {
+            console.log('player is invisible');
+            return false;
+        }
+
+        return super.isValid();
     }
 }

--- a/src/engine/entity/Player.ts
+++ b/src/engine/entity/Player.ts
@@ -1950,12 +1950,10 @@ export default class Player extends PathingEntity {
 
     isValid(hash64?: bigint): boolean {
         if (this.loggingOut) {
-            console.log('player is loggingOut');
             return false;
         }
 
         if (this.visibility !== Visibility.DEFAULT) {
-            console.log('player is invisible');
             return false;
         }
 

--- a/src/engine/entity/Player.ts
+++ b/src/engine/entity/Player.ts
@@ -334,7 +334,6 @@ export default class Player extends PathingEntity {
         this.lastStats.fill(-1);
         this.lastLevels.fill(-1);
         this.input = new InputTracking(this);
-        this.isActive = true;
 
         for (let i = 0; i < this.vars.length; i++) {
             const varp = VarPlayerType.get(i);
@@ -361,6 +360,7 @@ export default class Player extends PathingEntity {
         this.timers.clear();
         this.heroPoints.clear();
         this.buildArea.clear(false);
+        this.isActive = false;
     }
 
     resetEntity(respawn: boolean) {
@@ -403,6 +403,7 @@ export default class Player extends PathingEntity {
 
         this.lastStepX = this.x - 1;
         this.lastStepZ = this.z;
+        this.isActive = true;
     }
 
     onReconnect() {

--- a/src/engine/script/ScriptIterators.ts
+++ b/src/engine/script/ScriptIterators.ts
@@ -3,7 +3,7 @@ import LocType from '#/cache/config/LocType.js';
 import NpcType from '#/cache/config/NpcType.js';
 
 import World from '#/engine/World.js';
-import {CoordGrid} from '#/engine/CoordGrid.js';
+import { CoordGrid } from '#/engine/CoordGrid.js';
 
 import Loc from '#/engine/entity/Loc.js';
 import HuntVis from '#/engine/entity/hunt/HuntVis.js';
@@ -12,7 +12,7 @@ import HuntModeType from '#/engine/entity/hunt/HuntModeType.js';
 import NpcIteratorType from '#/engine/entity/NpcIteratorType.js';
 import Entity from '#/engine/entity/Entity.js';
 
-import {isLineOfSight, isLineOfWalk} from '#/engine/GameMap.js';
+import { isLineOfSight, isLineOfWalk } from '#/engine/GameMap.js';
 
 abstract class ScriptIterator<T extends Entity> implements IterableIterator<T> {
     private readonly iterator: IterableIterator<T>;
@@ -51,21 +51,11 @@ export class HuntIterator extends ScriptIterator<Entity> {
     private readonly checkCategory: number;
     private readonly type: HuntModeType;
 
-    constructor(
-        tick: number,
-        level: number,
-        x: number,
-        z: number,
-        distance: number,
-        checkVis: HuntVis,
-        checkType: number,
-        checkCategory: number,
-        type: HuntModeType
-    ) {
+    constructor(tick: number, level: number, x: number, z: number, distance: number, checkVis: HuntVis, checkType: number, checkCategory: number, type: HuntModeType) {
         super(tick);
         const centerX: number = CoordGrid.zone(x);
         const centerZ: number = CoordGrid.zone(z);
-        const radius: number = (1 + (distance / 8)) | 0;
+        const radius: number = (1 + distance / 8) | 0;
         this.x = x;
         this.z = z;
         this.level = level;
@@ -101,10 +91,6 @@ export class HuntIterator extends ScriptIterator<Entity> {
                         }
 
                         if (this.checkVis === HuntVis.LINEOFWALK && !isLineOfWalk(this.level, this.x, this.z, player.x, player.z)) {
-                            continue;
-                        }
-
-                        if (player.loggingOut) {
                             continue;
                         }
 
@@ -203,18 +189,11 @@ export class NpcHuntAllCommandIterator extends ScriptIterator<Entity> {
     private readonly distance: number;
     private readonly checkVis: HuntVis;
 
-    constructor(
-        tick: number,
-        level: number,
-        x: number,
-        z: number,
-        distance: number,
-        checkVis: HuntVis,
-    ) {
+    constructor(tick: number, level: number, x: number, z: number, distance: number, checkVis: HuntVis) {
         super(tick);
         const centerX: number = CoordGrid.zone(x);
         const centerZ: number = CoordGrid.zone(z);
-        const radius: number = (1 + (distance / 8)) | 0;
+        const radius: number = (1 + distance / 8) | 0;
         this.x = x;
         this.z = z;
         this.level = level;
@@ -272,11 +251,11 @@ export class NpcIterator extends ScriptIterator<Npc> {
     private readonly type: NpcIteratorType;
     private readonly npcType?: NpcType;
 
-    constructor(tick: number, level: number, x: number, z: number,  distance: number, checkVis: HuntVis, type: NpcIteratorType, npcType?: NpcType) {
+    constructor(tick: number, level: number, x: number, z: number, distance: number, checkVis: HuntVis, type: NpcIteratorType, npcType?: NpcType) {
         super(tick);
         const centerX: number = CoordGrid.zone(x);
         const centerZ: number = CoordGrid.zone(z);
-        const radius: number = (1 + (distance / 8)) | 0;
+        const radius: number = (1 + distance / 8) | 0;
         this.x = x;
         this.z = z;
         this.level = level;

--- a/src/engine/zone/Zone.ts
+++ b/src/engine/zone/Zone.ts
@@ -461,7 +461,6 @@ export default class Zone {
 
     getObj(x: number, z: number, type: number, receiver64: bigint): Obj | null {
         for (const obj of this.getObjsSafe(CoordGrid.packZoneCoord(x, z))) {
-            // if (!((obj.receiver64 !== Obj.NO_RECEIVER && obj.receiver64 !== receiver64) || obj.type !== type)) {
             if ((obj.receiver64 === Obj.NO_RECEIVER || obj.receiver64 === receiver64) && obj.type === type) {
                 return obj;
             }
@@ -497,7 +496,7 @@ export default class Zone {
     *getAllPlayersSafe(): IterableIterator<Player> {
         for (const uid of this.players) {
             const player: Player | null = World.getPlayerByUid(uid);
-            if (player && player.checkLifeCycle(World.currentTick)) {
+            if (player && player.isValid()) {
                 yield player;
             }
         }
@@ -510,7 +509,7 @@ export default class Zone {
     *getAllNpcsSafe(): IterableIterator<Npc> {
         for (const nid of this.npcs) {
             const npc: Npc | undefined = World.getNpc(nid);
-            if (npc && npc.checkLifeCycle(World.currentTick)) {
+            if (npc && npc.isValid()) {
                 yield npc;
             }
         }
@@ -522,7 +521,7 @@ export default class Zone {
      */
     *getAllObjsSafe(): IterableIterator<Obj> {
         for (const obj of this.objs.all()) {
-            if (obj.checkLifeCycle(World.currentTick)) {
+            if (obj.isValid()) {
                 yield obj;
             }
         }
@@ -534,8 +533,7 @@ export default class Zone {
      */
     *getObjsSafe(coord: number): IterableIterator<Obj> {
         for (const obj of this.objs.stack(coord)) {
-            // lifecycle is set after reveal, this is so objects aren't unavailble the tick they are revealed
-            if (obj.checkLifeCycle(World.currentTick) || obj.reveal !== -1) {
+            if (obj.isValid()) {
                 yield obj;
             }
         }
@@ -565,7 +563,7 @@ export default class Zone {
      */
     *getAllLocsSafe(): IterableIterator<Loc> {
         for (const loc of this.locs.all()) {
-            if (loc.checkLifeCycle(World.currentTick)) {
+            if (loc.isValid()) {
                 yield loc;
             }
         }
@@ -577,7 +575,7 @@ export default class Zone {
      */
     *getLocsSafe(coord: number): IterableIterator<Loc> {
         for (const loc of this.locs.stack(coord)) {
-            if (loc.checkLifeCycle(World.currentTick)) {
+            if (loc.isValid()) {
                 yield loc;
             }
         }


### PR DESCRIPTION
This PR stacks on top of https://github.com/2004Scape/Server/pull/1301

This PR accomplishes the following:
- `Player.isActive` logic is added to `Player.onLogin()` and `Player.cleanup()`
- All `Entity` lookup methods on `Zone` now use the new `.isValid()` method rather than checking the `Entity`'s LIFECYCLE
- Removes some redundant logic from other places that is now handled inside of `isValid()`

