### PR TITLE
feat(engine): add drop_socket cheat command

### DIFF
--- a/src/network/rs225/client/handler/ClientCheatHandler.ts
+++ b/src/network/rs225/client/handler/ClientCheatHandler.ts
@@ -23,7 +23,7 @@ import LoggerEventType from '#/server/logger/LoggerEventType.js';
 import Obj from '#/engine/entity/Obj.js';
 import EntityLifeCycle from '#/engine/entity/EntityLifeCycle.js';
 import Visibility from '#/engine/entity/Visibility.js';
-import { isClientConnected } from '#/engine/entity/NetworkPlayer.js';
+import { isClientConnected, type NetworkPlayer } from '#/engine/entity/NetworkPlayer.js';
 
 export default class ClientCheatHandler extends MessageHandler<ClientCheat> {
     handle(message: ClientCheat, player: Player): boolean {
@@ -551,6 +551,10 @@ export default class ClientCheatHandler extends MessageHandler<ClientCheat> {
                 } else {
                     player.messageGame(`Player '${args[0]}' does not exist or is not logged in.`);
                 }
+            } else if (cmd === 'drop_socket') {
+                // custom
+                // for testing reconnection logic. silently drops client socket.
+                (player as NetworkPlayer).client.close();
             }
         }
 


### PR DESCRIPTION
This is useful for testing reconnection logic as there isn't an easy way to ask browser to close a WebSocket.

It silently drops connection so, to the client, it's the same as the network having a problem.

Limited to moderators+.