### PR TITLE
fix(engine): Allow dragging empty inventory slot

### DIFF
--- a/src/engine/entity/Player.ts
+++ b/src/engine/entity/Player.ts
@@ -1450,13 +1450,13 @@ export default class Player extends PathingEntity {
         }
 
         const fromObj = this.invGetSlot(fromInv, fromSlot);
-        if (!fromObj) {
-            throw new Error(`invMoveToSlot: Invalid from obj was null. This means the obj does not exist at this slot: ${fromSlot}`);
-        }
-
         const toObj = this.invGetSlot(toInv, toSlot);
-        this.invSet(toInv, fromObj.id, fromObj.count, toSlot);
 
+        if (fromObj) {
+            this.invSet(toInv, fromObj.id, fromObj.count, toSlot);
+        } else {
+            this.invDelSlot(toInv, toSlot);
+        }
         if (toObj) {
             this.invSet(fromInv, toObj.id, toObj.count, fromSlot);
         } else {

--- a/src/network/rs225/client/handler/InvButtonDHandler.ts
+++ b/src/network/rs225/client/handler/InvButtonDHandler.ts
@@ -24,7 +24,7 @@ export default class InvButtonDHandler extends MessageHandler<InvButtonD> {
         }
 
         const inv = player.getInventoryFromListener(listener);
-        if (!inv || !inv.validSlot(slot) || !inv.get(slot) || !inv.validSlot(targetSlot)) {
+        if (!inv || !inv.validSlot(slot) || !inv.validSlot(targetSlot)) {
             return false;
         }
 


### PR DESCRIPTION
In osrs it used to be possible to drag an item after equipping or dropping it.