### PR TITLE
fix(content): Firemaking no longer delays the player if they are on an adjacent tile

### DIFF
--- a/data/src/scripts/skill_firemaking/scripts/firemaking.rs2
+++ b/data/src/scripts/skill_firemaking/scripts/firemaking.rs2
@@ -147,7 +147,6 @@ if (~in_duel_arena($origin_coord) = true) {
     return;
 }
 if (coord ! $origin_coord) {
-    p_delay(0);
     return;
 }
 if (lineofwalk(coord, movecoord(coord, -1, 0, 0)) = true & coord = $origin_coord) { // check west


### PR DESCRIPTION

https://github.com/user-attachments/assets/bc3e663a-73a9-4f75-a397-bb4d503d8300

Removed the stall to match osrs behavior