### PR TITLE
fix(content): Fixing the level up message highlighting for level 40 Ranged.

### DIFF
--- a/data/src/scripts/levelup/scripts/levelup_unlocks_ranged.rs2
+++ b/data/src/scripts/levelup/scripts/levelup_unlocks_ranged.rs2
@@ -5,7 +5,7 @@ switch_int(stat_base(ranged)) {
     case 10 : ~objbox(black_knife,"Members can now wield @dbl@Black Throwing Weapons@bla@.", 250, 0, 0);
     case 20 : ~doubleobjbox(willow_shortbow,mithril_knife,"You can now wield @dbl@Willow Bows@bla@ and wear @dbl@Studded|@dbl@Armour@bla@ and @dbl@Coifs@bla@, and members can now wield @dbl@Mithril|@dbl@Throwing Weapons@bla@.", 200);
     case 30 : ~doubleobjbox(maple_shortbow,adamant_knife,"You can now wield @dbl@Maple Bows@bla@ and members can wield|@dbl@Adamant Throwing Weapons@bla@.", 200);
-    case 40 : ~doubleobjbox(yew_shortbow,dragonhide_body,"You can now wear @dbl@Green Dragonhide armour@bla@.|Members can wield @dbl@Yew Bows@bla@ & @dbl@Rune Throwing|@dbl@Weapons @bla@and wear @dbl@ranger boots@bla@ and the @dbl@Robin Hood hat@bla@.", 200);
+    case 40 : ~doubleobjbox(yew_shortbow,dragonhide_body,"You can now wear @dbl@Green Dragonhide armour@bla@.|Members can wield @dbl@Yew Bows@bla@ & @dbl@Rune Throwing|@dbl@Weapons @bla@and wear @dbl@ranger boots@bla@ and the @dbl@Robin|@dbl@Hood hat@bla@.", 200);
     case 50 : ~doubleobjbox(magic_shortbow,blue_dragonhide_body,"Members can now wield @dbl@Magic Bows@bla@ and can wear|@dbl@Blue Dragonhide armour@bla@.", 200);
     case 60 : ~objbox(red_dragonhide_body,"Members can now wear @dbl@Red Dragonhide armour@bla@.", 250, 0, divide(^objbox_height, 2));
     case 70 : ~objbox(black_dragonhide_body,"Members can now wear @dbl@Black Dragonhide armour@bla@.", 250, 0, 0);


### PR DESCRIPTION
When leveling up to 40 Ranged, the unlocks have a small text coloration issue where "Robin" is highlighted properly in blue, while "Hood hat" are moved to the next line and are no longer highlighted in blue. 

![image](https://github.com/user-attachments/assets/9e3ff236-a617-41f4-b7bd-421f0f454f3f)

This fixes that issue:

![image](https://github.com/user-attachments/assets/412c1839-b96f-4635-8f0f-9c901a1a945b)
