### PR TITLE
fix(content): reset boat vars on quest complete, and add check for ne…

### DIFF
--- a/data/src/scripts/areas/area_draynor/scripts/ned.rs2
+++ b/data/src/scripts/areas/area_draynor/scripts/ned.rs2
@@ -8,7 +8,7 @@ if(map_members = true & inv_total(inv, trail_clue_easy_simple_exp021) = 1) {
     // with him agreeing. Even though you cant access the ship anymore.
     // For now i'll just make it so he doesnt have it after the quest is finished.
     @ned_dragon_slayer_back_in_draynor_after_visiting_crandor;
-} else if (%dragon_ned_hired > 0) {
+} else if (%dragon_ned_hired > 0 & %dragon_progress < ^quest_dragon_sailed_to_crandor) {
     // ned got the job
     // looks like dragon slayer overrides neds standard dialogue https://youtu.be/kCMB4I_aJJM?t=129
     @ned_dragon_slayer_hired;

--- a/data/src/scripts/quests/quest_dragon/scripts/quest_dragon.rs2
+++ b/data/src/scripts/quests/quest_dragon/scripts/quest_dragon.rs2
@@ -27,6 +27,8 @@
 if (inzone(0_44_150_31_28, 0_44_150_47_46, coord) = true) { // only tele if in the elvarg lair
     p_teleport(0_44_150_30_36);
 }
+%dragon_ned_hired = ^false;
+%dragon_planks = 0;
 %dragon_progress = ^dragon_complete;
 stat_advance(strength, 186500);
 stat_advance(defence, 186500);


### PR DESCRIPTION
…d dialogue (#1311)

currently if you hire ned after returning from crandor, and then go through karamja to defeat elvarg, ned (draynor) will be stuck in the quest dialogue state