### PR TITLE
fix(engine): L/R mouse click events were switched

### DIFF
--- a/src/network/rs225/client/handler/EventTrackingHandler.ts
+++ b/src/network/rs225/client/handler/EventTrackingHandler.ts
@@ -4,10 +4,10 @@ import Player from '#/engine/entity/Player.js';
 import Packet from '#/io/Packet.js';
 
 export enum InputTrackingEventType {
-    MOUSEDOWNL = 1,
-    MOUSEDOWNR = 2,
-    MOUSEUPL = 3,
-    MOUSEUPR = 4,
+    MOUSEDOWNR = 1,
+    MOUSEDOWNL = 2,
+    MOUSEUPR = 3,
+    MOUSEUPL = 4,
     MOUSEMOVE1 = 5,
     MOUSEMOVE2 = 6,
     MOUSEMOVE3 = 7,


### PR DESCRIPTION
Java client sends `event_type(1)` / `event_type(3)` for R mouse click up/down respectively, and `event_type(2)` / `event_type(4)` for L mouse clicks and all others (ie middle).

This doesn't need to go in with any urgency, but it's worth fixing long-term.