### PR TITLE
fix(content): macro event ents and raw herring easter egg

### DIFF
--- a/data/src/scripts/macro events/scripts/woodcutting/macro_event_ent.rs2
+++ b/data/src/scripts/macro events/scripts/woodcutting/macro_event_ent.rs2
@@ -57,29 +57,30 @@ if (stat(woodcutting) < $level) {
 // check inv space 2nd
 if (inv_freespace(inv) < 1) {
     anim(null, 0);
-    mes("Your inventory is too full to hold any more <lowercase(oc_name($product))>.");
+    mes("Your inventory is too full to hold any more logs.");
     return;
 }
 if (%action_delay < map_clock) {
-    // scuffed implementation for lining up skill sounds (very first chop)
-    if (%skill_sound = calc(map_clock + 4)) {
-        sound_synth(woodchop_4,0,20);
-    }
-    %action_delay = calc(map_clock + 3);
-    %skill_anim = calc(map_clock + 3);
-    p_opnpc(1);
-} else {
-    // axe message is here after the skill clock is set
-    def_namedobj $axe = ~woodcutting_axe_checker();
-    if ($axe = null) {
+    if ($level > 0 & ~woodcutting_axe_checker = null) {
         return;
     }
-    anim(struct_param(oc_param($axe, woodcutting_struct), skill_anim), 0);
-    sound_synth(woodchop_4,0,10);
-    %skill_sound = calc(map_clock + 5);
-    mes("You swing your axe at the tree.");
-    @cut_ent;
+    %action_delay = calc(map_clock + 3);
+    p_opnpc(1);
+    return;
 }
+def_obj $axe = ~woodcutting_axe_checker;
+if ($axe = null) {
+    return;
+}
+
+anim(struct_param(oc_param($axe, woodcutting_struct), skill_anim), 0);
+sound_synth(woodchop, 0, 0);
+mes("You swing your axe at the tree.");
+if (%action_delay = map_clock) {
+    @macro_event_damage_axe($axe);
+}
+
+p_opnpc(3);
 
 [label,cut_ent]
 // check if player has axe and level, ifso return best axe
@@ -102,67 +103,44 @@ if (stat(woodcutting) < $level) {
     return;
 }
 // check inv space
-def_namedobj $product = db_getfield($data, woodcutting_trees:product, 0);
 if (inv_freespace(inv) < 1) {
     anim(null, 0);
-    mes("Your inventory is too full to hold any more <lowercase(oc_name($product))>.");
+    mes("Your inventory is too full to hold any more logs.");
     return;
 }
-// play animation every 4 ticks
-// make sure this is before the skill clock check, else theres a few cases where the skill anim
-// gets redefined after skill(anim, null)
-if (%skill_anim <= map_clock) {
-    %skill_anim = calc(map_clock + 4);
-    anim(struct_param(oc_param($axe, woodcutting_struct), skill_anim), 0);
-}
-// this is here because theres always a tick where no mes("You swing your axe at the tree.") when spam clicking on tree
-// this tick is when you get you get a roll. so that means that skill clock is set next tick after roll is given
-if (%action_delay < map_clock) {
-    %action_delay = calc(map_clock + 3);
-}
-if (%action_delay = map_clock) { // break axe
-    // https://youtu.be/1vo3B5DEgIQ
-    // https://youtu.be/-0z2OZKdIM8?t=684
-    if (%macro_ent_counter = 6) {
-        %macro_ent_counter = 0;
-        def_namedobj $axe_broken = oc_param($axe, broken);
-        // todo: use inv_changeslot?
-        if (inv_total(worn, $axe) > 0) {
-            inv_del(worn, $axe, 1);
-            inv_setslot(worn, ^wearpos_rhand, $axe_broken, 1);
-            ~update_all($axe);
-        } else if (inv_total(inv, $axe) > 0) {
-            inv_del(inv, $axe, 1);
-            inv_add(inv, $axe_broken, 1);
-        }
-        mes("That's not a tree, it's an Ent!");
-        mes("The Ent damages your axe!");
-        npc_anim(seq_335, 0); // todo: need a video of this
-        npc_facesquare(coord);
-        anim(null, 0);
-        sound_synth(staff_stab, 0, 0); // osrs used spear sound
-        session_log(^log_adventure, "Broke their <oc_name($axe)>");
-        return;
-    }
-    %macro_ent_counter = add(%macro_ent_counter, 1);
-}
-// this is for the very first chop
-if (%skill_sound = calc(map_clock + 4)) {
-    %skill_sound = calc(map_clock + 3);
-    sound_synth(woodchop_4,0,25);
-} 
-// third
-else if (%skill_sound < map_clock) {
-    %skill_sound = calc(map_clock + 3);
-    sound_synth(woodchop_4,0,8);
-} 
-// second
-else if (%skill_sound = map_clock) {
-    sound_synth(woodchop_4,0,0);
-} 
-// first
-else if (%skill_sound = calc(map_clock + 2)) {
-    sound_synth(woodchop_4,0,18);
-}
 
+if (%action_delay < map_clock) {
+    anim(struct_param(oc_param($axe, woodcutting_struct), skill_anim), 0);
+    %action_delay = calc(map_clock + 3);
+} else if (%action_delay = map_clock) {
+    @macro_event_damage_axe($axe);
+}
+p_opnpc(3);
+
+
+// https://youtu.be/1vo3B5DEgIQ
+// https://youtu.be/-0z2OZKdIM8?t=684
+[label,macro_event_damage_axe](obj $axe)
+if (%macro_ent_counter = 6) {
+    %macro_ent_counter = 0;
+    def_namedobj $axe_broken = oc_param($axe, broken);
+    // todo: use inv_changeslot?
+    if (inv_total(worn, $axe) > 0) {
+        inv_del(worn, $axe, 1);
+        inv_setslot(worn, ^wearpos_rhand, $axe_broken, 1);
+        ~update_all($axe);
+    } else if (inv_total(inv, $axe) > 0) {
+        inv_del(inv, $axe, 1);
+        inv_add(inv, $axe_broken, 1);
+    }
+    mes("That's not a tree, it's an Ent!");
+    mes("The Ent damages your axe!");
+    npc_anim(seq_335, 0); // todo: need a video of this
+    npc_facesquare(coord);
+    anim(null, 0);
+    sound_synth(staff_stab, 0, 0); // osrs used spear sound
+    session_log(^log_adventure, "Broke their <oc_name($axe)>");
+    return;
+}
+%macro_ent_counter = add(%macro_ent_counter, 1);
 p_opnpc(3);

--- a/data/src/scripts/macro events/scripts/woodcutting/macro_event_ent.rs2
+++ b/data/src/scripts/macro events/scripts/woodcutting/macro_event_ent.rs2
@@ -22,10 +22,10 @@ p_opnpc(1); // not sure if p_opnpc is used (delays an extra tick)
 switch_obj(last_useitem) {
     case bronze_axe, iron_axe, steel_axe, black_axe, mithril_axe, adamant_axe, rune_axe :
         p_opnpc(1); // gets delayed by a tick >:(
-    case raw_herring, herring :
-        // note: added in 2005-2006 by mod ash?
-        mes("This is not the mightiest tree in the forest.");
-        return;
+    // case raw_herring, herring :
+    //     // note: added in 2005-2006 by mod ash?
+    //     mes("This is not the mightiest tree in the forest.");
+    //     return;
     case default : ~displaymessage(^dm_default);
 };
 

--- a/data/src/scripts/skill_woodcutting/scripts/woodcut.rs2
+++ b/data/src/scripts/skill_woodcutting/scripts/woodcut.rs2
@@ -7,9 +7,9 @@
 switch_obj(last_useitem) {
     case bronze_axe, iron_axe, steel_axe, black_axe, mithril_axe, adamant_axe, rune_axe :
         p_oploc(1); // gets delayed by a tick >:(
-    case raw_herring, herring :
-        mes("This is not the mightiest tree in the forest.");
-        return;
+    // case raw_herring, herring :
+    //     mes("This is not the mightiest tree in the forest.");
+    //     return;
     case default : ~displaymessage(^dm_default);
 };
 


### PR DESCRIPTION
- removes the raw herring easter egg:

![image](https://github.com/user-attachments/assets/75742795-d72a-48e5-8777-76c2603b819b)


- matches standard wcing anims and sounds with ent macro events