### PR TITLE
refactor(content): only call ~player_combat_stat on stat change and equipment change

### DIFF
--- a/data/src/scripts/areas/area_combat_training/scripts/combat_training_camp.rs2
+++ b/data/src/scripts/areas/area_combat_training/scripts/combat_training_camp.rs2
@@ -43,7 +43,6 @@ if(%biohazard_progress < ^biohazard_complete) {
 ~open_and_close_double_door2(~check_axis(coord, loc_coord, loc_angle), $side, grate_open);
 
 [oploc1,combat_training_dummy] // Combat training camp dummy
-~player_combat_stat;
 if (%damagestyle = ^style_ranged_accurate | %damagestyle = ^style_ranged_longrange | %damagestyle = ^style_ranged_rapid) {
     mes("You can't use ranged attacks on the dummy.");
     return;

--- a/data/src/scripts/areas/area_varrock/scripts/attack_dummy.rs2
+++ b/data/src/scripts/areas/area_varrock/scripts/attack_dummy.rs2
@@ -1,5 +1,4 @@
 [oploc2,attack_dummy]
-~player_combat_stat;
 if (%damagestyle = ^style_ranged_accurate | %damagestyle = ^style_ranged_longrange | %damagestyle = ^style_ranged_rapid) {
     mes("You can't use ranged attacks on the dummy.");
     return;

--- a/data/src/scripts/quests/quest_chompybird/scripts/chompy_bird.rs2
+++ b/data/src/scripts/quests/quest_chompybird/scripts/chompy_bird.rs2
@@ -163,8 +163,6 @@ if (%action_delay > map_clock) {
     return;
 }
 
-~player_combat_stat; // update combat varps before calculating action_delay and shooting
-
 // set the skill clock depending on the weapon attack rate
 %action_delay = add(map_clock, oc_param($rhand, attackrate));
 

--- a/data/src/scripts/quests/quest_mcannon/scripts/cannon.rs2
+++ b/data/src/scripts/quests/quest_mcannon/scripts/cannon.rs2
@@ -326,8 +326,6 @@ if ($dir = 0) {
 }
 %mcannon_clock = add(%mcannon_clock, 1);
 
-~player_combat_stat;
-
 // check close range
 npc_huntall($close_range, 1, 1);
 while (npc_huntnext = true) {

--- a/data/src/scripts/skill_combat/scripts/player/player_magic.rs2
+++ b/data/src/scripts/skill_combat/scripts/player/player_magic.rs2
@@ -146,7 +146,6 @@ if ($spell = ^crumble_undead & npc_param(undead) = ^false) {
 }
 
 [proc,pvm_spell_cast](dbrow $spell_data)(int)
-~player_combat_stat;
 ~delete_spell_runes($spell_data);
 ~give_spell_xp($spell_data);
 

--- a/data/src/scripts/skill_combat/scripts/player/player_melee.rs2
+++ b/data/src/scripts/skill_combat/scripts/player/player_melee.rs2
@@ -25,8 +25,6 @@ if (npc_stat(hitpoints) = 0) {
     return; // this means the npc is not avail to fight i.e dead
 }
 
-~player_combat_stat; // update combat varps before swinging
-
 // check hit, give combat xp
 def_int $damage = 0;
 if (~player_npc_hit_roll(%damagetype) = true) {

--- a/data/src/scripts/skill_combat/scripts/player/player_ranged.rs2
+++ b/data/src/scripts/skill_combat/scripts/player/player_ranged.rs2
@@ -12,8 +12,6 @@ if (npc_stat(hitpoints) = 0) {
     return;
 }
 
-~player_combat_stat; // update combat varps before calculating action_delay and shooting
-
 // set the skill clock depending on the weapon attack rate
 def_obj $rhand = inv_getobj(worn, ^wearpos_rhand);
 if ($rhand = null) {

--- a/data/src/scripts/skill_combat/scripts/pvp/pvp_magic.rs2
+++ b/data/src/scripts/skill_combat/scripts/pvp/pvp_magic.rs2
@@ -206,8 +206,6 @@ sound_synth($sound, 0, 0);
 [proc,pvp_spell_cast](dbrow $spell_data)(int)
 ~set_pk_vars;
 .if_close;
-~player_combat_stat;
-~.player_combat_stat;
 ~delete_spell_runes($spell_data);
 ~give_spell_xp($spell_data);
 

--- a/data/src/scripts/skill_combat/scripts/pvp/pvp_melee.rs2
+++ b/data/src/scripts/skill_combat/scripts/pvp/pvp_melee.rs2
@@ -15,9 +15,6 @@ if (.stat(hitpoints) = 0) {
 p_opplayer(2);
 ~set_pk_vars;
 
-~player_combat_stat;
-~.player_combat_stat;
-
 def_int $damage = 0;
 // not sure if xp multipler exists for us or not?!
 // https://oldschool.runescape.wiki/w/Combat#PvP_bonus_experience

--- a/data/src/scripts/skill_combat/scripts/pvp/pvp_ranged.rs2
+++ b/data/src/scripts/skill_combat/scripts/pvp/pvp_ranged.rs2
@@ -22,9 +22,6 @@ if ($ammo = null) {
 p_opplayer(2);
 ~set_pk_vars;
 
-~player_combat_stat;
-~.player_combat_stat;
-
 def_int $damage = 0;
 // not sure if xp multipler exists for us or not?!
 // https://oldschool.runescape.wiki/w/Combat#PvP_bonus_experience

--- a/data/src/scripts/tutorial/scripts/skills/tut_player_magic.rs2
+++ b/data/src/scripts/tutorial/scripts/skills/tut_player_magic.rs2
@@ -42,7 +42,6 @@ if (npc_type = tut_chicken & %tutorial_progress < ^tutorial_successful_wind_stri
 
 
 [proc,tut_pvm_spell_cast](dbrow $spell_data)(int)
-~player_combat_stat;
 ~delete_spell_runes($spell_data);
 ~tut_give_spell_xp($spell_data);
 


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/c89fbd60-1794-4d46-a7eb-501b7ec475fd)

Fairly certain they only need to be calculated on stat change and equipment change. I think there were also some osrs bugs related to this at some point with new weaponry?

Should also help with server tick speed :)