### PR TITLE
fix(content): change regen softtimer to timer

### DIFF
--- a/data/src/scripts/login_logout/login.rs2
+++ b/data/src/scripts/login_logout/login.rs2
@@ -11,10 +11,10 @@ if (%game_brightness = 0) {
 }
 
 // register the soft timer that handles replenishing stats
-softtimer(stat_regen, 100);
-softtimer(stat_boost_restore, 100);
+settimer(stat_regen, 100);
+settimer(stat_boost_restore, 100);
 // same for health
-softtimer(health_regen, 100);
+settimer(health_regen, 100);
 // random event timer
 settimer(general_macro_events, 500);
 // chest macro gas 

--- a/data/src/scripts/player/scripts/stat.rs2
+++ b/data/src/scripts/player/scripts/stat.rs2
@@ -27,7 +27,7 @@ switch_stat($stat) {
 error("Invalid stat: <~stat_name($stat)>");
 
 // handles restoring a players stat towards the base level
-[softtimer,stat_regen]
+[timer,stat_regen]
 def_int $i = 1;
 while ($i <= enum_getoutputcount(stats)) {
     def_stat $stat = enum(int, stat, stats, $i);
@@ -42,7 +42,7 @@ while ($i <= enum_getoutputcount(stats)) {
     $i = calc($i + 1);
 }
 
-[softtimer,stat_boost_restore]
+[timer,stat_boost_restore]
 def_int $i = 1;
 while ($i <= enum_getoutputcount(stats)) {
     def_stat $stat = enum(int, stat, stats, $i);
@@ -56,7 +56,7 @@ while ($i <= enum_getoutputcount(stats)) {
 }
 
 //hp is on a seperate timer, because of rapid heal and rapid restore
-[softtimer,health_regen]
+[timer,health_regen]
 // hitpoints doesnt deplete when too high
 if (stat(hitpoints) < stat_base(hitpoints)) {
     stat_add(hitpoints, 1, 0);

--- a/data/src/scripts/skill_prayer/scripts/prayers/rapidheal.rs2
+++ b/data/src/scripts/skill_prayer/scripts/prayers/rapidheal.rs2
@@ -24,8 +24,8 @@ if (%prayer_rapidheal = ^true) {
         cleartimer(drain_prayer);
         //clearqueue(start_draining);
     }
-    clearsofttimer(health_regen);
-    softtimer(health_regen, 100);
+    cleartimer(health_regen);
+    settimer(health_regen, 100);
 } else {
     if (~prayer_checks($data) = false) {
         %prayer_rapidheal = ^false;
@@ -35,8 +35,8 @@ if (%prayer_rapidheal = ^true) {
         ~mesbox("You need a @dbl@Prayer level of <tostring(db_getfield($data, prayers:level, 0))> to use <db_getfield($data, prayers:name, 0)>.");
     } else {
         %prayer_rapidheal = ^true;
-        clearsofttimer(health_regen);
-        softtimer(health_regen, 50);
+        cleartimer(health_regen);
+        settimer(health_regen, 50);
         ~prayer_activate($data);
     }
 }

--- a/data/src/scripts/skill_prayer/scripts/prayers/rapidrestore.rs2
+++ b/data/src/scripts/skill_prayer/scripts/prayers/rapidrestore.rs2
@@ -25,8 +25,8 @@ if (%prayer_rapidrestore = ^true) {
         cleartimer(drain_prayer);
         //clearqueue(start_draining);
     }
-    clearsofttimer(stat_regen);
-    softtimer(stat_regen, 100);
+    cleartimer(stat_regen);
+    settimer(stat_regen, 100);
 } else {
     if (~prayer_checks($data) = false) {
         %prayer_rapidrestore = ^false;
@@ -36,8 +36,8 @@ if (%prayer_rapidrestore = ^true) {
         ~mesbox("You need a @dbl@Prayer level of <tostring(db_getfield($data, prayers:level, 0))> to use <db_getfield($data, prayers:name, 0)>.");
     } else {
         %prayer_rapidrestore = ^true;
-        clearsofttimer(stat_regen);
-        softtimer(stat_regen, 50);
+        cleartimer(stat_regen);
+        settimer(stat_regen, 50);
         ~prayer_activate($data);
     }
 }


### PR DESCRIPTION
From this [blog post](https://oldschool.runescape.wiki/w/Update:Game_Engine_Update):

`Over time, if your stats have been reduced or raised, most of them restore slowly back towards their default levels. However, if you opened an interface such as one of the skill guides or a shop, your stats used to stop restoring until you closed it again. We've now fixed it so that your stats will restore normally even if you have an interface open.`