### PR TITLE
fix(client): Mobile improvements for controls & canvas reset | unhide controls adjusted to support apple & non-US inputs 

### DIFF
--- a/view/client.ejs
+++ b/view/client.ejs
@@ -77,6 +77,9 @@
     </style>
  
     <script>
+
+        const isMobile = /Mobi|Android|iPhone|iPad|Windows Phone|Mobile/i.test(navigator.userAgent);
+        
         function toggleFullscreen() {
             if (document.fullscreenElement || document.webkitFullscreenElement || document.mozFullScreenElement || document.msFullscreenElement) {
                 if (document.exitFullscreen) {
@@ -175,14 +178,16 @@
 
             document.getElementById('controls').style.display = '';
             document.getElementById('hide-message').style.display = 'none';
-            
+
             localStorage.removeItem('hideControls');
         }
 
         document.addEventListener('keydown', function(e) {
-            if (e.ctrlKey && e.altKey && e.key == 'i') {
-                e.preventDefault();
-                showControls();
+            if ((e.ctrlKey || e.metaKey) && e.altKey) {
+                if (e.code === 'KeyI') {
+                    e.preventDefault();
+                    showControls();
+                }
             }
         })
 
@@ -194,15 +199,18 @@
                 setFiltering(canvas, filtering === 'true');
             }
 
-            let size = parseInt(localStorage.getItem('canvasSize'));
-            if (size) {
-                canvasSize = setCanvasSize(canvas, size);
-                localStorage.setItem('canvasSize', canvasSize);
-            }
-
-            let controls = localStorage.getItem('hideControls');
-            if (controls === 'true') {
-                hideControls();
+            if (!isMobile)
+            {
+                let size = parseInt(localStorage.getItem('canvasSize'));
+                if (size) {
+                    canvasSize = setCanvasSize(canvas, size);
+                    localStorage.setItem('canvasSize', canvasSize);
+                }
+            
+                let controls = localStorage.getItem('hideControls');
+                if (controls === 'true') {
+                    hideControls();
+                }
             }
         }
     </script>
@@ -225,7 +233,7 @@
         </div>
         <div id="hide-message" style="display: none;">
             <p class="green blink">Controls have been hidden press ctrl+alt+i to unhide.</p>
-            <p class="green" id="count-down"></span>
+            <p class="green" id="count-down"></p>
         </div>
     </center>
 


### PR DESCRIPTION
- Mobile device to reset canvas to default (1x) and show hidden controls on reload/refresh. Desktop remains as is, respecting all localStorage settings, including unhide controls & canvas size.
 - When accessing live server or local client direct via mobile device and controls are hidden, there is no easy way to unhide controls without manually clearing localStorage. Canvas can be hard to change if raised > than 1x when embedded vs direct - a refresh allows reset to 1x - mobile only.

- Made 'ctrl+alt+i' ' / 'unhide controls' key-combo more universal for apple keyboards, as well as non-English keyboards. 
  - Example: acute i was registering on a user debug and not sending to client.
  - fix - look for e.code and not e.key, avoids clashing with non-US keyboards and also covers if caps lock is on without needing toLowerCase.
  - fix - listen for command+option+i on mac
 

Image to show a comparison of user having issue vs my working client debug -- their debug shows acute i being registered. 
![keystroke debug - acute i failure vs English i success between 2 users](https://github.com/user-attachments/assets/6887b122-6733-4f09-b4a4-d3d1bc64749c)


Showing mobile interaction - canvas and controls are default on reload, other settings respected.
https://github.com/user-attachments/assets/91b7afad-d306-41bd-80fa-ed0c134f10f6

Showing desktop interaction - all localSettings are respected
https://github.com/user-attachments/assets/d26861a4-4133-433e-a56f-85d6c5502566


