### PR TITLE
fix(engine): improve input tracking

### DIFF
--- a/prisma/multiworld/migrations/20250220184917_input_report_event_raw/migration.sql
+++ b/prisma/multiworld/migrations/20250220184917_input_report_event_raw/migration.sql
@@ -1,0 +1,9 @@
+-- CreateTable
+CREATE TABLE `input_report_event_raw` (
+    `input_report_id` INTEGER NOT NULL,
+    `seq` INTEGER NOT NULL,
+    `coord` INTEGER NOT NULL,
+    `data` LONGBLOB NOT NULL,
+
+    PRIMARY KEY (`input_report_id`, `seq`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;

--- a/prisma/multiworld/schema.prisma
+++ b/prisma/multiworld/schema.prisma
@@ -195,3 +195,13 @@ model input_report_event {
     
     @@id([input_report_id, seq])
 }
+
+model input_report_event_raw {
+    input_report_id Int
+    seq             Int
+
+    coord           Int
+    data            Bytes
+
+    @@id([input_report_id, seq])
+}

--- a/prisma/singleworld/migrations/20250220184559_input_report_event_raw/migration.sql
+++ b/prisma/singleworld/migrations/20250220184559_input_report_event_raw/migration.sql
@@ -1,0 +1,41 @@
+/*
+  Warnings:
+
+  - The primary key for the `ignorelist` table will be changed. If it partially fails, the table could be left without primary key constraint.
+  - You are about to alter the column `timestamp` on the `input_report` table. The data in that column could be lost. The data in that column will be cast from `Unsupported("datetime(3)")` to `DateTime`.
+
+*/
+-- CreateTable
+CREATE TABLE "input_report_event_raw" (
+    "input_report_id" INTEGER NOT NULL,
+    "seq" INTEGER NOT NULL,
+    "coord" INTEGER NOT NULL,
+    "data" BLOB NOT NULL,
+
+    PRIMARY KEY ("input_report_id", "seq")
+);
+
+-- RedefineTables
+PRAGMA defer_foreign_keys=ON;
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_ignorelist" (
+    "account_id" INTEGER NOT NULL,
+    "value" TEXT NOT NULL,
+    "created" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    PRIMARY KEY ("account_id", "value")
+);
+INSERT INTO "new_ignorelist" ("account_id", "created", "value") SELECT "account_id", "created", "value" FROM "ignorelist";
+DROP TABLE "ignorelist";
+ALTER TABLE "new_ignorelist" RENAME TO "ignorelist";
+CREATE TABLE "new_input_report" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "account_id" INTEGER NOT NULL,
+    "timestamp" DATETIME NOT NULL,
+    "session_uuid" TEXT NOT NULL
+);
+INSERT INTO "new_input_report" ("account_id", "id", "session_uuid", "timestamp") SELECT "account_id", "id", "session_uuid", "timestamp" FROM "input_report";
+DROP TABLE "input_report";
+ALTER TABLE "new_input_report" RENAME TO "input_report";
+PRAGMA foreign_keys=ON;
+PRAGMA defer_foreign_keys=OFF;

--- a/prisma/singleworld/schema.prisma
+++ b/prisma/singleworld/schema.prisma
@@ -195,3 +195,13 @@ model input_report_event {
     
     @@id([input_report_id, seq])
 }
+
+model input_report_event_raw {
+    input_report_id Int
+    seq             Int
+
+    coord           Int
+    data            Bytes
+
+    @@id([input_report_id, seq])
+}

--- a/src/db/types.ts
+++ b/src/db/types.ts
@@ -58,21 +58,10 @@ export type ignorelist = {
     value: string;
     created: Generated<string>;
 };
-export type ipban = {
-    ip: string;
-};
-export type login = {
-    uuid: string;
-    account_id: number;
-    world: number;
-    timestamp: string;
-    uid: number;
-    ip: string | null;
-};
 export type input_report = {
     id: Generated<number>;
     account_id: number;
-    timestamp: Timestamp;
+    timestamp: string;
     session_uuid: string;
 };
 export type input_report_event = {
@@ -84,6 +73,23 @@ export type input_report_event = {
     mouse_x: number | null;
     mouse_y: number | null;
     key_code: number | null;
+};
+export type input_report_event_raw = {
+    input_report_id: number;
+    seq: number;
+    coord: number;
+    data: Buffer;
+};
+export type ipban = {
+    ip: string;
+};
+export type login = {
+    uuid: string;
+    account_id: number;
+    world: number;
+    timestamp: string;
+    uid: number;
+    ip: string | null;
 };
 export type newspost = {
     id: Generated<number>;
@@ -140,6 +146,7 @@ export type DB = {
     ignorelist: ignorelist;
     input_report: input_report;
     input_report_event: input_report_event;
+    input_report_event_raw: input_report_event_raw;
     ipban: ipban;
     login: login;
     newspost: newspost;

--- a/src/engine/entity/tracking/InputEvent.ts
+++ b/src/engine/entity/tracking/InputEvent.ts
@@ -1,22 +1,11 @@
-import { InputTrackingEventType } from '#/network/rs225/client/handler/EventTrackingHandler.js';
-
 export default class InputTrackingEvent {
-
-    readonly type: InputTrackingEventType;
     readonly seq: number;
-    readonly delta: number;
-    readonly mouseX?: number;
-    readonly mouseY?: number;
-    readonly keyPress?: number;
+    readonly data: string;
     readonly coord?: number;
 
-    constructor(type: InputTrackingEventType, seq: number, delta: number, mouseX?: number, mouseY?: number, keyPress?: number, coord?: number) {
+    constructor(data: Uint8Array, seq: number, coord?: number) {
         this.seq = seq;
-        this.type = type;
-        this.delta = delta;
-        this.mouseX = mouseX;
-        this.mouseY = mouseY;
-        this.keyPress = keyPress;
+        this.data = Buffer.from(data).toString('base64');
         this.coord = coord;
     }
 }

--- a/src/engine/entity/tracking/InputTracking.ts
+++ b/src/engine/entity/tracking/InputTracking.ts
@@ -5,7 +5,6 @@ import World from '#/engine/World.js';
 import InputTrackingEvent from '#/engine/entity/tracking/InputEvent.js';
 import { NetworkPlayer } from '#/engine/entity/NetworkPlayer.js';
 import LoggerEventType from '#/server/logger/LoggerEventType.js';
-import { InputTrackingEventType } from '#/network/rs225/client/handler/EventTrackingHandler.js';
 import Environment from '#/util/Environment.js';
 
 export default class InputTracking {
@@ -24,6 +23,7 @@ export default class InputTracking {
     endTrackingAt: number = this.calculateTrackingEnd();
     recordedEvents: InputTrackingEvent[] = [];
     recordedEventCount: number = 0;
+    recordedEventsSizeTotal: number = 0;
 
     constructor(player: Player) {
         this.player = player;
@@ -89,9 +89,9 @@ export default class InputTracking {
         return this.player.submitInput || Environment.NODE_SUBMIT_INPUT;
     }
 
-    record(type: InputTrackingEventType, delta: number, mouseX?: number, mouseY?: number, keyPress?: number): void {
-        this.recordedEvents.push(new InputTrackingEvent(type, this.recordedEventCount++, delta, mouseX, mouseY, keyPress, this.player.coord));
-        this.recordedEventCount++;
+    record(rawData: Uint8Array): void {
+        this.recordedEventsSizeTotal += rawData.length;
+        this.recordedEvents.push(new InputTrackingEvent(rawData, this.recordedEventCount++, this.player.coord));
     }
 
     /**
@@ -120,6 +120,7 @@ export default class InputTracking {
         this.waitingForLastReport = false;
         this.recordedEvents = [];
         this.recordedEventCount = 0;
+        this.recordedEventsSizeTotal = 0;
         this.hasSeenReport = false;
     }
 

--- a/src/engine/entity/tracking/InputTracking.ts
+++ b/src/engine/entity/tracking/InputTracking.ts
@@ -2,7 +2,6 @@ import Player from '#/engine/entity/Player.js';
 import EnableTracking from '#/network/server/model/EnableTracking.js';
 import FinishTracking from '#/network/server/model/FinishTracking.js';
 import World from '#/engine/World.js';
-import ReportEvent from '#/engine/entity/tracking/ReportEvent.js';
 import InputTrackingEvent from '#/engine/entity/tracking/InputEvent.js';
 import { NetworkPlayer } from '#/engine/entity/NetworkPlayer.js';
 import LoggerEventType from '#/server/logger/LoggerEventType.js';
@@ -10,36 +9,43 @@ import { InputTrackingEventType } from '#/network/rs225/client/handler/EventTrac
 import Environment from '#/util/Environment.js';
 
 export default class InputTracking {
-    private static readonly TRACKING_RATE: number = 200; // 2m track interval +offset. lower this to be more aggressive.
-    private static readonly TRACKING_TIME: number = 150; // 90s to track from the client
-    private static readonly REPORT_TIME: number = 8; // 5s for client to report
+    // How many ticks between tracking sessions:
+    private static readonly TRACKING_RATE: number = 200;  // 120 seconds
+    // How many ticks the tracking is enabled for:
+    private static readonly TRACKING_TIME: number = 150;  // 90 seconds
+    // How many ticks to allow for the last client report:
+    private static readonly FINAL_REPORT_TIME_LEEWAY: number = 16;  // ~10 seconds
 
     private readonly player: Player;
 
     enabled: boolean = false;
-    lastTrack: number = -1;
-    waitingReport: boolean = false;
-    lastReport: number = -1;
+    endTrackingAt: number = -1;
+    waitingForLastReport: boolean = false;
     recordedEvents: InputTrackingEvent[] = [];
     recordedEventCount: number = 0;
 
     constructor(player: Player) {
         this.player = player;
-        this.lastTrack = World.currentTick + (InputTracking.TRACKING_RATE + this.offset(15));
+    }
+
+    private calculateTrackingEnd(): number {
+        return World.currentTick + (InputTracking.TRACKING_RATE + this.offset(15));
     }
 
     process(): void {
         // if tracking finished and waiting for client to send back the report up to 15s.
-        if (this.waitingReport && this.lastReport + InputTracking.REPORT_TIME <= World.currentTick) {
-            this.report(ReportEvent.NO_REPORT);
+        if (this.waitingForLastReport) {
+            if (this.endTrackingAt + InputTracking.FINAL_REPORT_TIME_LEEWAY > World.currentTick) {
+                this.submitEvents();
+            }
             return;
         }
         // if current tracking dont do anything.
-        if (this.lastTrack > World.currentTick) {
+        if (this.endTrackingAt > World.currentTick) {
             return;
         }
         // if need to start tracking.
-        if (this.lastTrack <= World.currentTick + (InputTracking.TRACKING_RATE + this.offset(15)) && !this.enabled) {
+        if (this.endTrackingAt <= this.calculateTrackingEnd() && !this.enabled) {
             this.enable();
             return;
         }
@@ -51,8 +57,9 @@ export default class InputTracking {
             return;
         }
         this.enabled = true;
-        // start tracking for 90s. it ends early if the client gives some input.
-        this.lastTrack = World.currentTick + InputTracking.TRACKING_TIME;
+        // Set the tick count at which we will end tracking:
+        this.endTrackingAt = World.currentTick + InputTracking.TRACKING_TIME;
+        // Notify the client
         this.player.write(new EnableTracking());
     }
 
@@ -61,51 +68,49 @@ export default class InputTracking {
             return;
         }
         this.enabled = false;
-        this.lastTrack = World.currentTick + (InputTracking.TRACKING_RATE + this.offset(15));
+        this.endTrackingAt = World.currentTick + (InputTracking.TRACKING_RATE + this.offset(15));
         this.player.write(new FinishTracking());
-        if (!this.waitingReport) {
-            // wait up to 15s for the client to send us the data.
-            this.waitingReport = true;
-            this.lastReport = World.currentTick;
+        if (!this.waitingForLastReport) {
+            // wait up to an amount of time for the client to send us the last batch of data.
+            this.waitingForLastReport = true;
         }
     }
 
-    tracking(): boolean {
-        return this.enabled || this.waitingReport;
+    isActive(): boolean {
+        return this.enabled || this.waitingForLastReport;
     }
 
     record(type: InputTrackingEventType, delta: number, mouseX?: number, mouseY?: number, keyPress?: number): void {
         this.recordedEvents.push(new InputTrackingEvent(type, this.recordedEventCount++, delta, mouseX, mouseY, keyPress, this.player.coord));
-        this.report(ReportEvent.ACTIVE);
+        this.recordedEventCount++;
     }
 
-    report(event: ReportEvent): void {
-        if (!this.waitingReport) {
-            return;
-        }
-        // We either have a report (ReportEvent.ACTIVE), or we do not (ReportEvent.NO_REPORT).
-        // Either way, we are no longer waiting for one to come in:
-        this.waitingReport = false;
-        this.lastReport = -1;
-        if (event === ReportEvent.NO_REPORT) {
+    /**
+     * Submit recorded events to the World server.
+     * If there are no events seen, player will be kicked.
+     * Otherwise, if we are actually recording, submit tracking.
+     */
+    submitEvents(): void {
+        if (this.recordedEventCount === 0) {
             // this means that:
             // 1: the player is trying to avoid afk timer.
             // 2: the player is on a very slow connection and the report packet never came in.
             this.player.addSessionLog(LoggerEventType.ENGINE, 'Client did not submit an input tracking report');
             this.player.requestIdleLogout = true;
-            return;
-        }
-        // everything below means the player was active during this tracking.
-        if (this.recordedEvents.length > 0) {
+        } else {
+            // Have events to be submitted
             if (Environment.NODE_SUBMIT_INPUT || this.player.submitInput) {
                 World.submitInputTracking(
                     this.player.username, 
                     this.player instanceof NetworkPlayer ? this.player.client.uuid : 'headless', 
-                    this.recordedEvents);
+                    this.recordedEvents,
+                );
             }
-            this.recordedEvents = [];
-            this.recordedEventCount = 0;
         }
+        // This finalizes the tracking session, so reset initial state.
+        this.waitingForLastReport = false;
+        this.recordedEvents = [];
+        this.recordedEventCount = 0;
     }
 
     offset(n: number): number {

--- a/src/engine/entity/tracking/ReportEvent.ts
+++ b/src/engine/entity/tracking/ReportEvent.ts
@@ -1,6 +1,0 @@
-enum ReportEvent {
-    NO_REPORT,
-    ACTIVE,
-}
-
-export default ReportEvent;

--- a/src/network/rs225/client/handler/EventTrackingHandler.ts
+++ b/src/network/rs225/client/handler/EventTrackingHandler.ts
@@ -28,6 +28,18 @@ export default class EventTrackingHandler extends MessageHandler<EventTracking> 
         if (!player.input.isActive()) {
             return false;
         }
+        // Mark that the player has sent at least one report in this tracking.
+        player.input.hasSeenReport = true;
+        // Only parse the data if we're specifically profiling this player.
+        if (!player.input.shouldSubmitTrackingDetails()) {
+            return true;
+        }
+        if (player.input.recordedEventCount > 10_000) {
+            // An upper limit for the number of events in a tracking session.
+            // Could only get under half in 2m with constant spamming the mouse non-stop.
+            // Prevents further parsing of events.
+            return false;
+        }
         const buf: Packet = new Packet(bytes);
         while (buf.available > 0 && player.input.isActive()) {
             const event: number = buf.g1();

--- a/src/network/rs225/client/handler/EventTrackingHandler.ts
+++ b/src/network/rs225/client/handler/EventTrackingHandler.ts
@@ -1,23 +1,7 @@
 import MessageHandler from '#/network/client/handler/MessageHandler.js';
 import EventTracking from '#/network/client/model/EventTracking.js';
 import Player from '#/engine/entity/Player.js';
-import Packet from '#/io/Packet.js';
-
-export enum InputTrackingEventType {
-    MOUSEDOWNR = 1,
-    MOUSEDOWNL = 2,
-    MOUSEUPR = 3,
-    MOUSEUPL = 4,
-    MOUSEMOVE1 = 5,
-    MOUSEMOVE2 = 6,
-    MOUSEMOVE3 = 7,
-    KEYDOWN = 8,
-    KEYUP = 9,
-    FOCUS = 10,
-    BLUR = 11,
-    MOUSEENTER = 12,
-    MOUSELEAVE = 13
-}
+import Environment from '#/util/Environment.js';
 
 export default class EventTrackingHandler extends MessageHandler<EventTracking> {
     handle(message: EventTracking, player: Player): boolean {
@@ -34,105 +18,12 @@ export default class EventTrackingHandler extends MessageHandler<EventTracking> 
         if (!player.input.shouldSubmitTrackingDetails()) {
             return true;
         }
-        if (player.input.recordedEventCount > 10_000) {
-            // An upper limit for the number of events in a tracking session.
-            // Could only get under half in 2m with constant spamming the mouse non-stop.
-            // Prevents further parsing of events.
+        if (player.input.recordedEventsSizeTotal > Environment.NODE_LIMIT_BYTES_PER_TRACKING_SESSION) {
+            // An upper limit for the quantity of data used for a tracking session.
+            // Prevents further parsing/storing of events.
             return false;
         }
-        const buf: Packet = new Packet(bytes);
-        while (buf.available > 0 && player.input.isActive()) {
-            const event: number = buf.g1();
-            if (event === InputTrackingEventType.MOUSEDOWNL || event === InputTrackingEventType.MOUSEDOWNR) {
-                this.onmousedown(player, buf, event);
-            } else if (event === InputTrackingEventType.MOUSEUPL || event === InputTrackingEventType.MOUSEUPR) {
-                this.onmouseup(player, buf, event);
-            } else if (event === InputTrackingEventType.MOUSEMOVE1) {
-                this.onmousemove(player, buf, event);
-            } else if (event === InputTrackingEventType.MOUSEMOVE2) {
-                this.onmousemove(player, buf, event);
-            } else if (event === InputTrackingEventType.MOUSEMOVE3) {
-                this.onmousemove(player, buf, event);
-            } else if (event === InputTrackingEventType.KEYDOWN) {
-                this.onkeydown(player, buf, event);
-            } else if (event === InputTrackingEventType.KEYUP) {
-                this.onkeyup(player, buf, event);
-            } else if (event === InputTrackingEventType.FOCUS) {
-                this.onfocus(player, buf, event);
-            } else if (event === InputTrackingEventType.BLUR) {
-                this.onblur(player, buf, event);
-            } else if (event === InputTrackingEventType.MOUSEENTER) {
-                this.onmouseenter(player, buf, event);
-            } else if (event === InputTrackingEventType.MOUSELEAVE) {
-                this.onmouseleave(player, buf, event);
-            } else {
-                break;
-            }
-        }
+        player.input.record(bytes);
         return true;
-    }
-
-    onmousedown(player: Player, buf: Packet, event: InputTrackingEventType): void {
-        const delta = buf.g1();
-        const pos = buf.g3();
-        const posX = pos & 0x3FF;
-        const posY = (pos >> 10) & 0x3FF;
-        player.input.record(event, delta, posX, posY);
-    }
-
-    onmouseup(player: Player, buf: Packet, event: InputTrackingEventType): void {
-        const delta = buf.g1();
-        player.input.record(event, delta);
-    }
-
-    onmousemove(player: Player, buf: Packet, event: InputTrackingEventType): void {
-        const delta = buf.g1();
-        let posX = -1;
-        let posY = -1;
-        if (event === InputTrackingEventType.MOUSEMOVE1) {
-            const pos = buf.g1();
-            posX = pos & 0xF;
-            posY = (pos >> 4) & 0xFFF;
-        } else if (event === InputTrackingEventType.MOUSEMOVE2) {
-            posX = buf.g1();
-            posY = buf.g1();
-        } else if (event === InputTrackingEventType.MOUSEMOVE3) {
-            const pos = buf.g3();
-            posX = pos & 0x3FF;
-            posY = (pos >> 10) & 0x3FF;
-        }
-        player.input.record(event, delta, posX, posY);
-    }
-
-    onkeydown(player: Player, buf: Packet, event: InputTrackingEventType): void {
-        const delta = buf.g1();
-        const key = buf.g1();
-        player.input.record(event, delta, undefined, undefined, key);
-    }
-
-    onkeyup(player: Player, buf: Packet, event: InputTrackingEventType): void {
-        const delta = buf.g1();
-        const key = buf.g1();
-        player.input.record(event, delta, undefined, undefined, key); 
-    }
-
-    onfocus(player: Player, buf: Packet, event: InputTrackingEventType): void {
-        const delta = buf.g1();
-        player.input.record(event, delta); 
-    }
-
-    onblur(player: Player, buf: Packet, event: InputTrackingEventType): void {
-        const delta = buf.g1();
-        player.input.record(event, delta); 
-    }
-
-    onmouseenter(player: Player, buf: Packet, event: InputTrackingEventType): void {
-        const delta = buf.g1();
-        player.input.record(event, delta); 
-    }
-
-    onmouseleave(player: Player, buf: Packet, event: InputTrackingEventType): void {
-        const delta = buf.g1();
-        player.input.record(event, delta); 
     }
 }

--- a/src/network/rs225/client/handler/EventTrackingHandler.ts
+++ b/src/network/rs225/client/handler/EventTrackingHandler.ts
@@ -25,11 +25,11 @@ export default class EventTrackingHandler extends MessageHandler<EventTracking> 
         if (bytes.length === 0 || bytes.length > 500) {
             return false;
         }
-        if (!player.input.tracking()) {
+        if (!player.input.isActive()) {
             return false;
         }
         const buf: Packet = new Packet(bytes);
-        while (buf.available > 0 && player.input.tracking()) {
+        while (buf.available > 0 && player.input.isActive()) {
             const event: number = buf.g1();
             if (event === InputTrackingEventType.MOUSEDOWNL || event === InputTrackingEventType.MOUSEDOWNR) {
                 this.onmousedown(player, buf, event);

--- a/src/server/logger/LoggerServer.ts
+++ b/src/server/logger/LoggerServer.ts
@@ -59,6 +59,9 @@ export default class LoggerServer {
                         }
                         case 'input_track': {
                             const { username, session_uuid, timestamp, events } = msg;
+                            if (!events.length) {
+                                break;
+                            }
 
                             const account = await db.selectFrom('account').where('username', '=', username).selectAll().executeTakeFirst();
                             if (!account) {
@@ -72,16 +75,12 @@ export default class LoggerServer {
                                 const values = events.map((e: InputTrackingEvent) => {
                                     return {
                                         input_report_id: report.insertId,
-                                        input_type: e.type,
                                         seq: e.seq,
-                                        delta: e.delta,
                                         coord: e.coord,
-                                        mouse_x: e.mouseX,
-                                        mouse_y: e.mouseY,
-                                        key_code: e.keyPress
+                                        data: Buffer.from(e.data, 'base64'),
                                     };
                                 });
-                                await loggerDb.insertInto('input_report_event').values(values).execute();
+                                await loggerDb.insertInto('input_report_event_raw').values(values).execute();
                             }
                             break;
                         }

--- a/src/server/login/LoginThread.ts
+++ b/src/server/login/LoginThread.ts
@@ -86,7 +86,7 @@ async function handleRequests(parentPort: ParentPort, msg: any) {
                         reply: 4,
                         staffmodlevel,
                         save: null,
-                        account_id: -1
+                        account_id: 1
                     });
                 } else {
                     parentPort.postMessage({
@@ -98,7 +98,7 @@ async function handleRequests(parentPort: ParentPort, msg: any) {
                         reply: 0,
                         staffmodlevel,
                         save: fs.readFileSync(`data/players/${profile}/${username}.sav`),
-                        account_id: -1
+                        account_id: 1
                     });
                 }
             }

--- a/src/util/Environment.ts
+++ b/src/util/Environment.ts
@@ -27,6 +27,9 @@ export default {
     // production mode!
     NODE_PRODUCTION: tryParseBoolean(process.env.NODE_PRODUCTION, false),
     NODE_SUBMIT_INPUT: tryParseBoolean(process.env.NODE_SUBMIT_INPUT, false),
+    // Maximum approximate number of storage bytes allowed per single input tracking session.
+    // It does not seem remotely possible to get near this amount under normal inputs.
+    NODE_LIMIT_BYTES_PER_TRACKING_SESSION: tryParseInt(process.env.NODE_MAX_BYTES_PER_TRACKING_SESSION, 50_000),
     // automatic shutdown time for production mode on sigint
     NODE_KILLTIMER: tryParseInt(process.env.NODE_KILLTIMER, 500), // 5 minutes
     // extra debug info e.g. missing triggers


### PR DESCRIPTION
- Store raw data from client instead of new row per input event (there could be tens of thousands per tracking event!)
- Introduce rate limit for how much data we're willing to store per tracking session (it's 500 bytes limit per flush, and anecdotal testing suggests we won't get more than a few thousand bytes per tracking session, but if someone is malicious, we cap to 50kb per few minutes).
- Fix bug where we were losing part of the logs due to race between ending the tracking session and pushing data to the DB.

In time when we don't need data stored in the previous table we can easily remove it.

Tested:
- Player is still AFK kicked due to no activity
- Players which are tracked vs untracked do not know the difference (we don't end early or anything)
- We don't parse data if the user isn't being specifically tracked
- Data is stored correctly, and can be replayed correctly.