### PR TITLE
fix(content): level 42 hobgoblin drop table

### DIFF
--- a/data/src/scripts/drop tables/scripts/hobgoblin.rs2
+++ b/data/src/scripts/drop tables/scripts/hobgoblin.rs2
@@ -117,11 +117,9 @@ if ($random < 3) {
 } else if ($random < 89) {
     if (map_members = true) {
         obj_add(npc_coord, coins, 1, ^lootdrop_duration);
-    } else {
-        obj_add(npc_coord, goblin_mail, 3, ^lootdrop_duration);
     }
 } else if ($random < 90) {
-    obj_add(npc_coord, coins, 42, ^lootdrop_duration);
+    obj_add(npc_coord, coins, 1, ^lootdrop_duration);
 } else if ($random < 111) {
     obj_add(npc_coord, limpwurt_root, 1, ^lootdrop_duration);
 } else if ($random < 113) {


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/a7e447fd-80e3-432a-b4e8-0aea7049ae2d)
https://oldschool.runescape.wiki/w/Hobgoblin#Armed_hobgoblin_drops
