### PR TITLE
fix(content): heroes - close mesbox when summoning grip

### DIFF
--- a/data/src/scripts/quests/quest_hero/scripts/locs/brimhaven_scarface_mansion.rs2
+++ b/data/src/scripts/quests/quest_hero/scripts/locs/brimhaven_scarface_mansion.rs2
@@ -24,6 +24,7 @@ if (npc_find(coord, pirate_guard, 4, 0) = true) {
         npc_setmode(none);
         npc_walk(0_43_49_25_62);
         npc_say("Stay out of my drinks cabinet!");
+        if_close;
         p_delay(6);
         npc_queue(10, 0, 1);
       }


### PR DESCRIPTION
https://youtu.be/O-GstkQpa7M?t=90

video shows mesbox is closed, and confirms that the player is delayed while summonign grip (clicked to walk, but didn't move)