### PR TITLE
fix(content): handle special npc's better in combat, and other combat refactors

### DIFF
--- a/data/src/scripts/npc/scripts/shadow_spider.rs2
+++ b/data/src/scripts/npc/scripts/shadow_spider.rs2
@@ -1,9 +1,20 @@
 [ai_opplayer2,shadow_spider] 
+if (stat(hitpoints) = 0) {
+    npc_setmode(null);
+    return;
+}
+if (%npc_action_delay > map_clock) {
+    return;
+}
+if (~npc_can_attack_player = false) {
+    npc_setmode(null);
+    return;
+}
 // https://www.youtube.com/watch?v=qCuX19-3SHc&t=185s
 if (~npc_out_of_combat = true) {
     ~shadow_spider_drain;
 }
-gosub(npc_default_attack);
+~npc_meleeattack;
 
 [proc,shadow_spider_drain]
 mes("The spider drains your prayer...");

--- a/data/src/scripts/npc/scripts/shadow_spider.rs2
+++ b/data/src/scripts/npc/scripts/shadow_spider.rs2
@@ -9,3 +9,9 @@ gosub(npc_default_attack);
 mes("The spider drains your prayer...");
 sound_synth(prayer_drain, 0, 0);
 stat_sub(prayer, divide(stat(prayer), 2), 0); // division by 2 round up, thats why percent isn't being used 
+
+[ai_queue2,shadow_spider]
+if (~npc_out_of_combat = true & finduid(%npc_aggressive_player) = true) {
+    ~shadow_spider_drain;
+}
+~npc_default_damage(last_int);

--- a/data/src/scripts/quests/quest_arthur/scripts/sir_mordred.rs2
+++ b/data/src/scripts/quests/quest_arthur/scripts/sir_mordred.rs2
@@ -12,6 +12,8 @@ gosub(npc_default_death);
 [ai_queue4,sir_mordred] gosub(npc_default_death);
 
 [label,lefaye_spare_son]
+npc_statheal(hitpoints, npc_basestat(hitpoints), 0);
+
 if_close;
 if(p_finduid(%npc_aggressive_player) = false) {
     return;

--- a/data/src/scripts/quests/quest_demon/scripts/delrith.rs2
+++ b/data/src/scripts/quests/quest_demon/scripts/delrith.rs2
@@ -12,38 +12,6 @@ if (npc_stat(hitpoints) = 0) {
     }
 }
 
-[apnpc2,delrith]
-if (npc_range(coord) > 1)
-{
-  p_aprange(1);
-  return;
-}
-@attack_delrith;
-
-[opnpc2,delrith]
-@attack_delrith;
-
-[label,attack_delrith]
-if (%demon_progress = ^demon_silverlight) {
-    if (inv_getobj(worn, 3) ! silverlight) {
-        if (inv_total(inv, silverlight) > 0) {
-            mes("Maybe I'd better wield silverlight first.");
-            return;
-        }
-
-        if (inv_total(inv, silverlight) < 1) {
-            mes("I'd rather not. He looks scary.");
-            return;
-        }
-    }
-    @player_combat_start;
-} else if (%demon_progress = ^demon_complete) {
-    mes("You've already done that quest.");
-}
-else{
-    mes("I'd rather not. He looks scary");
-}
-
 [queue,delrith_death]
 if_close;
 if (npc_find(coord, delrith, 8, 0) = true) {

--- a/data/src/scripts/quests/quest_grail/scripts/black_knight_titan.rs2
+++ b/data/src/scripts/quests/quest_grail/scripts/black_knight_titan.rs2
@@ -29,6 +29,7 @@ if(inv_total(worn, excalibur) = 0) { // if this was queued we'll need to regain 
     if(%grail_progress = ^grail_spoken_crone) {
         %grail_progress = ^grail_failed_defeat_titan;
     }
+    npc_statheal(hitpoints, npc_basestat(hitpoints), 0);
     mes("Maybe you need something more to beat the titan?");
     ~chatnpc("<p,angry>@red@Puny mortal...|@red@You cannot defeat me...");
     ~chatnpc("<p,angry>@red@I...|@red@Am...|@red@INVINCIBLE!!!");

--- a/data/src/scripts/quests/quest_mcannon/scripts/cannon.rs2
+++ b/data/src/scripts/quests/quest_mcannon/scripts/cannon.rs2
@@ -354,9 +354,6 @@ if (%mcannon_ammo < 1) {
 if (~npc_is_attackable = false) {
     return;
 }
-if (npc_stat(hitpoints) = 0) {
-    return;
-}
 if (~player_in_combat_check = false) { // https://youtu.be/TeQXQDaawO0?t=247
     return;
 }

--- a/data/src/scripts/quests/quest_mcannon/scripts/cannon.rs2
+++ b/data/src/scripts/quests/quest_mcannon/scripts/cannon.rs2
@@ -37,6 +37,11 @@ while ($i < 50) {
 return(null);
 
 [opheld1,cannon_base]
+if (%mcannon_progress < ^mcannon_complete) {
+    mes("You can't set up this cannon.");
+    mes("You need to complete the Dwarf Cannon quest."); // osrs
+    return;
+}
 if (%mcannon_coord ! null) {
     if (loc_find(%mcannon_coord, cannon) = true) {
         // osrs

--- a/data/src/scripts/quests/quest_vampire/scripts/count_draynor.rs2
+++ b/data/src/scripts/quests/quest_vampire/scripts/count_draynor.rs2
@@ -1,15 +1,9 @@
-[ai_queue3,count_draynor] // do nothing
 [ai_queue4,count_draynor] gosub(npc_death);
 
-[opnpc2,count_draynor]
-if (~player_in_combat_check = false) {
-    return;
-}
-if (%vampire_progress = ^vampire_complete) {
-    mes("You've done enough vampire slaying.");
-    return;
-}
-// osrs wiki says manually casting spells doesnt work but autocast does. So its probably here
+// https://youtu.be/67aR5-_INcU
+// - seems to be called on npc damage, and on npc hit
+// - two calls from 66 hits
+[proc,count_draynor_garlic]
 if (inv_total(inv, garlic) > 0) {
     if (npc_stat(hitpoints) = npc_basestat(hitpoints)) { // osrs https://archive.is/djWKq
         npc_statsub(hitpoints, 10, 0);
@@ -17,44 +11,45 @@ if (inv_total(inv, garlic) > 0) {
         npc_statsub(strength, 10, 0);
         npc_statsub(defence, 40, 0);
         mes("The vampire seems to weaken.");
-    } else if (random(16) = 0) {
+    } else if (random(64) = 0) {
         mes("The vampire seems to weaken.");
     }
 }
 
-@player_combat_start;
-[apnpc2,count_draynor]
-if (~player_in_combat_check = false) {
+[ai_opplayer2,count_draynor]
+if (stat(hitpoints) = 0) {
+    npc_setmode(null);
     return;
 }
-if (%vampire_progress = ^vampire_complete) {
-    mes("You've done enough vampire slaying.");
+if (%npc_action_delay > map_clock) {
     return;
 }
-// osrs wiki says manually casting spells doesnt work but autocast does. So its probably here
-if (inv_total(inv, garlic) > 0) {
-    if (npc_stat(hitpoints) = npc_basestat(hitpoints)) { // osrs https://archive.is/djWKq
-        npc_statsub(hitpoints, 10, 0);
-        npc_statsub(attack, 10, 0);
-        npc_statsub(strength, 10, 0);
-        npc_statsub(defence, 40, 0);
-        mes("The vampire seems to weaken.");
-    } else if (random(16) = 0) {
-        mes("The vampire seems to weaken.");
-    }
+if (~npc_can_attack_player = false) {
+    npc_setmode(null);
+    return;
 }
-@player_combat_start_ap;
+anim(%com_defendanim, 0);
+npc_anim(npc_param(attack_anim), 0);
+if (npc_param(attack_sound) ! null) {
+    sound_synth(npc_param(attack_sound), 0, 0);
+}
+~count_draynor_garlic;
+~npc_meleeattack;
 
 [ai_queue2,count_draynor]
-~npc_default_damage(last_int);
-if (npc_stat(hitpoints) = 0) {
-    if (npc_findhero = true) {
-        if (p_finduid(uid) = true) {
-            @count_draynor_use_stake;
-        }
-    }
-    npc_statheal(hitpoints, 1, 0);
+if (finduid(%npc_aggressive_player) = true) {
+    ~count_draynor_garlic;
 }
+~npc_default_damage(last_int);
+
+
+[ai_queue3,count_draynor]
+if (npc_findhero = true) {
+    if (p_finduid(uid) = true) {
+        @count_draynor_use_stake;
+    }
+}
+npc_statheal(hitpoints, 1, 0);
 
 [label,count_draynor_use_stake]
 if (inv_total(inv, stake) = 0) {

--- a/data/src/scripts/skill_combat/scripts/npc/npc_combat.rs2
+++ b/data/src/scripts/skill_combat/scripts/npc/npc_combat.rs2
@@ -160,6 +160,9 @@ if(npc_type = npc_374 & %damagetype <= ^crush_style & npc_range(coord) <= 1) {
     mes("These ogres are for ranged combat only.");
     return (false);
 }
+if (npc_type = delrith & (%demon_progress >= ^demon_complete | inv_getobj(worn, ^wearpos_rhand) ! silverlight)) {
+    return(false);
+}
 
 if (npc_hasop(2) = true) {
     return (true);
@@ -227,6 +230,9 @@ if (npc_type = chompy_bird) {
 }
 if (%vampire_progress = ^vampire_complete & npc_type = count_draynor) {
     mes("You've done enough vampire slaying.");
+    return(false);
+}
+if (npc_type = delrith & (%demon_progress >= ^demon_complete | inv_getobj(worn, ^wearpos_rhand) ! silverlight)) {
     return(false);
 }
 

--- a/data/src/scripts/skill_combat/scripts/npc/npc_combat.rs2
+++ b/data/src/scripts/skill_combat/scripts/npc/npc_combat.rs2
@@ -160,8 +160,20 @@ if(npc_type = npc_374 & %damagetype <= ^crush_style & npc_range(coord) <= 1) {
     mes("These ogres are for ranged combat only.");
     return (false);
 }
-if (npc_type = delrith & (%demon_progress >= ^demon_complete | inv_getobj(worn, ^wearpos_rhand) ! silverlight)) {
-    return(false);
+
+if (npc_type = delrith) {
+    if (%demon_progress >= ^demon_complete) {
+        mes("You've already done that quest.");
+        return(false);
+    }
+    if (inv_getobj(worn, 3) ! silverlight) {
+        if (inv_total(inv, silverlight) > 0) {
+            mes("Maybe I'd better wield silverlight first.");
+            return(false);
+        }
+        mes("I'd rather not. He looks scary");
+        return(false);
+    }
 }
 
 if (npc_hasop(2) = true) {
@@ -232,8 +244,19 @@ if (%vampire_progress = ^vampire_complete & npc_type = count_draynor) {
     mes("You've done enough vampire slaying.");
     return(false);
 }
-if (npc_type = delrith & (%demon_progress >= ^demon_complete | inv_getobj(worn, ^wearpos_rhand) ! silverlight)) {
-    return(false);
+if (npc_type = delrith) {
+    if (%demon_progress >= ^demon_complete) {
+        mes("You've already done that quest.");
+        return(false);
+    }
+    if (inv_getobj(worn, 3) ! silverlight) {
+        if (inv_total(inv, silverlight) > 0) {
+            mes("Maybe I'd better wield silverlight first.");
+            return(false);
+        }
+        mes("I'd rather not. He looks scary");
+        return(false);
+    }
 }
 
 if (npc_hasop(2) = true) {

--- a/data/src/scripts/skill_combat/scripts/npc/npc_combat.rs2
+++ b/data/src/scripts/skill_combat/scripts/npc/npc_combat.rs2
@@ -175,6 +175,12 @@ if (npc_type = delrith) {
         return(false);
     }
 }
+if (npc_type = count_draynor) {
+    if (%vampire_progress = ^vampire_complete) {
+        mes("You've done enough vampire slaying.");
+        return(false);
+    }
+}
 
 if (npc_hasop(2) = true) {
     return (true);
@@ -258,7 +264,12 @@ if (npc_type = delrith) {
         return(false);
     }
 }
-
+if (npc_type = count_draynor) {
+    if (%vampire_progress = ^vampire_complete) {
+        mes("You've done enough vampire slaying.");
+        return(false);
+    }
+}
 if (npc_hasop(2) = true) {
     return (true);
 }

--- a/data/src/scripts/skill_combat/scripts/player/player_combat.rs2
+++ b/data/src/scripts/skill_combat/scripts/player/player_combat.rs2
@@ -29,14 +29,8 @@ if (%damagetype = ^ranged_style) {
     @player_ranged_attack;
 }
 if (~player_autocast_enabled = true) {
-    def_dbrow $spell_data = ~get_spell_data(%autocast_spell);
-    if (~check_spell_requirements($spell_data) = true) {
-        p_stopaction;
-        p_opnpct(db_getfield($spell_data, magic_spell_table:spellcom, 0));
-    }  
-    return;
+    @player_magic_attack;
 }
-
 @player_melee_attack;
 
 

--- a/data/src/scripts/skill_combat/scripts/player/player_magic.rs2
+++ b/data/src/scripts/skill_combat/scripts/player/player_magic.rs2
@@ -3,6 +3,14 @@
 // add it to the spell table in ../configs/magic/magic_combat_spells.dbrow
 // create an apnpct trigger for it in this script
 
+[label,player_magic_attack]
+def_dbrow $spell_data = ~get_spell_data(%autocast_spell);
+if (~check_spell_requirements($spell_data) = false) {
+    // todo: figure out if this should automatically unset autocast?
+    return;
+}  
+p_opnpct(db_getfield($spell_data, magic_spell_table:spellcom, 0));
+
 // osrs's opnpct triggers are unused
 [apnpct,magic:wind_strike]
 if (%tutorial_progress < ^tutorial_complete) {
@@ -60,15 +68,10 @@ if (~player_npc_hit_roll(^magic_style) = true) {
     ~pvm_spell_fail($spell_data, $duration);
 }
 
+// no 0 hp check for magic: you can attack slayer npcs when they're at 0 hp
 [proc,pvm_combat_spell_checks](dbrow $spell_data)(boolean)
 if_close;
 p_stopaction;
-if(npc_stat(hitpoints) = 0 & (npc_type = sir_mordred | npc_type = black_knight_titan)) {
-    npc_statheal(hitpoints, npc_basestat(hitpoints), 0);
-}
-if (npc_stat(hitpoints) = 0) {
-    return(false); // this means the npc is not avail to fight i.e dead
-}
 if (map_clock < %action_delay) {
     p_opnpct(db_getfield($spell_data, magic_spell_table:spellcom, 0));
     return(false);
@@ -80,20 +83,8 @@ if (~player_in_combat_check = false) {
     return(false);
 }
 // check if npc is attackable
-if (~npc_is_attackable_opt() = false) {
+if (~npc_is_attackable_opt = false) {
     return(false);
-}
-if (npc_type = delrith) {
-    if (%demon_progress < ^demon_complete) {
-        if (inv_getobj(worn, 3) ! silverlight) {
-           return(false);
-        }
-    } else {
-        return(false);
-    }
-}
-if (npc_type = shadow_spider & %npc_attacking_uid ! uid & ~npc_out_of_combat = true) {
-    ~shadow_spider_drain;
 }
 return(true);
 

--- a/data/src/scripts/skill_combat/scripts/player/player_magic.rs2
+++ b/data/src/scripts/skill_combat/scripts/player/player_magic.rs2
@@ -4,11 +4,16 @@
 // create an apnpct trigger for it in this script
 
 [label,player_magic_attack]
+if (~npc_is_attackable = false) { // test: wormbrain's special mes shows before if you dont have enough runes to autocast a specific spell
+    return;
+}
 def_dbrow $spell_data = ~get_spell_data(%autocast_spell);
 if (~check_spell_requirements($spell_data) = false) {
-    // todo: figure out if this should automatically unset autocast?
+    if (%autocast_spell = db_getfield($spell_data, magic_spell_table:spell, 0)) { // matches osrs behavior
+        %attackstyle_magic = 0;
+    }
     return;
-}  
+}
 p_opnpct(db_getfield($spell_data, magic_spell_table:spellcom, 0));
 
 // osrs's opnpct triggers are unused
@@ -77,6 +82,9 @@ if (map_clock < %action_delay) {
     return(false);
 }
 if (~check_spell_requirements($spell_data) = false) {
+    if (%autocast_spell = db_getfield($spell_data, magic_spell_table:spell, 0)) { // matches osrs behavior
+        %attackstyle_magic = 0;
+    }
     return(false);
 }
 if (~player_in_combat_check = false) {

--- a/data/src/scripts/skill_combat/scripts/player/player_melee.rs2
+++ b/data/src/scripts/skill_combat/scripts/player/player_melee.rs2
@@ -67,8 +67,4 @@ if ($weapon = null) {
     %action_delay = add(map_clock, oc_param($weapon, attackrate));
 }
 
-if (npc_type = shadow_spider & %npc_attacking_uid ! uid & ~npc_out_of_combat = true) {
-    ~shadow_spider_drain;
-}
-
 p_opnpc(2);

--- a/data/src/scripts/skill_combat/scripts/player/player_ranged.rs2
+++ b/data/src/scripts/skill_combat/scripts/player/player_ranged.rs2
@@ -1,30 +1,5 @@
 [label,player_ranged_attack]
-p_stopaction;
-// npc_setmode(opplayer2);
-// facesquare(npc_coord);
-
-// todo this is for flinching players (pvp etc)
-//if (autoretaliateenabled && action_clock < gameClock()) action_clock = gameClock() + (weaponSpeed / 2)
-if(%action_delay <= map_clock & npc_stat(hitpoints) = 0 & (npc_type = sir_mordred | npc_type = black_knight_titan)) {
-    npc_statheal(hitpoints, npc_basestat(hitpoints), 0);
-}
-
-if (npc_stat(hitpoints) = 0) {
-    p_stopaction;
-    return; // this means the npc is not avail to fight i.e dead
-}
-
-def_obj $rhand = inv_getobj(worn, ^wearpos_rhand);
-if ($rhand = null) {
-    mes("That was your last one!");
-    p_stopaction;
-    ~update_all($rhand);
-    return;
-}
-
-// check if npc is attackable
-if (~npc_is_attackable() = false) {
-    p_stopaction;
+if (~npc_is_attackable = false) {
     return;
 }
 
@@ -33,14 +8,18 @@ if (%action_delay > map_clock) {
     return;
 }
 
+if (npc_stat(hitpoints) = 0) {
+    return;
+}
+
 ~player_combat_stat; // update combat varps before calculating action_delay and shooting
 
 // set the skill clock depending on the weapon attack rate
-def_obj $weapon = inv_getobj(worn, ^wearpos_rhand);
-if ($weapon = null) {
+def_obj $rhand = inv_getobj(worn, ^wearpos_rhand);
+if ($rhand = null) {
     %action_delay = add(map_clock, 4);
 } else {
-    %action_delay = add(map_clock, oc_param($weapon, attackrate));
+    %action_delay = add(map_clock, oc_param($rhand, attackrate));
 }
 if (%damagestyle = ^style_ranged_rapid) {
     %action_delay = sub(%action_delay, 1);
@@ -82,11 +61,8 @@ if (npc_param(defend_sound) ! null) {
 }
 
 npc_heropoints($damage);
-
-if (npc_type = shadow_spider & %npc_attacking_uid ! uid & ~npc_out_of_combat = true) {
-    ~shadow_spider_drain;
-}
 p_opnpc(2);
+
 if ($ammo = holy_water) {
     world_delay(calc($delay / 30 - 2));
     if (map_blocked(npc_coord) = true) {
@@ -146,4 +122,8 @@ return(~npc_projectile(coord, npc_uid, oc_param($ammo, proj_travel), 40, 36, 41,
 [proc,ranged_throw_npc](obj $ammo)(int)
 spotanim_pl(oc_param($ammo, proj_launch), 96, 0);
 inv_moveitem(worn, ranged_quiver_inv, $ammo, 1);
+if (inv_total(worn, $ammo) = 0) {
+    mes("That was your last one!");
+    ~update_all(inv_getobj(worn, ^wearpos_rhand));
+}
 return(~npc_projectile(coord, npc_uid, oc_param($ammo, proj_travel), 40, 36, 32, 15, 0, 11, 5));

--- a/data/src/scripts/skill_combat/scripts/pvp/pvp_combat.rs2
+++ b/data/src/scripts/skill_combat/scripts/pvp/pvp_combat.rs2
@@ -17,11 +17,10 @@ if (inv_getobj(worn, ^wearpos_rhand) ! null) {
 if (~player_autocast_enabled = true){
     $attackrange = 10;
 }
-if ($attackrange <= 1) {
+if (($attackrange <= 1 & ~pvp_is_attackable = false) | $distance > $attackrange) {
     p_aprange($attackrange); // walk then op again
     return;
 }
-p_aprange($attackrange);
 @pvp_combat_start;
 
 [label,pvp_combat_start]
@@ -33,16 +32,7 @@ if (%damagetype = ^ranged_style) {
 }
 
 if (~player_autocast_enabled = true) {
-    // look for spell in db
-    def_dbrow $spell_data = ~get_spell_data(%autocast_spell);
-    if (~check_spell_requirements($spell_data) = false) {
-        %attackstyle_magic = 0;
-        return;
-    }
-
-    // in osrs you cant tick manip with autocast delay, so its prob its on varp?
-    p_opplayert(db_getfield($spell_data, magic_spell_table:spellcom, 0));
-    return;
+    @pvp_magic_attack;
 }
 @pvp_melee_attack;
 

--- a/data/src/scripts/skill_combat/scripts/pvp/pvp_magic.rs2
+++ b/data/src/scripts/skill_combat/scripts/pvp/pvp_magic.rs2
@@ -1,3 +1,11 @@
+[label,pvp_magic_attack]
+def_dbrow $spell_data = ~get_spell_data(%autocast_spell);
+if (~check_spell_requirements($spell_data) = false) {
+    // %attackstyle_magic = 0; // todo: figure out if this is needed or not (unsets auto cast)
+    return;
+}
+p_opplayert(db_getfield($spell_data, magic_spell_table:spellcom, 0));
+
 [applayert,magic:wind_strike] ~pvp_default_spell(^wind_strike);
 [applayert,magic:water_strike] ~pvp_default_spell(^water_strike);
 [applayert,magic:earth_strike] ~pvp_default_spell(^earth_strike);

--- a/data/src/scripts/skill_combat/scripts/pvp/pvp_magic.rs2
+++ b/data/src/scripts/skill_combat/scripts/pvp/pvp_magic.rs2
@@ -1,7 +1,9 @@
 [label,pvp_magic_attack]
 def_dbrow $spell_data = ~get_spell_data(%autocast_spell);
 if (~check_spell_requirements($spell_data) = false) {
-    // %attackstyle_magic = 0; // todo: figure out if this is needed or not (unsets auto cast)
+    if (%autocast_spell = db_getfield($spell_data, magic_spell_table:spell, 0)) { // matches osrs behavior
+        %attackstyle_magic = 0;
+    }
     return;
 }
 p_opplayert(db_getfield($spell_data, magic_spell_table:spellcom, 0));
@@ -67,6 +69,9 @@ if (map_clock < %action_delay) {
     return(false);
 }
 if (~check_spell_requirements($spell_data) = false) {
+    if (%autocast_spell = db_getfield($spell_data, magic_spell_table:spell, 0)) { // matches osrs behavior
+        %attackstyle_magic = 0;
+    }
     return(false);
 }
 // these go after rune check

--- a/data/src/scripts/skill_combat/scripts/pvp/pvp_ranged.rs2
+++ b/data/src/scripts/skill_combat/scripts/pvp/pvp_ranged.rs2
@@ -6,18 +6,12 @@ if (.stat(hitpoints) = 0) {
     p_stopaction;
     return;
 }
-def_obj $rhand = inv_getobj(worn, ^wearpos_rhand);
-if ($rhand = null) {
-    mes("That was your last one!");
-    p_stopaction;
-    ~update_all($rhand);
-    return;
-}
 if (%action_delay > map_clock) {
     p_opplayer(2);
     return;
 }
 // this can be either the quiver or rhand.
+def_obj $rhand = inv_getobj(worn, ^wearpos_rhand);
 def_obj $ammo = ~player_ranged_check_ammo($rhand);
 if ($ammo = null) {
     p_stopaction;
@@ -42,7 +36,6 @@ if (~pvp_hit_roll(%damagetype) = true) {
     $damage = min(randominc($maxhit), .stat(hitpoints)); // tick eating existed! https://oldschool.runescape.wiki/w/Update:The_Wintertodt
     ~give_combat_experience_pvp(%damagestyle, $damage, ~pvp_xp_multiplier(~.player_combat_level));
 }
-
 def_int $delay = ~pvp_ranged_use_weapon($rhand, $ammo);
 anim(%com_attackanim, 0);
 sound_synth(%com_attacksound, 0, 0);
@@ -57,12 +50,11 @@ both_heropoints($damage);
 // .sound_synth(.%com_defendsound, 0, 20);
 // sound_synth(.%com_defendsound, 0, 20);
 
-def_obj $weapon = inv_getobj(worn, ^wearpos_rhand);
-if ($weapon = null) {
+if ($rhand = null) {
     %action_delay = add(map_clock, 4);
 } else {
-    %action_delay = add(map_clock, oc_param($weapon, attackrate));
-    def_int $poison_severity = oc_param($weapon, poison_severity);
+    %action_delay = add(map_clock, oc_param($rhand, attackrate));
+    def_int $poison_severity = oc_param($rhand, poison_severity);
     if ($damage > 0 & $poison_severity > 0 & random(4) = 0) { // 1/4 chance to poison
         .queue(poison_player, 0, $poison_severity);
     }
@@ -98,6 +90,10 @@ switch_category(oc_category($rhand)) {
     case weapon_bow, weapon_crossbow :
         $delay = ~player_projectile(coord, .coord, .uid, oc_param($ammo, proj_travel), 40, 36, 32, 15, 0, 11, 5);
     case weapon_thrown, weapon_javelin :
+        if (inv_total(worn, $ammo) = 0) {
+            mes("That was your last one!");
+            ~update_all($rhand);
+        }
         $delay = ~player_projectile(coord, .coord, .uid, oc_param($ammo, proj_travel), 40, 36, 32, 15, 0, 11, 5);
 }
 return($delay);


### PR DESCRIPTION
- refactors some combat scripts
- remove custom opnpc2 and apnpc2 triggers for count draynor and delrith. Move these to ~npc_is_attackable to allow p_aprange calculations to run.
- removes 0 hp check for magic and cannoning (these dont exist in osrs!)
- adds cannon quest req to place cannons
- heal black knight titan and sir mordred from their death instead of being attacked at 0 hp
- shadow spiders drain prayer when they *retaliate*
- reset autocast when out of runes, if trying to attack with your autocast spell (matches osrs)
- move garlic behavior to count count draynor's attack script and *retaliate* script