### PR TITLE
fix(engine): Fixing typo in input tracking file

### DIFF
--- a/src/engine/entity/tracking/InputTracking.ts
+++ b/src/engine/entity/tracking/InputTracking.ts
@@ -18,7 +18,7 @@ export default class InputTracking {
     private readonly player: Player;
 
     enabled: boolean = false;
-    hasSeenReport: boolean = false;;
+    hasSeenReport: boolean = false;
     waitingForLastReport: boolean = false;
     endTrackingAt: number = this.calculateTrackingEnd();
     recordedEvents: InputTrackingEvent[] = [];


### PR DESCRIPTION
- Small typo that's causing a linting error.