### PR TITLE
fix: Updated Dockerfile - would not find json - /app empty

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,8 @@ FROM node:22
 
 RUN apt-get update && apt-get install -y openjdk-17-jre-headless
 
-VOLUME ["/app"]
-
 WORKDIR /app
+COPY . /app
 
 RUN npm install
 


### PR DESCRIPTION
-Docker does not bind the volume at build-time, only at runtime, resulting in /app directory being empty

-Replaced VOLUME with COPY to build the Dockerfile

-The volume is still mounted at runtime by docker-compose

Split effort by myself and iPsych0