### PR TITLE
fix(engine): don't convert teleport op to walk/run

### DIFF
--- a/src/engine/World.ts
+++ b/src/engine/World.ts
@@ -1097,7 +1097,6 @@ class World {
     private processInfo(): void {
         // TODO: benchmark this?
         for (const player of this.players) {
-            player.convertMovementDir();
             player.reorient();
 
             const grid = this.playerGrid;
@@ -1112,7 +1111,6 @@ class World {
         }
 
         for (const npc of this.npcs) {
-            npc.convertMovementDir();
             npc.reorient();
             this.npcRenderer.computeInfo(npc);
         }

--- a/src/engine/entity/PathingEntity.ts
+++ b/src/engine/entity/PathingEntity.ts
@@ -309,40 +309,6 @@ export default abstract class PathingEntity extends Entity {
         }
     }
 
-    convertMovementDir() {
-        // temp variables to convert movement operations
-        let walkDir = this.walkDir;
-        let runDir = this.runDir;
-        let tele = this.tele;
-
-        // convert p_teleport() into walk or run
-        const distanceMoved = CoordGrid.distanceTo(this, {
-            x: this.lastTickX,
-            z: this.lastTickZ,
-            width: this.width,
-            length: this.length
-        });
-        if (tele && !this.jump && distanceMoved <= 2) {
-            if (distanceMoved === 2) {
-                // run
-                walkDir = CoordGrid.face(this.lastTickX, this.lastTickZ, this.x, this.z);
-                const walkX = CoordGrid.moveX(this.lastTickX, walkDir);
-                const walkZ = CoordGrid.moveZ(this.lastTickZ, walkDir);
-                runDir = CoordGrid.face(walkX, walkZ, this.x, this.z);
-            } else {
-                // walk
-                walkDir = CoordGrid.face(this.lastTickX, this.lastTickZ, this.x, this.z);
-                runDir = -1;
-            }
-
-            tele = false;
-        }
-
-        this.walkDir = walkDir;
-        this.runDir = runDir;
-        this.tele = tele;
-    }
-
     /**
      * Face and orient to a specified fine coord.
      * Enable `client` to update connected clients about the new focus, enabling the face_coord mask.


### PR DESCRIPTION
Currently, the engine converts a 1/2 tile teleport op to a walk/run, this is incorrect as the client will already convert any <= 2 teleport into a walk anyways if it's not a jump (https://github.com/2004Scape/Client/blob/67f5eda79588149043170088a53465fe3b00aa1a/client/src/main/java/client.java#L10278

This matches OSRS 1, see the p_teleport used here: https://youtu.be/FPNmOhs8jdw?si=K-5L2oh6J3OLuIjs&t=602

Previous:

https://github.com/user-attachments/assets/c786ebb8-b496-488d-8c99-dcb25527ae50

After change:

https://github.com/user-attachments/assets/87dbbfc5-4b19-4103-a26e-1327b07bfdc3

