### PR TITLE
fix(engine): improve (and simplify) input tracking

### DIFF
--- a/src/engine/entity/tracking/InputTracking.ts
+++ b/src/engine/entity/tracking/InputTracking.ts
@@ -2,7 +2,6 @@ import Player from '#/engine/entity/Player.js';
 import EnableTracking from '#/network/server/model/EnableTracking.js';
 import FinishTracking from '#/network/server/model/FinishTracking.js';
 import World from '#/engine/World.js';
-import ReportEvent from '#/engine/entity/tracking/ReportEvent.js';
 import InputTrackingEvent from '#/engine/entity/tracking/InputEvent.js';
 import { NetworkPlayer } from '#/engine/entity/NetworkPlayer.js';
 import LoggerEventType from '#/server/logger/LoggerEventType.js';
@@ -10,36 +9,43 @@ import { InputTrackingEventType } from '#/network/rs225/client/handler/EventTrac
 import Environment from '#/util/Environment.js';
 
 export default class InputTracking {
-    private static readonly TRACKING_RATE: number = 200; // 2m track interval +offset. lower this to be more aggressive.
-    private static readonly TRACKING_TIME: number = 150; // 90s to track from the client
-    private static readonly REPORT_TIME: number = 8; // 5s for client to report
+    // How many ticks between tracking sessions:
+    private static readonly TRACKING_RATE: number = 200;  // 120 seconds
+    // How many ticks the tracking is enabled for:
+    private static readonly TRACKING_TIME: number = 150;  // 90 seconds
+    // How many ticks to allow for the last client report:
+    private static readonly FINAL_REPORT_TIME_LEEWAY: number = 16;  // ~10 seconds
 
     private readonly player: Player;
 
     enabled: boolean = false;
-    lastTrack: number = -1;
-    waitingReport: boolean = false;
-    lastReport: number = -1;
+    endTrackingAt: number = -1;
+    waitingForLastReport: boolean = false;
     recordedEvents: InputTrackingEvent[] = [];
     recordedEventCount: number = 0;
 
     constructor(player: Player) {
         this.player = player;
-        this.lastTrack = World.currentTick + (InputTracking.TRACKING_RATE + this.offset(15));
+    }
+
+    private calculateTrackingEnd(): number {
+        return World.currentTick + (InputTracking.TRACKING_RATE + this.offset(15));
     }
 
     process(): void {
         // if tracking finished and waiting for client to send back the report up to 15s.
-        if (this.waitingReport && this.lastReport + InputTracking.REPORT_TIME <= World.currentTick) {
-            this.report(ReportEvent.NO_REPORT);
+        if (this.waitingForLastReport) {
+            if (this.endTrackingAt + InputTracking.FINAL_REPORT_TIME_LEEWAY > World.currentTick) {
+                this.submitEvents();
+            }
             return;
         }
         // if current tracking dont do anything.
-        if (this.lastTrack > World.currentTick) {
+        if (this.endTrackingAt > World.currentTick) {
             return;
         }
         // if need to start tracking.
-        if (this.lastTrack <= World.currentTick + (InputTracking.TRACKING_RATE + this.offset(15)) && !this.enabled) {
+        if (this.endTrackingAt <= this.calculateTrackingEnd() && !this.enabled) {
             this.enable();
             return;
         }
@@ -51,8 +57,9 @@ export default class InputTracking {
             return;
         }
         this.enabled = true;
-        // start tracking for 90s. it ends early if the client gives some input.
-        this.lastTrack = World.currentTick + InputTracking.TRACKING_TIME;
+        // Set the tick count at which we will end tracking:
+        this.endTrackingAt = World.currentTick + InputTracking.TRACKING_TIME;
+        // Notify the client
         this.player.write(new EnableTracking());
     }
 
@@ -61,51 +68,49 @@ export default class InputTracking {
             return;
         }
         this.enabled = false;
-        this.lastTrack = World.currentTick + (InputTracking.TRACKING_RATE + this.offset(15));
+        this.endTrackingAt = World.currentTick + (InputTracking.TRACKING_RATE + this.offset(15));
         this.player.write(new FinishTracking());
-        if (!this.waitingReport) {
-            // wait up to 15s for the client to send us the data.
-            this.waitingReport = true;
-            this.lastReport = World.currentTick;
+        if (!this.waitingForLastReport) {
+            // wait up to an amount of time for the client to send us the last batch of data.
+            this.waitingForLastReport = true;
         }
     }
 
-    tracking(): boolean {
-        return this.enabled || this.waitingReport;
+    isActive(): boolean {
+        return this.enabled || this.waitingForLastReport;
     }
 
     record(type: InputTrackingEventType, delta: number, mouseX?: number, mouseY?: number, keyPress?: number): void {
         this.recordedEvents.push(new InputTrackingEvent(type, this.recordedEventCount++, delta, mouseX, mouseY, keyPress, this.player.coord));
-        this.report(ReportEvent.ACTIVE);
+        this.recordedEventCount++;
     }
 
-    report(event: ReportEvent): void {
-        if (!this.waitingReport) {
-            return;
-        }
-        // We either have a report (ReportEvent.ACTIVE), or we do not (ReportEvent.NO_REPORT).
-        // Either way, we are no longer waiting for one to come in:
-        this.waitingReport = false;
-        this.lastReport = -1;
-        if (event === ReportEvent.NO_REPORT) {
+    /**
+     * Submit recorded events to the World server.
+     * If there are no events seen, player will be kicked.
+     * Otherwise, if we are actually recording, submit tracking.
+     */
+    submitEvents(): void {
+        if (this.recordedEventCount === 0) {
             // this means that:
             // 1: the player is trying to avoid afk timer.
             // 2: the player is on a very slow connection and the report packet never came in.
             this.player.addSessionLog(LoggerEventType.ENGINE, 'Client did not submit an input tracking report');
             this.player.requestIdleLogout = true;
-            return;
-        }
-        // everything below means the player was active during this tracking.
-        if (this.recordedEvents.length > 0) {
+        } else {
+            // Have events to be submitted
             if (Environment.NODE_SUBMIT_INPUT || this.player.submitInput) {
                 World.submitInputTracking(
                     this.player.username, 
                     this.player instanceof NetworkPlayer ? this.player.client.uuid : 'headless', 
-                    this.recordedEvents);
+                    this.recordedEvents,
+                );
             }
-            this.recordedEvents = [];
-            this.recordedEventCount = 0;
         }
+        // This finalizes the tracking session, so reset initial state.
+        this.waitingForLastReport = false;
+        this.recordedEvents = [];
+        this.recordedEventCount = 0;
     }
 
     offset(n: number): number {

--- a/src/engine/entity/tracking/ReportEvent.ts
+++ b/src/engine/entity/tracking/ReportEvent.ts
@@ -1,6 +1,0 @@
-enum ReportEvent {
-    NO_REPORT,
-    ACTIVE,
-}
-
-export default ReportEvent;

--- a/src/network/rs225/client/handler/EventTrackingHandler.ts
+++ b/src/network/rs225/client/handler/EventTrackingHandler.ts
@@ -25,11 +25,11 @@ export default class EventTrackingHandler extends MessageHandler<EventTracking> 
         if (bytes.length === 0 || bytes.length > 500) {
             return false;
         }
-        if (!player.input.tracking()) {
+        if (!player.input.isActive()) {
             return false;
         }
         const buf: Packet = new Packet(bytes);
-        while (buf.available > 0 && player.input.tracking()) {
+        while (buf.available > 0 && player.input.isActive()) {
             const event: number = buf.g1();
             if (event === InputTrackingEventType.MOUSEDOWNL || event === InputTrackingEventType.MOUSEDOWNR) {
                 this.onmousedown(player, buf, event);


### PR DESCRIPTION
Old code would bail early on the first flush of input events. New code properly waits for all data to be received (up to a limit). It also simplifies quite a lot.

Tested:
- Kicks player due to inactivity exactly same as before
- Processes all input event batches received by the client