### PR TITLE
fix(engine): corrections to zones implementation

### DIFF
--- a/src/engine/World.ts
+++ b/src/engine/World.ts
@@ -1383,6 +1383,23 @@ class World {
         this.trackZone(this.currentTick, zone);
     }
 
+    changeLoc(from: Loc, to: Loc, duration: number): void {
+        const fromType: LocType = LocType.get(from.type);
+        if (fromType.blockwalk) {
+            changeLocCollision(from.shape, from.angle, fromType.blockrange, fromType.length, fromType.width, fromType.active, from.x, from.z, from.level, false);
+        }
+        const toType: LocType = LocType.get(to.type);
+        if (toType.blockwalk) {
+            changeLocCollision(to.shape, to.angle, toType.blockrange, toType.length, toType.width, toType.active, to.x, to.z, to.level, true);
+        }
+        const zone: Zone = this.gameMap.getZone(from.x, from.z, from.level);
+        zone.changeLoc(from, to);
+        from.setLifeCycle(this.currentTick + duration);
+        to.setLifeCycle(this.currentTick + duration);
+        this.trackZone(this.currentTick + duration, zone);
+        this.trackZone(this.currentTick, zone);
+    }
+
     mergeLoc(loc: Loc, player: Player, startCycle: number, endCycle: number, south: number, east: number, north: number, west: number): void {
         // printDebug(`[World] mergeLoc => name: ${LocType.get(loc.type).name}`);
         const zone: Zone = this.gameMap.getZone(loc.x, loc.z, loc.level);

--- a/src/engine/entity/Loc.ts
+++ b/src/engine/entity/Loc.ts
@@ -1,5 +1,6 @@
 import NonPathingEntity from '#/engine/entity/NonPathingEntity.js';
 import EntityLifeCycle from '#/engine/entity/EntityLifeCycle.js';
+import { LocAngle, LocLayer, LocShape, locShapeLayer } from '@2004scape/rsmod-pathfinder';
 
 export default class Loc extends NonPathingEntity {
     // constructor properties
@@ -7,19 +8,24 @@ export default class Loc extends NonPathingEntity {
 
     constructor(level: number, x: number, z: number, width: number, length: number, lifecycle: EntityLifeCycle, type: number, shape: number, angle: number) {
         super(level, x, z, width, length, lifecycle);
-        // 16383, 31, 3
-        this.info = (type & 0x3fff) | ((shape & 0x1f) << 14) | ((angle & 0x3) << 19);
+        const layer: number = locShapeLayer(shape);
+        // 16383, 31, 3, 3
+        this.info = (type & 0x3fff) | ((shape & 0x1f) << 14) | ((angle & 0x3) << 19) | ((layer & 0x3) << 21);
     }
 
     get type(): number {
         return this.info & 0x3fff;
     }
 
-    get shape(): number {
+    get shape(): LocShape {
         return (this.info >> 14) & 0x1f;
     }
 
-    get angle(): number {
+    get angle(): LocAngle {
         return (this.info >> 19) & 0x3;
+    }
+
+    get layer(): LocLayer {
+        return (this.info >> 21) & 0x3;
     }
 }

--- a/src/engine/entity/NetworkPlayer.ts
+++ b/src/engine/entity/NetworkPlayer.ts
@@ -383,9 +383,12 @@ export class NetworkPlayer extends Player {
             const zone: Zone = World.gameMap.getZoneIndex(zoneIndex);
             if (!loadedZones.has(zone.index)) {
                 zone.writeFullFollows(this);
+            } else {
+                // osrs does partial follows first, and then partial enclosed.
+                zone.writePartialFollows(this);
+                // partial enclosed is only written with already viewed zones.
+                zone.writePartialEnclosed(this);
             }
-            zone.writePartialEncloses(this);
-            zone.writePartialFollows(this);
             loadedZones.add(zone.index);
         }
     }


### PR DESCRIPTION
Our implementation is slightly incorrect. We perform way too many `loc_del` packets than what Jagex does.

1. `loc_change` will only send the `loc_add` packet. We currently send a `loc_del` -> `loc_add`.
2. Our current implementation actually sends 2 `loc_del` packets in some cases with temporary locs (like doors).
3. If a temporary loc is currently replacing a permanent loc, then we should only send the `loc_add` packet. We currently send a `loc_del` -> `loc_add`.
4. The only time a `loc_del` is actually used, is when there are no temporary locs in place of a permanent one.
5. Loc events are sent before the obj events.
6. I was not able to send a `partial enclosed` packet with a `full follows` one on osrs. `full follows` and `partial follows` are only written with new zones in view. Otherwise, it uses `partial follows` and `partial enclosed`.
7. Idk why but `partial follows` is always sent with every single obj event, no matter what.
8. Uses the new `isValid()` boolean logic recently added.
9. This is the best I could do without doing some sort of redesign in general to account for this...