### PR TITLE
revert(engine): remove unlinkQueuedScript from levelup engine queue

### DIFF
--- a/src/engine/entity/Player.ts
+++ b/src/engine/entity/Player.ts
@@ -1620,7 +1620,6 @@ export default class Player extends PathingEntity {
 
             const script = ScriptProvider.getByTriggerSpecific(ServerTriggerType.ADVANCESTAT, stat, -1);
             if (script) {
-                this.unlinkQueuedScript(script.id, PlayerQueueType.ENGINE);
                 this.enqueueScript(script, PlayerQueueType.ENGINE);
             }
         }


### PR DESCRIPTION
reverts part of this https://github.com/2004Scape/Server/pull/1054


In OSRS, big xp drops such as quest completions or wines will only show the last level up. This is because `advancestat()` is only being called once. But theres certain scenarios where `advancestat()` can be called again before the levelup engine queue runs. Since levelup interface & mes are handled in runescript, itll only show the most recent levelup hence why dupe messages can exist.


Osrs during leagues for example:

![image](https://github.com/user-attachments/assets/0a481ae1-87e2-46c7-8ae0-0670a5514cf9)


The only example I could think of for 2004scape is smithing 10 bronze items at level 1 (50+ smith xp), since smithing is p_delay'd in this version. I believe this is authentic behavior, since the interfaces ran straight from the engine queue early osrs and pre 2007 - there are no weakqueue'd interfaces to clear, if duplicates.


https://github.com/user-attachments/assets/0ef7ea5e-483f-4ddf-b94c-abc1dd85b424

