### PR TITLE
feat(engine): red-flag marker (public part)

### DIFF
--- a/prisma/multiworld/migrations/20250228142154_red_flag/migration.sql
+++ b/prisma/multiworld/migrations/20250228142154_red_flag/migration.sql
@@ -1,0 +1,7 @@
+-- AlterTable
+ALTER TABLE `account` ADD COLUMN `flag_removed_by_id` INTEGER NULL,
+    ADD COLUMN `flag_removed_reason` VARCHAR(191) NULL,
+    ADD COLUMN `flagged_at` DATETIME(3) NULL,
+    ADD COLUMN `red_flag` BOOLEAN NOT NULL DEFAULT false,
+    ADD COLUMN `red_flag_context` VARCHAR(191) NULL,
+    ADD COLUMN `red_flag_reason` INTEGER NULL;

--- a/prisma/multiworld/schema.prisma
+++ b/prisma/multiworld/schema.prisma
@@ -40,6 +40,13 @@ model account {
     notes_updated DateTime?
 
     members       Boolean  @default(true)
+
+    red_flag        Boolean  @default(false)
+    red_flag_reason Int?
+    red_flag_context String?
+    flagged_at      DateTime?
+    flag_removed_by_id Int?
+    flag_removed_reason String?
 }
 
 model session {

--- a/prisma/singleworld/migrations/20250228142206_red_flag/migration.sql
+++ b/prisma/singleworld/migrations/20250228142206_red_flag/migration.sql
@@ -1,0 +1,33 @@
+-- RedefineTables
+PRAGMA defer_foreign_keys=ON;
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_account" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "username" TEXT NOT NULL,
+    "password" TEXT NOT NULL,
+    "email" TEXT,
+    "registration_ip" TEXT,
+    "registration_date" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "logged_in" INTEGER NOT NULL DEFAULT 0,
+    "login_time" DATETIME,
+    "logged_out" INTEGER NOT NULL DEFAULT 0,
+    "logout_time" DATETIME,
+    "muted_until" DATETIME,
+    "banned_until" DATETIME,
+    "staffmodlevel" INTEGER NOT NULL DEFAULT 0,
+    "notes" TEXT,
+    "notes_updated" DATETIME,
+    "members" BOOLEAN NOT NULL DEFAULT true,
+    "red_flag" BOOLEAN NOT NULL DEFAULT false,
+    "red_flag_reason" INTEGER,
+    "red_flag_context" TEXT,
+    "flagged_at" DATETIME,
+    "flag_removed_by_id" INTEGER,
+    "flag_removed_reason" TEXT
+);
+INSERT INTO "new_account" ("banned_until", "email", "id", "logged_in", "logged_out", "login_time", "logout_time", "members", "muted_until", "notes", "notes_updated", "password", "registration_date", "registration_ip", "staffmodlevel", "username") SELECT "banned_until", "email", "id", "logged_in", "logged_out", "login_time", "logout_time", "members", "muted_until", "notes", "notes_updated", "password", "registration_date", "registration_ip", "staffmodlevel", "username" FROM "account";
+DROP TABLE "account";
+ALTER TABLE "new_account" RENAME TO "account";
+CREATE UNIQUE INDEX "account_username_key" ON "account"("username");
+PRAGMA foreign_keys=ON;
+PRAGMA defer_foreign_keys=OFF;

--- a/prisma/singleworld/schema.prisma
+++ b/prisma/singleworld/schema.prisma
@@ -40,6 +40,13 @@ model account {
     notes_updated DateTime?
 
     members       Boolean  @default(true)
+
+    red_flag        Boolean  @default(false)
+    red_flag_reason Int?
+    red_flag_context String?
+    flagged_at      DateTime?
+    flag_removed_by_id Int?
+    flag_removed_reason String?
 }
 
 // logged in sessions

--- a/src/db/types.ts
+++ b/src/db/types.ts
@@ -20,7 +20,13 @@ export type account = {
     staffmodlevel: Generated<number>;
     notes: string | null;
     notes_updated: string | null;
-    members: Generated<boolean>;
+    members: Generated<number>;
+    red_flag: Generated<number>;
+    red_flag_reason: number | null;
+    red_flag_context: string | null;
+    flagged_at: string | null;
+    flag_removed_by_id: number | null;
+    flag_removed_reason: string | null;
 };
 export type account_session = {
     id: Generated<number>;

--- a/src/engine/World.ts
+++ b/src/engine/World.ts
@@ -2214,6 +2214,15 @@ class World {
         });
     }
 
+    addRedFlag(player: Player, reason_index: number, extra_context?: string) {
+        this.loggerThread.postMessage({
+            type: 'red_flag',
+            username: player.username,
+            reason_index: reason_index,
+            extra_context: extra_context,
+        });
+    }
+
     submitInputTracking(username: string, session_uuid: string, events: InputTrackingEvent[]) {
         this.loggerThread.postMessage({
             type: 'input_track',

--- a/src/network/rs225/client/handler/ClientCheatHandler.ts
+++ b/src/network/rs225/client/handler/ClientCheatHandler.ts
@@ -565,6 +565,25 @@ export default class ClientCheatHandler extends MessageHandler<ClientCheat> {
                 } else {
                     player.messageGame(`Player '${args[0]}' does not exist or is not logged in.`);
                 }
+            } else if (cmd === 'red_flag') {
+                // custom - for testing flag behaviour
+                if (args.length < 2) {
+                    // ::red_flag username reason_index
+                    player.messageGame('Usage: ::red_flag <username> <reason_number>');
+                    return false;
+                }
+                const username = args[0];
+                const reason_index = tryParseInt(args[1], -1);
+                if (reason_index === -1) {
+                    return false;
+                }
+                const other = World.getPlayerByUsername(username);
+                if (!other) {
+                    player.messageGame(`Player '${args[0]}' does not exist or is not logged in.`);
+                    return false;
+                }
+                World.addRedFlag(other, reason_index);
+                player.messageGame(`flag ${reason_index} has been applied to player '${username}'`);
             }
         }
 

--- a/src/server/logger/LoggerClient.ts
+++ b/src/server/logger/LoggerClient.ts
@@ -63,4 +63,19 @@ export default class LoggerClient extends InternalClient {
             events
         }));
     }
+
+    public async redFlag(username: string, reason_index: number, extra_context?: string) {
+        await this.connect();
+
+        if (!this.ws || !this.wsr || !this.wsr.checkIfWsLive()) {
+            return;
+        }
+
+        this.ws.send(JSON.stringify({
+            type: 'red_flag',
+            username,
+            reason_index,
+            extra_context,
+        }));
+    }
 }

--- a/src/server/logger/LoggerServer.ts
+++ b/src/server/logger/LoggerServer.ts
@@ -84,6 +84,25 @@ export default class LoggerServer {
                             }
                             break;
                         }
+                        case 'red_flag': {
+                            const { username, reason_index, extra_context } = msg;
+                            const account = await db.selectFrom('account').where('username', '=', username).selectAll().executeTakeFirst();
+                            if (!account) {
+                                console.log('red_flag: no account found for %s, aborting.', username);
+                                break;
+                            }
+                            await db.updateTable('account')
+                                .set({
+                                    red_flag: 1,
+                                    red_flag_reason: reason_index,
+                                    red_flag_context: extra_context,
+                                    flagged_at: toDbDate(new Date(Date.now())),
+                                    flag_removed_by_id: null,
+                                    flag_removed_reason: null,
+                                })
+                                .where('id', '=', account.id)
+                                .execute();
+                        }
                     }
                 } catch (err) {
                     console.error(err);

--- a/src/server/logger/LoggerThread.ts
+++ b/src/server/logger/LoggerThread.ts
@@ -64,6 +64,13 @@ async function handleRequests(_parentPort: ParentPort, msg: any) {
             }
             break;
         }
+        case 'red_flag': {
+            if (Environment.LOGGER_SERVER) {
+                const { username, reason_index, extra_context } = msg;
+                await client.redFlag(username, reason_index, extra_context);
+            }
+            break;
+        }
         // todo: store session's packet traffic for analysis
         default:
             console.error('Unknown message type: ' + msg.type);


### PR DESCRIPTION
Add infrastructure to support a flag on Account which can be set, along with a reason index (int) and optional context (str). There is also database scaffolding for dismissing flags, but that side isnt present here.

No actual markers are present in this PR.