### PR TITLE
fix(engine): Npc timers, hunts, and interactions/movement have been significantly reworked to better match rs2 engine

### DIFF
--- a/data/src/scripts/skill_combat/scripts/npc/npc_poison.rs2
+++ b/data/src/scripts/skill_combat/scripts/npc/npc_poison.rs2
@@ -1,31 +1,22 @@
 [ai_timer,_] ~npc_poison_timer;
 
 [proc,npc_poison_timer]
-// Todo: Confirm this
-// OSRS Wiki:
-// "If a poisoned monster goes out of combat (no longer trying to attack) the effect of poison is immediately removed from the monster."
-if (npc_getmode ! applayer2 & npc_getmode ! opplayer2) {
+// damage npc
+%npc_poison = sub(%npc_poison, 1);
+if (%npc_poison > 0) {
+    npc_damage(^hitmark_poison, divide(add(%npc_poison, 4), 5));
+    // They died
+    if (npc_stat(hitpoints) = 0){
+        npc_queue(3, 0, 0);
+    }
+} else {
     ~npc_poison_clear;
     return;
 }
-// if npc is already dead
-if (npc_stat(hitpoints) < 1) {
-    return;
-}
-// damage npc
-npc_damage(^hitmark_poison, divide(add(%npc_poison, 4), 5));
-if (npc_stat(hitpoints) > 0) { // if they lived from that damage:
-    %npc_poison = sub(%npc_poison, 1);
-    if (%npc_poison > 0) {
-        npc_settimer(30);
-        return;
-    } else {
-        ~npc_poison_clear;
-        return;
-    }
-}
-// else they died
-npc_queue(3, 0, 0);
+
+
+
+
 
 
 [proc,npc_poison_clear]
@@ -41,7 +32,7 @@ if (map_members = false) {
     return;
 }
 
-if (%npc_poison < 1) {
+if ($severity > %npc_poison) {
     npc_settimer(30);
+    %npc_poison = $severity;
 }
-%npc_poison = $severity; // poison severity is reset

--- a/src/engine/entity/Npc.ts
+++ b/src/engine/entity/Npc.ts
@@ -37,7 +37,8 @@ import HeroPoints from '#/engine/entity/HeroPoints.js';
 
 import LinkList from '#/util/LinkList.js';
 
-import { CollisionFlag } from '@2004scape/rsmod-pathfinder';
+import { CollisionFlag, CollisionType } from '@2004scape/rsmod-pathfinder';
+import { findNaivePath } from '#/engine/GameMap.js';
 
 import InfoProt from '#/network/rs225/server/prot/InfoProt.js';
 import Visibility from '#/engine/entity/Visibility.js';
@@ -64,10 +65,12 @@ export default class Npc extends PathingEntity {
     timerInterval: number = 0;
     timerClock: number = 0;
     regenClock: number = 0;
+    huntClock: number = 0;
     huntMode: number = -1;
-    nextHuntTick: number = -1;
     huntTarget: Entity | null = null;
     huntrange: number = 0;
+    observerCount: number = 0;
+    spawnTriggerPending: boolean = true;
 
     nextPatrolTick: number = -1;
     nextPatrolPoint: number = 0;
@@ -155,27 +158,39 @@ export default class Npc extends PathingEntity {
 
             const npcType: NpcType = NpcType.get(this.type);
             this.huntrange = npcType.huntrange;
-            const hunt = HuntType.get(this.huntMode);
-            if (hunt) {
-                this.nextHuntTick = World.currentTick + hunt.rate;
-            }
+            this.huntMode = npcType.huntmode;
+            this.huntClock = 0;
+            this.huntTarget = null;
+            this.spawnTriggerPending = true;
         }
         super.resetPathingEntity();
     }
 
+    pathToPathingTarget(): void {
+        if (!this.target) {
+            return;
+        }
+
+        if (CoordGrid.intersects(this.x, this.z, this.width, this.length, this.target.x, this.target.z, this.target.width, this.target.length)) {
+            this.queueWaypoints(findNaivePath(this.level, this.x, this.z, this.target.x, this.target.z, this.width, this.length, this.target.width, this.target.length, 0, CollisionType.NORMAL));
+            return;
+        }
+
+        this.pathToTarget();
+    }
+
     updateMovement(repathAllowed: boolean = true): boolean {
         const type = NpcType.get(this.type);
-        if (!this.targetWithinMaxRange()) {
-            this.defaultMode();
-            return false;
-        }
         if (type.moverestrict === MoveRestrict.NOMOVE) {
             return false;
         }
-        if (repathAllowed && this.target instanceof PathingEntity && !this.interacted && this.walktrigger === -1) {
+        if (repathAllowed) {
             this.pathToPathingTarget();
         }
-        if (this.walktrigger !== -1) {
+
+        const { x, z } = CoordGrid.unpackCoord(this.waypoints[this.waypointIndex]);
+
+        if (this.walktrigger !== -1 && (this.x !== x || this.z !== z)) {
             const type = NpcType.get(this.type);
             const script = ScriptProvider.getByTrigger(ServerTriggerType.AI_QUEUE1 + this.walktrigger, type.id, type.category);
             this.walktrigger = -1;
@@ -189,28 +204,13 @@ export default class Npc extends PathingEntity {
             this.moveSpeed = this.defaultMoveSpeed();
         }
 
-        if (!super.processMovement()) {
-            // nothing
-        }
+        super.processMovement();
 
         const moved = this.lastTickX !== this.x || this.lastTickZ !== this.z;
         if (moved) {
             this.lastMovement = World.currentTick + 1;
         }
         return moved;
-    }
-
-    clearInteraction() {
-        super.clearInteraction();
-        this.huntTarget = null;
-    }
-
-    pathToTarget(): void {
-        if (!this.targetWithinMaxRange()) {
-            this.defaultMode();
-            return;
-        }
-        super.pathToTarget();
     }
 
     targetWithinMaxRange(): boolean {
@@ -293,7 +293,6 @@ export default class Npc extends PathingEntity {
     setTimer(interval: number) {
         if (interval !== -1) {
             this.timerInterval = interval;
-            this.timerClock = 0;
         }
     }
 
@@ -343,13 +342,12 @@ export default class Npc extends PathingEntity {
     }
 
     processTimers() {
-        if (this.timerInterval !== 0 && this.timerClock >= this.timerInterval) {
-            this.timerClock = 0;
-
+        if (this.timerInterval > 0 && ++this.timerClock >= this.timerInterval) {
             const type = NpcType.get(this.type);
             const script = ScriptProvider.getByTrigger(ServerTriggerType.AI_TIMER, type.id, type.category);
             if (script) {
                 this.executeScript(ScriptRunner.init(script, this));
+                this.timerClock = 0;
             }
         }
     }
@@ -424,6 +422,9 @@ export default class Npc extends PathingEntity {
     }
 
     processNpcModes() {
+        if (this.delayed) {
+            return;
+        }
         if (this.targetOp === NpcMode.NULL) {
             this.defaultMode();
         } else if (this.targetOp === NpcMode.NONE) {
@@ -446,21 +447,27 @@ export default class Npc extends PathingEntity {
     }
 
     noMode(): void {
-        this.clearInteraction();
+        // this.clearInteraction();
         this.updateMovement(false);
-        this.targetOp = NpcMode.NONE;
-        this.faceEntity = -1;
-        this.masks |= InfoProt.NPC_FACE_ENTITY.id;
+        // this.targetOp = NpcMode.NONE;
+        // this.faceEntity = -1;
+        // this.masks |= InfoProt.NPC_FACE_ENTITY.id;
     }
 
     defaultMode(): void {
         this.clearInteraction();
-        this.updateMovement(false);
         const type: NpcType = NpcType.get(this.type);
         this.targetOp = type.defaultmode;
         this.lastWanderTick = World.currentTick; // osrs
         this.faceEntity = -1;
         this.masks |= InfoProt.NPC_FACE_ENTITY.id;
+
+        const npcType: NpcType = NpcType.get(this.type);
+        this.huntMode = npcType.huntmode;
+        this.huntClock = 0;
+        this.huntTarget = null;
+        // Reset timer interval
+        this.timerInterval = type.timer;
     }
 
     wanderMode(): void {
@@ -510,7 +517,7 @@ export default class Npc extends PathingEntity {
     }
 
     playerEscapeMode(): void {
-        if (!this.validateTarget()) {
+        if (!this.validateTarget() || !this.targetWithinMaxRange()) {
             this.defaultMode();
             return;
         }
@@ -570,7 +577,7 @@ export default class Npc extends PathingEntity {
     }
 
     playerFollowMode(): void {
-        if (!this.validateTarget()) {
+        if (!this.validateTarget() || !this.targetWithinMaxRange()) {
             this.defaultMode();
             return;
         }
@@ -610,8 +617,6 @@ export default class Npc extends PathingEntity {
             this.defaultMode();
             return;
         }
-        this.clearWaypoints();
-        this.updateMovement(false);
     }
 
     playerFaceCloseMode(): void {
@@ -634,16 +639,38 @@ export default class Npc extends PathingEntity {
             this.defaultMode();
             return;
         }
-        this.clearWaypoints();
-        this.updateMovement(false);
     }
 
     aiMode(): void {
-        if (!this.target || !this.validateTarget() || this.delayed || this.target.level !== this.level) {
+        const type: NpcType = NpcType.get(this.type);
+        if (!this.target || !this.target.isValid() || this.target.level !== this.level || !this.targetWithinMaxRange()) {
             this.defaultMode();
             return;
         }
 
+        // Try to interact before moving, include op Obj and Loc
+        if (this.tryInteract(true)) {
+            return;
+        }
+
+        const moved: boolean = this.updateMovement();
+
+        // Clear target if givechase=no
+        if (moved && !type.givechase) {
+            this.defaultMode();
+            return;
+        }
+
+        // Try to interact again after moving
+        if (this.target) {
+            this.tryInteract(false);
+        }
+    }
+
+    private tryInteract(allowOpScenery: boolean): boolean {
+        if (!this.target) {
+            return false;
+        }
         const type: NpcType = NpcType.get(this.type);
         const apTrigger: boolean =
             (this.targetOp >= NpcMode.APNPC1 && this.targetOp <= NpcMode.APNPC5) ||
@@ -653,49 +680,21 @@ export default class Npc extends PathingEntity {
         const opTrigger: boolean = !apTrigger;
 
         const script: ScriptFile | null = this.getTrigger();
-        if (script && opTrigger && this.inOperableDistance(this.target) && this.target instanceof PathingEntity) {
-            this.interacted = true;
-            this.clearWaypoints();
+
+        if (script && opTrigger && this.inOperableDistance(this.target) && (this.target instanceof PathingEntity || allowOpScenery)) {
             this.executeScript(ScriptRunner.init(script, this, this.target));
-            return;
+            return true;
         }
         if (script && apTrigger && this.inApproachDistance(type.attackrange, this.target)) {
-            this.interacted = true;
-            this.clearWaypoints();
             this.executeScript(ScriptRunner.init(script, this, this.target));
-            return;
+            return true;
         }
-        if (this.inOperableDistance(this.target) && this.target instanceof PathingEntity) {
-            this.target = null;
-            this.interacted = true;
-            this.clearWaypoints();
-            return;
+        if (this.inOperableDistance(this.target)) {
+            // this.target = null;
+            this.defaultMode();
+            return true;
         }
-
-        const moved: boolean = this.updateMovement();
-        if (moved) {
-            if (!type.givechase) {
-                this.defaultMode();
-                return;
-            }
-        }
-
-        if (this.target && !this.interacted) {
-            this.interacted = false;
-            if (script && opTrigger && this.inOperableDistance(this.target) && (this.target instanceof PathingEntity || !moved)) {
-                this.interacted = true;
-                this.clearWaypoints();
-                this.executeScript(ScriptRunner.init(script, this, this.target));
-            } else if (script && apTrigger && this.inApproachDistance(type.attackrange, this.target)) {
-                this.interacted = true;
-                this.clearWaypoints();
-                this.executeScript(ScriptRunner.init(script, this, this.target));
-            } else if (this.inOperableDistance(this.target) && (this.target instanceof PathingEntity || !moved)) {
-                this.target = null;
-                this.interacted = true;
-                this.clearWaypoints();
-            }
-        }
+        return false;
     }
 
     private getTrigger(): ScriptFile | null {
@@ -834,22 +833,17 @@ export default class Npc extends PathingEntity {
     // https://x.com/JagexAsh/status/1821236327150710829
     // https://x.com/JagexAsh/status/1799793914595131463
     huntAll(): void {
-        if (this.nextHuntTick > World.currentTick) {
-            return;
-        }
-        if (this.huntrange < 1) {
-            return;
-        }
+        this.huntTarget = null;
+
         const hunt: HuntType = HuntType.get(this.huntMode);
-        if (hunt.type === HuntModeType.OFF) {
+
+        // If a huntrate is defined, this acts as a throttle
+        if (this.huntClock < hunt.rate - 1) {
             return;
         }
-        if (hunt.nobodyNear === HuntNobodyNear.PAUSEHUNT && !World.gameMap.getZoneGrid(this.level).isFlagged(CoordGrid.zone(this.x), CoordGrid.zone(this.z), 5)) {
-            return;
-        }
-        // in osrs, and in this 2005: https://youtu.be/8AFed6tyOp8?t=231
-        // once an npc finds a huntTarget, it will no longer hunt until it's interactions are cleared
-        if (!hunt.findKeepHunting && this.huntTarget !== null) {
+
+        // If no hunt, just return
+        if (hunt.type === HuntModeType.OFF || this.huntrange < 1) {
             return;
         }
 
@@ -864,21 +858,45 @@ export default class Npc extends PathingEntity {
             hunted = this.huntLocs(hunt);
         }
 
-        // pick randomly from the hunted entities
+        // Pick randomly from the hunted entities
         if (hunted.length > 0) {
             const entity: Entity = hunted[Math.floor(Math.random() * hunted.length)];
             this.huntTarget = entity;
-            if (NpcMode.QUEUE1 <= hunt.findNewMode && hunt.findNewMode <= NpcMode.QUEUE20) {
-                const npcType = NpcType.get(this.type);
-                const script = ScriptProvider.getByTrigger(ServerTriggerType.AI_QUEUE1 + (hunt.findNewMode - NpcMode.QUEUE1), npcType.id, npcType.category);
-                if (script) {
-                    this.enqueueScript(script, 0, 0);
-                }
-            } else {
-                this.setInteraction(Interaction.SCRIPT, entity, hunt.findNewMode);
-            }
         }
-        this.nextHuntTick = World.currentTick + hunt.rate;
+    }
+
+    consumeHuntTarget() {
+        const hunt: HuntType = HuntType.get(this.huntMode);
+
+        // We need a huntTarget and a huntMode
+        if (!this.huntTarget || hunt.type === HuntModeType.OFF) {
+            return;
+        }
+
+        // Findnewmode runs a Queue trigger rather than setting the interaction
+        if (NpcMode.QUEUE1 <= hunt.findNewMode && hunt.findNewMode <= NpcMode.QUEUE20) {
+            const npcType = NpcType.get(this.type);
+            const script = ScriptProvider.getByTrigger(ServerTriggerType.AI_QUEUE1 + (hunt.findNewMode - NpcMode.QUEUE1), npcType.id, npcType.category);
+
+            if (script) {
+                const state = ScriptRunner.init(script, this, null, null);
+                ScriptRunner.execute(state);
+            }
+        } else {
+            // Set the interaction
+            this.setInteraction(Interaction.SCRIPT, this.huntTarget, hunt.findNewMode);
+        }
+
+        // Clear target
+        this.huntTarget = null;
+        this.huntClock = 0;
+
+        // In osrs, and in this 2005: https://youtu.be/8AFed6tyOp8?t=231
+        // Once an npc finds a huntTarget, it will no longer hunt until its interactions are cleared
+        if (!hunt.findKeepHunting) {
+            this.huntMode = -1;
+            return;
+        }
     }
 
     private huntPlayers(hunt: HuntType): Entity[] {

--- a/src/network/rs225/server/codec/NpcInfoEncoder.ts
+++ b/src/network/rs225/server/codec/NpcInfoEncoder.ts
@@ -46,7 +46,7 @@ export default class NpcInfoEncoder extends MessageEncoder<NpcInfo> {
     }
 
     private writeNpcs(buf: Packet, updates: Packet, message: NpcInfo, bytes: number): number {
-        const {currentTick, renderer, player } = message;
+        const { currentTick, renderer, player } = message;
         const buildArea: BuildArea = player.buildArea;
         // update existing npcs (255 max - 8 bits)
         buf.pBit(8, buildArea.npcs.size);
@@ -97,12 +97,14 @@ export default class NpcInfoEncoder extends MessageEncoder<NpcInfo> {
         buf.pBit(5, z);
         buf.pBit(1, 1); // extend
         this.lowdefinition(updates, renderer, npc);
+        npc.observerCount++;
         player.buildArea.npcs.add(npc);
     }
 
     private remove(buf: Packet, buildArea: BuildArea, npc: Npc): void {
         buf.pBit(1, 1);
         buf.pBit(2, 3);
+        npc.observerCount--;
         buildArea.npcs.delete(npc);
     }
 

--- a/tools/pack/config/HuntConfig.ts
+++ b/tools/pack/config/HuntConfig.ts
@@ -1,12 +1,4 @@
-import {
-    ConfigValue,
-    ConfigLine,
-    PackedData,
-    isConfigBoolean,
-    getConfigBoolean,
-    HuntCheckInv, HuntCheckInvParam,
-    HuntCheckVar
-} from '#tools/pack/config/PackShared.js';
+import { ConfigValue, ConfigLine, PackedData, isConfigBoolean, getConfigBoolean, HuntCheckInv, HuntCheckInvParam, HuntCheckVar } from '#tools/pack/config/PackShared.js';
 
 import HuntModeType from '#/engine/entity/hunt/HuntModeType.js';
 import HuntVis from '#/engine/entity/hunt/HuntVis.js';
@@ -14,17 +6,7 @@ import HuntCheckNotTooStrong from '#/engine/entity/hunt/HuntCheckNotTooStrong.js
 import HuntNobodyNear from '#/engine/entity/hunt/HuntNobodyNear.js';
 import NpcMode from '#/engine/entity/NpcMode.js';
 
-import {
-    CategoryPack,
-    HuntPack,
-    InvPack,
-    LocPack,
-    NpcPack,
-    ObjPack,
-    ParamPack,
-    VarnPack,
-    VarpPack
-} from '#/util/PackFile.js';
+import { CategoryPack, HuntPack, InvPack, LocPack, NpcPack, ObjPack, ParamPack, VarnPack, VarpPack } from '#/util/PackFile.js';
 
 export function parseHuntConfig(key: string, value: string): ConfigValue | null | undefined {
     const stringKeys: string[] = [];
@@ -344,7 +326,7 @@ export function parseHuntConfig(key: string, value: string): ConfigValue | null 
         if (isNaN(val)) {
             return null;
         }
-        return {inv, obj, condition, val};
+        return { inv, obj, condition, val };
     } else if (key === 'check_invparam') {
         // check_inv=inv,param,min,max
         const parts: string[] = value.split(',');
@@ -370,14 +352,14 @@ export function parseHuntConfig(key: string, value: string): ConfigValue | null 
         if (isNaN(val)) {
             return null;
         }
-        return {inv, param, condition, val};
+        return { inv, param, condition, val };
     } else if (key === 'extracheck_var') {
         const parts: string[] = value.split(',');
-    
+
         if (parts.length !== 2) {
             return null;
         }
-    
+
         if (!parts[0].startsWith('%')) {
             return null;
         }
@@ -394,13 +376,13 @@ export function parseHuntConfig(key: string, value: string): ConfigValue | null 
         if (isNaN(val)) {
             return null;
         }
-        return {varp, condition, val};
+        return { varp, condition, val };
     } else {
         return undefined;
     }
 }
 
-export function packHuntConfigs(configs: Map<string, ConfigLine[]>): { client: PackedData, server: PackedData } {
+export function packHuntConfigs(configs: Map<string, ConfigLine[]>): { client: PackedData; server: PackedData } {
     const client: PackedData = new PackedData(HuntPack.size);
     const server: PackedData = new PackedData(HuntPack.size);
 
@@ -464,35 +446,50 @@ export function packHuntConfigs(configs: Map<string, ConfigLine[]>): { client: P
                     server.p2(value as number);
                 }
             } else if (key === 'check_category') {
-                if (config.every(x => x.key !== 'check_npc' && x.key !== 'check_obj' && x.key !== 'check_loc' && x.key !== 'check_inv' && x.key !== 'check_invparam') && config.filter(x => x.key === 'type' && (x.value === HuntModeType.NPC || x.value === HuntModeType.OBJ || x.value === HuntModeType.SCENERY)).length > 0) {
+                if (
+                    config.every(x => x.key !== 'check_npc' && x.key !== 'check_obj' && x.key !== 'check_loc' && x.key !== 'check_inv' && x.key !== 'check_invparam') &&
+                    config.filter(x => x.key === 'type' && (x.value === HuntModeType.NPC || x.value === HuntModeType.OBJ || x.value === HuntModeType.SCENERY)).length > 0
+                ) {
                     server.p1(12);
                     server.p2(value as number);
                 } else {
                     throw new Error(`Hunt config: [${debugname}] unable to pack line!!!.\nInvalid property value: ${key}=${value}`);
                 }
             } else if (key === 'check_npc') {
-                if (config.every(x => x.key !== 'check_category' && x.key !== 'check_obj' && x.key !== 'check_loc' && x.key !== 'check_inv' && x.key !== 'check_invparam') && config.filter(x => x.key === 'type' && x.value === HuntModeType.NPC).length > 0) {
+                if (
+                    config.every(x => x.key !== 'check_category' && x.key !== 'check_obj' && x.key !== 'check_loc' && x.key !== 'check_inv' && x.key !== 'check_invparam') &&
+                    config.filter(x => x.key === 'type' && x.value === HuntModeType.NPC).length > 0
+                ) {
                     server.p1(13);
                     server.p2(value as number);
                 } else {
                     throw new Error(`Hunt config: [${debugname}] unable to pack line!!!.\nInvalid property value: ${key}=${value}`);
                 }
             } else if (key === 'check_obj') {
-                if (config.every(x => x.key !== 'check_category' && x.key !== 'check_npc' && x.key !== 'check_loc' && x.key !== 'check_inv' && x.key !== 'check_invparam') && config.filter(x => x.key === 'type' && x.value === HuntModeType.OBJ).length > 0) {
+                if (
+                    config.every(x => x.key !== 'check_category' && x.key !== 'check_npc' && x.key !== 'check_loc' && x.key !== 'check_inv' && x.key !== 'check_invparam') &&
+                    config.filter(x => x.key === 'type' && x.value === HuntModeType.OBJ).length > 0
+                ) {
                     server.p1(14);
                     server.p2(value as number);
                 } else {
                     throw new Error(`Hunt config: [${debugname}] unable to pack line!!!.\nInvalid property value: ${key}=${value}`);
                 }
             } else if (key === 'check_loc') {
-                if (config.every(x => x.key !== 'check_category' && x.key !== 'check_npc' && x.key !== 'check_obj' && x.key !== 'check_inv' && x.key !== 'check_invparam') && config.filter(x => x.key === 'type' && x.value === HuntModeType.SCENERY).length > 0) {
+                if (
+                    config.every(x => x.key !== 'check_category' && x.key !== 'check_npc' && x.key !== 'check_obj' && x.key !== 'check_inv' && x.key !== 'check_invparam') &&
+                    config.filter(x => x.key === 'type' && x.value === HuntModeType.SCENERY).length > 0
+                ) {
                     server.p1(15);
                     server.p2(value as number);
                 } else {
                     throw new Error(`Hunt config: [${debugname}] unable to pack line!!!.\nInvalid property value: ${key}=${value}`);
                 }
             } else if (key === 'check_inv') {
-                if (config.every(x => x.key !== 'check_category' && x.key !== 'check_npc' && x.key !== 'check_obj' && x.key !== 'check_loc' && x.key !== 'check_invparam') && config.filter(x => x.key === 'type' && x.value === HuntModeType.PLAYER).length > 0) {
+                if (
+                    config.every(x => x.key !== 'check_category' && x.key !== 'check_npc' && x.key !== 'check_obj' && x.key !== 'check_loc' && x.key !== 'check_invparam') &&
+                    config.filter(x => x.key === 'type' && x.value === HuntModeType.PLAYER).length > 0
+                ) {
                     const checkInv: HuntCheckInv = value as HuntCheckInv;
                     server.p1(16);
                     server.p2(checkInv.inv);
@@ -503,7 +500,10 @@ export function packHuntConfigs(configs: Map<string, ConfigLine[]>): { client: P
                     throw new Error(`Hunt config: [${debugname}] unable to pack line!!!.\nInvalid property value: ${key}=${value}`);
                 }
             } else if (key === 'check_invparam') {
-                if (config.every(x => x.key !== 'check_category' && x.key !== 'check_npc' && x.key !== 'check_obj' && x.key !== 'check_loc' && x.key !== 'check_inv') && config.filter(x => x.key === 'type' && x.value === HuntModeType.PLAYER).length > 0) {
+                if (
+                    config.every(x => x.key !== 'check_category' && x.key !== 'check_npc' && x.key !== 'check_obj' && x.key !== 'check_loc' && x.key !== 'check_inv') &&
+                    config.filter(x => x.key === 'type' && x.value === HuntModeType.PLAYER).length > 0
+                ) {
                     const checkInv: HuntCheckInvParam = value as HuntCheckInvParam;
                     server.p1(17);
                     server.p2(checkInv.inv);
@@ -513,10 +513,11 @@ export function packHuntConfigs(configs: Map<string, ConfigLine[]>): { client: P
                 } else {
                     throw new Error(`Hunt config: [${debugname}] unable to pack line!!!.\nInvalid property value: ${key}=${value}`);
                 }
-            } else if (key === 'extracheck_var') { // 18-20
+            } else if (key === 'extracheck_var') {
+                // 18-20
                 if (extracheckVarsCount > 2) {
                     throw new Error(`Hunt config: [${debugname}] unable to pack line!!!.\nLimit of 3 extracheck_var properties exceeded.`);
-                } else if (value !== null  && config.filter(x => x.key === 'type' && (x.value === HuntModeType.PLAYER)).length > 0) {
+                } else if (value !== null && config.filter(x => x.key === 'type' && x.value === HuntModeType.PLAYER).length > 0) {
                     const checkVar: HuntCheckVar = value as HuntCheckVar;
                     server.p1(18 + extracheckVarsCount);
                     server.p2(checkVar.varp);
@@ -526,7 +527,7 @@ export function packHuntConfigs(configs: Map<string, ConfigLine[]>): { client: P
                 } else {
                     throw new Error(`Hunt config: [${debugname}] unable to pack line!!!.\nInvalid property value: ${key}=${value}`);
                 }
-            } 
+            }
         }
 
         server.p1(250);


### PR DESCRIPTION
This pull request changes a significant amount of Npc behavior and mechanics to more accurately model the rs2 engine

- Hunts for Npcs have been significantly reworked

  - Hunt delay is processed during the Npc's turn, and is better handled in general
  - findnewmode now runs the `ai_queue` script immediately rather than adding it to the Npc's queue
  - If `findkeephunting` is no, then the Npc will disable its huntmode after consuming a hunt target
  - `Npc.defaultMode()` does a better job of resetting the Npc's relevant hunt variables
  - findnobodynear=no now checks if Npc is rendered by any player before allowing a hunt

- Npc pathing and interactions is a bit different

  - Interaction order has corrected
  - More robust logic for handling Npc walktrigger
  - `Npc.defaultMode()` no longer tries to path the Npc
    - This was causing the Npc to path on the tick they lose target
    - Imps could path two tiles in a single tick!
  - Destination is no longer cleared every tick when the Npc has a targeted mode
  - Npc's max range is no longer checked when it shouldn't be

- Npc timer logic improved
  - Timer is now incremented during an Npc's turn
  - Timer variables are now properly reset when `Npc.defaultMode()` is called
  - Poison logic has been rewritten to be more accurate to rs2
