### PR TITLE
fix(engine): Prevent Npcs from searching for Players when no one is around

### DIFF
--- a/src/engine/World.ts
+++ b/src/engine/World.ts
@@ -640,7 +640,7 @@ class World {
             // Check if npc is alive
             if (npc.isActive) {
                 // Hunts will process even if the npc is delayed during this portion
-                if (npc.huntMode !== -1) {
+                if (npc.huntMode !== -1 && npc.observerCount > 0) {
                     const hunt = HuntType.get(npc.huntMode);
 
                     if (hunt && hunt.type === HuntModeType.PLAYER) {
@@ -790,7 +790,7 @@ class World {
                 if (npc.huntMode !== -1) {
                     const hunt = HuntType.get(npc.huntMode);
 
-                    if (hunt.nobodyNear !== HuntNobodyNear.PAUSEHUNT || npc.observerCount > 0) {
+                    if (hunt.nobodyNear !== HuntNobodyNear.PAUSEHUNT || npc.observerCount > 0 || hunt.type === HuntModeType.PLAYER) {
                         // - hunt npc/obj/loc
                         if (hunt && hunt.type !== HuntModeType.PLAYER) {
                             npc.huntAll();
@@ -930,10 +930,6 @@ class World {
                     state.pointerAdd(ScriptPointer.ProtectedActivePlayer);
                     ScriptRunner.execute(state);
 
-                    // Decrement observers of rendered npcs
-                    for (const npc of player.buildArea.npcs) {
-                        npc.observerCount--;
-                    }
                     this.removePlayer(player);
                 }
             }
@@ -1578,6 +1574,11 @@ class World {
         if (isClientConnected(player)) {
             player.logout();
             player.client.close();
+        }
+
+        // Decrement observers of rendered npcs
+        for (const npc of player.buildArea.npcs) {
+            npc.observerCount--;
         }
 
         this.playerRenderer.removePermanent(player.pid);

--- a/src/engine/World.ts
+++ b/src/engine/World.ts
@@ -1578,7 +1578,7 @@ class World {
 
         // Decrement observers of rendered npcs
         for (const npc of player.buildArea.npcs) {
-            npc.observerCount--;
+            npc.observerCount = Math.max(npc.observerCount - 1, 0);
         }
 
         this.playerRenderer.removePermanent(player.pid);
@@ -1588,11 +1588,6 @@ class World {
         player.cleanup();
 
         player.isActive = false;
-
-        // Decrement observers of rendered npcs
-        for (const npc of player.buildArea.npcs) {
-            npc.observerCount--;
-        }
 
         player.addSessionLog(LoggerEventType.MODERATOR, 'Logged out');
         this.flushPlayer(player);

--- a/src/network/rs225/server/codec/NpcInfoEncoder.ts
+++ b/src/network/rs225/server/codec/NpcInfoEncoder.ts
@@ -104,7 +104,7 @@ export default class NpcInfoEncoder extends MessageEncoder<NpcInfo> {
     private remove(buf: Packet, buildArea: BuildArea, npc: Npc): void {
         buf.pBit(1, 1);
         buf.pBit(2, 3);
-        npc.observerCount--;
+        npc.observerCount = Math.max(npc.observerCount - 1, 0);
         buildArea.npcs.delete(npc);
     }
 


### PR DESCRIPTION
Error in logic was causing some Npcs to try to hunt players even when no one is in the area. This should save a bit of processing power