### PR TITLE
fix(content): watch tower fixes

### DIFF
--- a/data/src/scripts/quests/quest_itwatchtower/scripts/city_guard.rs2
+++ b/data/src/scripts/quests/quest_itwatchtower/scripts/city_guard.rs2
@@ -51,7 +51,7 @@ if(last_useitem = deathrune) {
         inv_add(inv, skavid_map, 1);
         %itwatchtower_progress = ^itwatchtower_solved_riddle;
         ~chatplayer("<p,happy>I worked it out!");
-        ~chatplayer("<p,happy>Well, well. The imp has done it!|Thanks for the rune;|This is what you be needing...");
+        ~chatnpc("<p,happy>Well, well. The imp has done it!|Thanks for the rune;|This is what you be needing...");
         mes("The guard gives you a map.");
         return;
     }

--- a/data/src/scripts/quests/quest_itwatchtower/scripts/quest_itwatchtower.rs2
+++ b/data/src/scripts/quests/quest_itwatchtower/scripts/quest_itwatchtower.rs2
@@ -324,7 +324,7 @@ p_delay(0);
 mes("You climb over the low wall.");
 ~agility_exactmove(human_walk_fence_north, 30, 2, coord, $end, 30, 90, $dir, true);
 
-[opheld3,rock_cake]
+[opheld2,rock_cake]
 mes("You feel strangely heavier...");
 inv_del(inv, rock_cake, 1);
 // on OSRS if you have 5 HP or less it will do hp / 2 instead to prevent death


### PR DESCRIPTION
`chatplayer` instead of `chatnpc` for city guard dialogue, wrong script type on rock cake eat op