### PR TITLE
fix(content): reset current skull on attack if target is new

### DIFF
--- a/data/src/scripts/skill_combat/scripts/pvp/pk_skull.rs2
+++ b/data/src/scripts/skill_combat/scripts/pvp/pk_skull.rs2
@@ -3,11 +3,6 @@
 if (~in_duel_arena(coord) = true) {
     return(false);
 }
-if (%pk_skull > 0) { 
-    // in osrs pk skull resets after each new player you attack.
-    // this was not the case before this update though: https://oldschool.runescape.wiki/w/Update :Grand_Exchange_Tax_%26_Item_Sink
-    return(false);
-}
 if (.%pk_prey1 = uid | .%pk_prey2 = uid | %pk_predator1 = .uid | %pk_predator2 = .uid | %pk_predator3 = .uid) {
     return(false);
 }
@@ -34,6 +29,7 @@ if (~deserves_pk_skull = true) {
 [proc,pk_skull](int $duration)
 ~headicon_add(^headicon_skull);
 %pk_skull = add(map_clock, $duration);
+cleartimer(pk_skull_timer);
 softtimer(pk_skull_timer, $duration);
 
 [proc,clear_pk_skull]

--- a/data/src/scripts/skill_combat/scripts/pvp/pk_skull.rs2
+++ b/data/src/scripts/skill_combat/scripts/pvp/pk_skull.rs2
@@ -29,7 +29,7 @@ if (~deserves_pk_skull = true) {
 [proc,pk_skull](int $duration)
 ~headicon_add(^headicon_skull);
 %pk_skull = add(map_clock, $duration);
-cleartimer(pk_skull_timer);
+clearsofttimer(pk_skull_timer);
 softtimer(pk_skull_timer, $duration);
 
 [proc,clear_pk_skull]


### PR DESCRIPTION
https://oldschool.runescape.wiki/w/Update:Grand_Exchange_Tax_%26_Item_Sink I misunderstood this blogpost at the time. The skull would only not reset if the target wasnt new (u being within the last 2 players they attacked, and them being within the last 3 players you attacked)