### PR TITLE
feat(content): add authentic random event bug

### DIFF
--- a/data/src/scripts/macro events/scripts/fishing/macro_event_big_fish.rs2
+++ b/data/src/scripts/macro events/scripts/fishing/macro_event_big_fish.rs2
@@ -1,9 +1,6 @@
 // requires active npc
 [proc,macro_event_big_fish_spawn](namedobj $fishing_equipment)
 %macro_event = ^no_macro_event;
-if (p_finduid(uid) = false) {
-    return;
-}
 // todo: figure out sounds
 sound_synth(watersplash, 0, 0); // complete guess
 def_npc $old = npc_type;

--- a/data/src/scripts/macro events/scripts/fishing/macro_event_fishing.rs2
+++ b/data/src/scripts/macro events/scripts/fishing/macro_event_fishing.rs2
@@ -1,4 +1,7 @@
 [label,macro_event_fishing](namedobj $fishing_equipment)
+if (~macro_event_allowed = false) {
+    return;
+}
 switch_int (random(calc(~macro_event_general_count + 3))) {
     case 0 : ~macro_event_big_fish_spawn($fishing_equipment);
     case 1 : ~macro_event_river_troll_spawn;

--- a/data/src/scripts/macro events/scripts/fishing/macro_event_river_troll.rs2
+++ b/data/src/scripts/macro events/scripts/fishing/macro_event_river_troll.rs2
@@ -10,9 +10,7 @@ if ($event_coord = null) {
 npc_add($event_coord, $event, 1000); // guess
 npc_say("Fishies be mine, leave dem fishies!"); // https://youtu.be/X1KjOMAmJ_g?list=PLn23LiLYLb1am4weMQzkWn5m9b3m9fXv9&t=122
 %npc_macro_event_target = uid;
-if (finduid(uid) = false) {
-    return;
-}
+%macro_event = ^no_macro_event;
 sound_synth(watersplash, 0, 0); // osrs
 npc_delay(2);
 %aggressive_npc = npc_uid; // interupt the player if they're in combat https://youtu.be/tw66JWQzpD0?t=32

--- a/data/src/scripts/macro events/scripts/general/macro_event_drunken_dwarf.rs2
+++ b/data/src/scripts/macro events/scripts/general/macro_event_drunken_dwarf.rs2
@@ -42,6 +42,7 @@ if (finduid(%npc_macro_event_target) = true) {
         %aggressive_npc = npc_uid; // interupt the player if they're in combat https://youtu.be/tw66JWQzpD0?t=32
         npc_setmode(opplayer2);
         %npc_int = ^drunken_dwarf_angry;
+        %macro_event = ^no_macro_event;
         return;
     }
     %npc_int = add(%npc_int, 1);

--- a/data/src/scripts/macro events/scripts/general/macro_event_genie.rs2
+++ b/data/src/scripts/macro events/scripts/general/macro_event_genie.rs2
@@ -29,6 +29,7 @@ if (finduid(%npc_macro_event_target) = true) {
     } else if (%npc_int = 3) { // failing genie: https://youtu.be/MS7ADB-hh18?t=6
         npc_say("No one ignores me!");
         npc_anim(human_castteleport, 0);
+        %macro_event = ^no_macro_event;
         if (random(2) = 0 & inv_freespace(inv) < inv_size(inv)) { // 50% chance to teleport or scatter inv. Only scatter if they actually have items
             queue(macro_event_fail_scatter_inv, 0);
         } else {

--- a/data/src/scripts/macro events/scripts/general/macro_event_mysterious_old_man.rs2
+++ b/data/src/scripts/macro events/scripts/general/macro_event_mysterious_old_man.rs2
@@ -33,6 +33,7 @@ if (finduid(%npc_macro_event_target) = true) {
     } else if (%npc_int = 3) { // fail
         npc_say("No-one ignores me!");
         npc_anim(human_castteleport, 0);
+        %macro_event = ^no_macro_event;
         // https://youtu.be/Ai89wqupYqA?t=45
         queue(macro_event_fail_teleport, 0);
         queue(macro_event_fail_note_inv, 0);

--- a/data/src/scripts/macro events/scripts/general/macro_event_triffid.rs2
+++ b/data/src/scripts/macro events/scripts/general/macro_event_triffid.rs2
@@ -4,7 +4,6 @@ npc_anim(seq_348, 0);
 %npc_int = ^triffid_growing;
 %npc_macro_event_target = uid;
 sound_synth(triffid_appear, 0, 0);
-%macro_event = ^no_macro_event;
 
 [opnpc1,macro_event_triffid_friendly]
 if (%npc_macro_event_target ! uid) {
@@ -20,6 +19,7 @@ inv_add(inv, strange_fruit, 1);
 sound_synth(pick, 0, 0);
 // https://youtu.be/ghfKpXe7N5s?t=24
 mes("You pick the fruit from the plant."); // osrs
+%macro_event = ^no_macro_event;
 npc_anim(seq_350, 0); // take thing away
 npc_delay(22); // delayed when despawning in osrs
 npc_del;
@@ -36,8 +36,10 @@ if (%npc_int = ^triffid_ready_to_attack) { // turn hostile
     npc_settimer(1);
     if (finduid(%npc_macro_event_target) = true) {
         %aggressive_npc = npc_uid; // interupt the player if they're in combat https://youtu.be/tw66JWQzpD0?t=32
+        %macro_event = ^no_macro_event;
         npc_setmode(opplayer2);
     }
+    return;
 }
 %npc_int = ^triffid_ready_to_attack;
 

--- a/data/src/scripts/macro events/scripts/macro_events.rs2
+++ b/data/src/scripts/macro events/scripts/macro_events.rs2
@@ -176,9 +176,13 @@ if (finduid(%npc_macro_event_target) = true) {
     if (~macro_event_area(coord) = false) {
         return(true);
     }
-    // i think osrs added a distance check from spawn point after random event rework in 2014
-    // so going up ladders for example would make the random event despawn
-    npc_setmode(playerfollow); // this is here because they used ~chatnpc back in the day, which sets the npc
+    // https://youtu.be/vRlOfkCCGkw?t=87
+    if (coordy(coord) ! coordy(npc_coord) | npc_range(coord) > 15) {
+        npc_tele(map_findsquare(coord, 1, 1, ^map_findsquare_lineofwalk));
+        spotanim_map(small_smokepuff, npc_coord, 124, 0);
+        sound_synth(smokepuff, 0, 0);
+    }
+    npc_setmode(playerfollow);
     return(false);
 }
 return(true);

--- a/data/src/scripts/macro events/scripts/macro_events.rs2
+++ b/data/src/scripts/macro events/scripts/macro_events.rs2
@@ -70,8 +70,10 @@ return(true);
 
 // called when the player logs in
 [queue,macro_event_login]
-if (nc_param(~macro_event_npc(%macro_event), follow_player_on_logout) = ^true) {
-    ~macro_event_general_spawn(%macro_event);
+def_int $macro_event = %macro_event;
+%macro_event = 0;
+if (nc_param(~macro_event_npc($macro_event), follow_player_on_logout) = ^true) {
+    ~macro_event_general_spawn($macro_event);
 }
 
 [proc,macro_event_logout]

--- a/data/src/scripts/macro events/scripts/macro_events.rs2
+++ b/data/src/scripts/macro events/scripts/macro_events.rs2
@@ -1,19 +1,12 @@
 // timer is initiated on login, in scripts\player\scripts\global.rs2
 [timer,general_macro_events]
-if (~macro_event_area(coord) = false) { // return before checking so random events are effectively "queued" for when the player leaves a no macro event area
+// make sure this is before afk_event is called, to retain the 'queueing' behavior for random event spawning
+if (~macro_event_allowed = false) { 
     return;
 }
 if (afk_event = ^true) {
-    // macro_event varp resets when a random event is due to spawn?
-    // Just so the player isnt permanantly stuck at a certain %macro_event value
-    if (%macro_event > 0) {
-        %macro_event = ^no_macro_event;
-    }
-    // random events arent restricted in wildy?
-    // https://youtu.be/uPKaH7yg4To?t=421
-
+    // random events arent restricted in wildy? https://youtu.be/uPKaH7yg4To?t=421
     // Not restricted in banks: https://youtu.be/1Rz9Eg4ZHhA
-
     ~macro_event_general_spawn(~macro_event_set_random);
 }
 
@@ -30,7 +23,7 @@ if (afk_event = ^true) {
 // - smithing at furnace. Confirmed? https://youtu.be/a6NobmSGBYw
 // - crafting at furnace. Confirmed: https://youtu.be/7pS6s5rvvEY
 [proc,macro_event_general_spawn](int $event)
-if (~macro_event_area(coord) = false) {
+if (~macro_event_allowed = false) { 
     return;
 }
 def_coord $event_coord = map_findsquare(coord, 1, 1, ^map_findsquare_lineofwalk);
@@ -61,6 +54,16 @@ if (~inzone_coord_pair_table(trawler_game_zones, $coord) = true | ~inzone_coord_
     return(false);
 }
 if (~in_tutorial_island($coord) = true) {
+    return(false);
+}
+return(true);
+
+[proc,macro_event_allowed]()(boolean)
+if (~macro_event_area(coord) = false) {
+    return(false);
+}
+// if this var isnt reset on npc delete, then youll never get a random event: https://youtu.be/vRlOfkCCGkw
+if (%macro_event > 0) {
     return(false);
 }
 return(true);

--- a/data/src/scripts/macro events/scripts/mining/macro_event_lost_pickaxe.rs2
+++ b/data/src/scripts/macro events/scripts/mining/macro_event_lost_pickaxe.rs2
@@ -19,6 +19,7 @@ if (inv_total(worn, $pickaxe) > 0) {
 def_coord $pickaxe_coord = map_findsquare(coord, 1, 7, ^map_findsquare_lineofwalk);
 anim(human_mining_pickaxe_handle, 0);
 sound_synth(lost_pickaxe, 0, 0);
+%macro_event = ^no_macro_event;
 mes("You swing your pick at the rock.");
 def_int $delay = ~coord_projectile(coord, $pickaxe_coord, pickaxe_head_launch, 35, 0, 14, 16, -2, 64, 10);
 // world_delay(calc($delay/60));

--- a/data/src/scripts/macro events/scripts/mining/macro_event_mining.rs2
+++ b/data/src/scripts/macro events/scripts/mining/macro_event_mining.rs2
@@ -1,5 +1,8 @@
 // https://i.imgur.com/BEfenlv.png
 [label,macro_randommining]
+if (~macro_event_allowed = false) {
+    return;
+}
 switch_int (random(calc(~macro_event_general_count + 3))) {
     case 0 : ~macro_event_lost_pickaxe_spawn;
     case 1 : ~macro_event_gas_spawn;
@@ -8,6 +11,9 @@ switch_int (random(calc(~macro_event_general_count + 3))) {
 }
 // rune essence
 [label,macro_randomminingrune]
+if (~macro_event_allowed = false) {
+    return;
+}
 switch_int (random(calc(~macro_event_general_count + 2))) {
     case 0 : ~macro_event_lost_pickaxe_spawn;
     case 1 : ~macro_event_rock_golem_spawn;

--- a/data/src/scripts/macro events/scripts/mining/macro_event_rock_golem.rs2
+++ b/data/src/scripts/macro events/scripts/mining/macro_event_rock_golem.rs2
@@ -11,9 +11,7 @@ if ($event_coord = null) {
 npc_add($event_coord, $event, 1000); // guess
 npc_say("Rrrraaarrrrggghhhh, flee human!"); // https://youtu.be/vL0-EwN076w?list=PLn23LiLYLb1bQ7Hwp77KoNBjKvpZQTfJT&t=135
 %npc_macro_event_target = uid;
-if (finduid(uid) = false) {
-    return;
-}
+%macro_event = ^no_macro_event;
 sound_synth(rock_spirit_appear, 0, 0);
 npc_delay(2);
 %aggressive_npc = npc_uid; // interupt the player if they're in combat https://youtu.be/tw66JWQzpD0?t=32

--- a/data/src/scripts/macro events/scripts/prayer/macro_event_prayer.rs2
+++ b/data/src/scripts/macro events/scripts/prayer/macro_event_prayer.rs2
@@ -1,4 +1,7 @@
 [label,macro_event_prayer]
+if (~macro_event_allowed = false) {
+    return;
+}
 switch_int (random(calc(~macro_event_general_count + 2))) {
     case 0 : ~macro_event_zombie_spawn;
     case 1 : ~macro_event_shade_spawn;

--- a/data/src/scripts/macro events/scripts/prayer/macro_event_shade.rs2
+++ b/data/src/scripts/macro events/scripts/prayer/macro_event_shade.rs2
@@ -11,10 +11,8 @@ if ($shade_coord = null) {
 npc_add($shade_coord, $shade, 1000); // guess
 npc_say("Leave this place mortal!");
 %npc_macro_event_target = uid;
+%macro_event = ^no_macro_event;
 spotanim_map(zamorak_flame, $shade_coord, 0, 0);
-if (finduid(uid) = false) {
-    return;
-}
 npc_delay(3);
 %aggressive_npc = npc_uid; // interupt the player if they're in combat https://youtu.be/tw66JWQzpD0?t=32
 npc_setmode(opplayer2);

--- a/data/src/scripts/macro events/scripts/prayer/macro_event_zombie.rs2
+++ b/data/src/scripts/macro events/scripts/prayer/macro_event_zombie.rs2
@@ -11,10 +11,8 @@ if ($zombie_coord = null) {
 npc_add($zombie_coord, $zombie, 1000); // guess
 npc_say("Brainsssss...");
 %npc_macro_event_target = uid;
+%macro_event = ^no_macro_event;
 spotanim_map(zamorak_flame, $zombie_coord, 0, 0);
-if (finduid(uid) = false) {
-    return;
-}
 sound_synth(zombie_moan, 0, 0);
 npc_delay(3);
 %aggressive_npc = npc_uid; // interupt the player if they're in combat https://youtu.be/tw66JWQzpD0?t=32

--- a/data/src/scripts/macro events/scripts/thieving/macro_event_poisonous_gas.rs2
+++ b/data/src/scripts/macro events/scripts/thieving/macro_event_poisonous_gas.rs2
@@ -17,6 +17,7 @@ p_delay(0);
 settimer(poison_gas, 1); // start the timer
 
 say("I better run!"); // 2004 https://i.imgur.com/nwQIetY.png
+%macro_event = ^no_macro_event;
 
 // timer is set when chest_macro_gas is called.
 // timer is cleared when player is not within 10 tiles of chest_macro_gas

--- a/data/src/scripts/macro events/scripts/thieving/macro_event_thieving.rs2
+++ b/data/src/scripts/macro events/scripts/thieving/macro_event_thieving.rs2
@@ -1,4 +1,7 @@
 [label,macro_randomthieving]
+if (~macro_event_allowed = false) {
+    return;
+}
 switch_int (random(calc(~macro_event_general_count + 1))) {
     case 0 : ~macro_event_watchman_spawn;
     case default : ~macro_event_general_spawn(~macro_event_set_random);
@@ -6,6 +9,9 @@ switch_int (random(calc(~macro_event_general_count + 1))) {
 
 
 [label,macro_randomthievingchest]
+if (~macro_event_allowed = false) {
+    return;
+}
 switch_int (random(calc(~macro_event_general_count + 2))) {
     case 0 : ~macro_event_macro_gas_chest;
     case 1 : ~macro_event_watchman_spawn;

--- a/data/src/scripts/macro events/scripts/thieving/macro_event_watchman.rs2
+++ b/data/src/scripts/macro events/scripts/thieving/macro_event_watchman.rs2
@@ -14,9 +14,7 @@ if ($event_coord = null) {
 npc_add($event_coord, $event, 1000);
 npc_say("<displayname>, you are under arrest!");
 %npc_macro_event_target = uid;
-if (finduid(uid) = false) {
-    return;
-}
+%macro_event = ^no_macro_event;
 // no idea what sound he makes
 sound_synth(smokepuff, 0, 0);
 spotanim_map(small_smokepuff, npc_coord, 124, 0);

--- a/data/src/scripts/macro events/scripts/woodcutting/macro_event_dryad.rs2
+++ b/data/src/scripts/macro events/scripts/woodcutting/macro_event_dryad.rs2
@@ -10,9 +10,7 @@ if ($event_coord = null) {
 npc_add($event_coord, $event, 1000);
 npc_say("Leave these woods and never return!");
 %npc_macro_event_target = uid;
-if (finduid(uid) = false) {
-    return;
-}
+%macro_event = ^no_macro_event;
 sound_synth(dryad_appear, 0, 0);
 spotanim_map(snare_impact, npc_coord, 100, 0); // osrs
 npc_delay(1);

--- a/data/src/scripts/macro events/scripts/woodcutting/macro_event_ent.rs2
+++ b/data/src/scripts/macro events/scripts/woodcutting/macro_event_ent.rs2
@@ -15,6 +15,7 @@ if ($loc = null) {
 npc_add($coord, $ent, 60);
 sound_synth(anothercry, 0, 0); // complete guess, this is near the toher wc sounds so it might be this one?
 p_opnpc(1); // not sure if p_opnpc is used (delays an extra tick)
+%macro_event = ^no_macro_event;
 
 [opnpc1,_macro_event_ent] @attempt_cut_ent;
 [opnpc3,_macro_event_ent] @cut_ent;

--- a/data/src/scripts/macro events/scripts/woodcutting/macro_event_lost_axe.rs2
+++ b/data/src/scripts/macro events/scripts/woodcutting/macro_event_lost_axe.rs2
@@ -19,6 +19,7 @@ def_coord $axe_coord = map_findsquare(coord, 1, 7, ^map_findsquare_lineofwalk);
 anim(human_woodcutting_axe_handle, 0);
 // not sure what sound to use
 sound_synth(lost_pickaxe, 0, 0);
+%macro_event = ^no_macro_event;
 mes("You swing your axe at the tree.");
 
 def_int $delay = ~coord_projectile(coord, $axe_coord, axe_head_launch, 35, 0, 14, 16, -2, 64, 10);

--- a/data/src/scripts/macro events/scripts/woodcutting/macro_event_woodcutting.rs2
+++ b/data/src/scripts/macro events/scripts/woodcutting/macro_event_woodcutting.rs2
@@ -1,4 +1,7 @@
 [label,macro_randomwoodcutting]
+if (~macro_event_allowed = false) {
+    return;
+}
 switch_int (random(calc(~macro_event_general_count + 3))) {
     case 0 : ~macro_event_dryad_spawn;
     case 1 : ~macro_event_ent_spawn;

--- a/data/src/scripts/quests/quest_fluffs/scripts/pet.rs2
+++ b/data/src/scripts/quests/quest_fluffs/scripts/pet.rs2
@@ -12,6 +12,13 @@ if (p_finduid(uid) = true) {
 if (finduid(%npc_attacking_uid) = false | p_finduid(uid) = false) { //paused when player is busy
     return; 
 }
+if (coordy(coord) ! coordy(npc_coord) | npc_range(coord) > 15) {
+    npc_tele(map_findsquare(coord, 1, 1, ^map_findsquare_lineofwalk));
+}
+// temp fix for pets until refactor?
+if (modulo(%npc_int, 150) ! 0) {
+    return;
+} 
 def_int $hunger = getbit_range(%cat_growth, 0,  4); //hunger       (0-16-18-20)
 def_int $attent = getbit_range(%cat_growth, 5, 10); //attention    (0-40-45-50)
 def_int $growth = getbit_range(%cat_growth, 11,19); //growth       (0-120-320)
@@ -29,7 +36,7 @@ if(oc_category(nc_param(npc_type, pet_item_id)) ! overgrown) {
                 %follower_obj = nc_param(npc_type, pet_item_id);
                 %follower_uid = npc_uid;
                 npc_say("Meeeooowww!");
-                npc_settimer(150); //reset timer -- bug where timer would go insanely fast upon growing up
+                npc_settimer(10); //reset timer -- bug where timer would go insanely fast upon growing up
                 ~mesbox("Your kitten has grown into a healthy cat,|that can hunt for itself."); //imgur.com/ni0BBTb
             }
         case 320 :
@@ -39,7 +46,7 @@ if(oc_category(nc_param(npc_type, pet_item_id)) ! overgrown) {
                 %follower_uid = npc_uid;
                 %cat_growth = 0; //according to ash, this gets wiped when the cat becomes overgrown
                 npc_say("Meeeooowww!");
-                npc_settimer(150);
+                npc_settimer(10);
                 ~mesbox("Your cat has grown into a mighty feline,|but it will no longer be able to chase vermin."); //linebreak is guessed
             }
     } 
@@ -71,6 +78,7 @@ if(oc_category(nc_param(npc_type, pet_item_id)) = kitten) {
             ~follower_death;
     }
 }
+%npc_int = add(%npc_int, 10);
 
 [opheld5,_kitten] ~cat_drop; //kitten
 [opheld5,_cat] ~cat_drop; //cat
@@ -219,7 +227,7 @@ npc_add(coord, oc_param(last_item, follower_id), ^max_32bit_int);
 %npc_attacking_uid = uid;
 npc_setmode(playerfollow);
 npc_say("Miaow!");
-npc_settimer(150);
+npc_settimer(10);
 
 [proc,follower_death]
 if (npc_finduid(%follower_uid) = true) {
@@ -247,6 +255,6 @@ if (%follower_obj ! null) {
         %follower_uid = npc_uid;
         npc_setmode(playerfollow);
         npc_say("Meeeew!"); //youtu.be/6y_cOu5OQf4?t=110
-        npc_settimer(150);
+        npc_settimer(10);
     }
 }

--- a/src/engine/entity/Npc.ts
+++ b/src/engine/entity/Npc.ts
@@ -583,10 +583,6 @@ export default class Npc extends PathingEntity {
         this.pathToTarget();
         this.updateMovement();
 
-        if (player.level !== this.level || !CoordGrid.isWithinDistanceSW(this, player, 15)) {
-            this.teleport(player.x, player.z, player.level);
-        }
-
         this.startX = this.x;
         this.startZ = this.z;
         this.startLevel = this.level;


### PR DESCRIPTION
matches the bug in this video: https://youtu.be/vRlOfkCCGkw?t=79

- prevents multiple randoms from spawning at once (still possible if you fail a random though see: https://youtu.be/rnrOYENZQyA?t=13)
- moves npc's playerfollowmode tele to runescript, genie in this [video](https://youtu.be/vRlOfkCCGkw?t=79) runs a spotanim on tele.
- temp fix for pets - this probably needs to be refactored?
- manually reset %macro_event on login. Sorta like a temp variable but you dont want it to be temp since %macro_event is used for 'spawn on login' random events.