### PR TITLE
fix(content): Sheep Herder typo fixed

### DIFF
--- a/data/src/scripts/quests/quest_sheepherder/scripts/npcs/diseased_sheep.rs2
+++ b/data/src/scripts/quests/quest_sheepherder/scripts/npcs/diseased_sheep.rs2
@@ -96,7 +96,7 @@ if (~inzone_coord_pair_table(sheepherder_pen_gate, npc_coord) = true) {
     npc_facesquare(movecoord(npc_coord, 0, 0, -1));
     npc_setmode(none);
     %sheepherder_disposal = setbit(%sheepherder_disposal, $npc_start_bit);
-    mes("The sheep obligingly jumps over the gate and into the inclosure.");
+    mes("The sheep obligingly jumps over the gate and into the enclosure.");
 }
 
 [ai_timer,_diseased_sheep]


### PR DESCRIPTION
Fixed typo when sheep are herded into enclosure.

https://youtu.be/SrPeQHoiI0o?si=x50Pp2ipgc84w67n&t=652 - RSC version (Granted it was not uploaded around RSC time, but still fairly old)

https://youtu.be/fzoxDrN3W4w?si=_CEY5FQorTJ_qi3w&t=247 - OSRS

I can't imagine it'd have changed from 'enclosure' to 'inclosure' for a short period of time, hence this PR.