### PR TITLE
fix(content): prevent npcs from tick healing non-recoil damage

### DIFF
--- a/data/src/scripts/quests/quest_chompybird/scripts/chompy_bird.rs2
+++ b/data/src/scripts/quests/quest_chompybird/scripts/chompy_bird.rs2
@@ -175,7 +175,8 @@ if (%damagestyle = ^style_ranged_rapid) {
 // check hit, give combat xp
 def_int $damage = 0;
 if (~player_npc_hit_roll(%damagetype) = true) {
-    $damage = randominc(min(%com_maxhit, npc_param(max_dealt)));
+    def_int $maxhit = %com_maxhit;
+    $damage = randominc(min($maxhit, npc_param(max_dealt)));
     def_int $damage_capped = min($damage, npc_stat(hitpoints));
     ~give_combat_experience(%damagestyle, $damage_capped, %npc_combat_xp_multiplier);
     npc_heropoints($damage_capped);

--- a/data/src/scripts/quests/quest_chompybird/scripts/chompy_bird.rs2
+++ b/data/src/scripts/quests/quest_chompybird/scripts/chompy_bird.rs2
@@ -176,19 +176,20 @@ if (%damagestyle = ^style_ranged_rapid) {
 def_int $damage = 0;
 if (~player_npc_hit_roll(%damagetype) = true) {
     $damage = randominc(min(%com_maxhit, npc_param(max_dealt)));
-    ~give_combat_experience(%damagestyle, $damage, %npc_combat_xp_multiplier);
+    def_int $damage_capped = min($damage, npc_stat(hitpoints));
+    ~give_combat_experience(%damagestyle, $damage_capped, %npc_combat_xp_multiplier);
+    npc_heropoints($damage_capped);
 }
 
 def_int $delay = add(~player_use_ogre_bow($ammo), 30); // osrs it seems to be delayed an extra tick
 anim(%com_attackanim, 0);
 sound_synth(%com_attacksound, 0, 0);
 // Chompies don't fight back
-npc_queue(2, $damage, calc($delay / 30));
+npc_queue(2, $damage, calc($delay / 30)); // ai_queue2 takes uncapped damage (avoids npcs from tick healing)
 if (npc_param(defend_sound) ! null) {
     sound_synth(npc_param(defend_sound), 0, sub($delay, 30)); // delay 1 client tick for the hit queue
 }
 
-npc_heropoints($damage);
 p_opnpc(5);
 if (random(5) ! 0) {
     world_delay(calc($delay / 30 - 2));

--- a/data/src/scripts/quests/quest_chompybird/scripts/chompy_bird.rs2
+++ b/data/src/scripts/quests/quest_chompybird/scripts/chompy_bird.rs2
@@ -176,7 +176,6 @@ if (%damagestyle = ^style_ranged_rapid) {
 def_int $damage = 0;
 if (~player_npc_hit_roll(%damagetype) = true) {
     $damage = randominc(min(%com_maxhit, npc_param(max_dealt)));
-    $damage = min($damage, npc_stat(hitpoints));
     ~give_combat_experience(%damagestyle, $damage, %npc_combat_xp_multiplier);
 }
 

--- a/data/src/scripts/quests/quest_mcannon/scripts/cannon.rs2
+++ b/data/src/scripts/quests/quest_mcannon/scripts/cannon.rs2
@@ -370,7 +370,6 @@ sound_synth(mcannon_fire, 0, 0);
 def_int $damage = 0;
 if (~player_npc_hit_roll(%damagetype) = true) {
     $damage = randominc(min(30, npc_param(max_dealt)));
-    $damage = min($damage, npc_stat(hitpoints));
     stat_advance(ranged, multiply(20, $damage));
 }
 

--- a/data/src/scripts/quests/quest_mcannon/scripts/cannon.rs2
+++ b/data/src/scripts/quests/quest_mcannon/scripts/cannon.rs2
@@ -370,12 +370,13 @@ sound_synth(mcannon_fire, 0, 0);
 def_int $damage = 0;
 if (~player_npc_hit_roll(%damagetype) = true) {
     $damage = randominc(min(30, npc_param(max_dealt)));
-    stat_advance(ranged, multiply(20, $damage));
+    def_int $damage_capped = min($damage, npc_stat(hitpoints));
+    ~give_combat_experience(^style_ranged_accurate, $damage_capped, %npc_combat_xp_multiplier);
+    npc_heropoints($damage_capped);
 }
 
-npc_heropoints($damage);
 ~npc_retaliate(divide($duration, 30));
-npc_queue(2, $damage, divide($duration, 30));
+npc_queue(2, $damage, divide($duration, 30)); // ai_queue2 takes uncapped damage (avoids npcs from tick healing)
 
 if (npc_type = king_black_dragon) {
     @kbd_destroy_cannon;

--- a/data/src/scripts/skill_combat/scripts/npc/npc_combat.rs2
+++ b/data/src/scripts/skill_combat/scripts/npc/npc_combat.rs2
@@ -319,6 +319,7 @@ if (inv_getobj(worn, ^wearpos_ring) = ring_of_recoil & npc_finduid(%aggressive_n
     // https://oldschool.runescape.wiki/w/Update:Clue_Scroll_Step_Counter
     // - "Recoil damage will now always target the entity that caused the initial damage, rather than the most recent entity to deal damage."
     def_int $recoil_damage = add(scale(10, 100, $damage), 1);
+    $recoil_damage = min($recoil_damage, npc_stat(hitpoints));
     npc_queue(2, $recoil_damage, 0);
     ~ring_of_recoil_lose_charge($recoil_damage);
 }

--- a/data/src/scripts/skill_combat/scripts/player/player_magic.rs2
+++ b/data/src/scripts/skill_combat/scripts/player/player_magic.rs2
@@ -186,7 +186,6 @@ return($duration);
 sound_synth(db_getfield($spell_data, magic_spell_table:sound_success, 0), 0, 0);
 // roll 0-maxhit
 def_int $damage = randominc(min($maxhit, npc_param(max_dealt)));
-$damage = min($damage, npc_stat(hitpoints));
 if(npc_type = salarin_the_twisted) {
     def_int $spell = db_getfield($spell_data, magic_spell_table:spell, 0);
     // strike spells are the only way to damage salarin the twisted, the damage is fixed 9-12

--- a/data/src/scripts/skill_combat/scripts/player/player_magic.rs2
+++ b/data/src/scripts/skill_combat/scripts/player/player_magic.rs2
@@ -213,12 +213,12 @@ if ($maxhit ! null) {
     if (npc_param(defend_sound) ! null) {
         sound_synth(npc_param(defend_sound), 0, $duration); // delay 1 client tick for the hit queue
     }
-    ~give_combat_experience(%damagestyle, $damage, %npc_combat_xp_multiplier);
+    def_int $damage_capped = min($damage, npc_stat(hitpoints));
+    ~give_combat_experience(%damagestyle, $damage_capped, %npc_combat_xp_multiplier);
+    npc_heropoints($damage_capped);
 }
 // spell visual
 spotanim_npc(db_getfield($spell_data, magic_spell_table:spotanim_target, 0), $duration);
-// npc auto retal
-npc_heropoints($damage);
 
 
 [proc,pvm_spell_fail](dbrow $spell_data, int $duration)

--- a/data/src/scripts/skill_combat/scripts/player/player_melee.rs2
+++ b/data/src/scripts/skill_combat/scripts/player/player_melee.rs2
@@ -30,16 +30,16 @@ if (npc_stat(hitpoints) = 0) {
 // check hit, give combat xp
 def_int $damage = 0;
 if (~player_npc_hit_roll(%damagetype) = true) {
+    def_int $maxhit = %com_maxhit;
     if (npc_type = count_draynor & inv_total(inv, garlic) > 0) {
-        %com_maxhit = add(%com_maxhit, 1);
+        $maxhit = add($maxhit, 1);
     }
     if (npc_param(demonbane_vulnerable) = true & inv_total(worn, silverlight) > 0) {
-        %com_maxhit = divide(multiply(%com_maxhit, 160), 100);
+        $maxhit = divide(multiply($maxhit, 160), 100);
     }
-    $damage = randominc(min(%com_maxhit, npc_param(max_dealt)));
-    def_int $damage_capped = min($damage, npc_stat(hitpoints));
-    ~give_combat_experience(%damagestyle, $damage_capped, %npc_combat_xp_multiplier);
-    npc_heropoints($damage_capped);
+    $damage = randominc(min($maxhit, npc_param(max_dealt)));
+    $damage = min($damage, npc_stat(hitpoints));
+    ~give_combat_experience(%damagestyle, $damage, %npc_combat_xp_multiplier);
 }
 
 def_obj $weapon = inv_getobj(worn, ^wearpos_rhand);

--- a/data/src/scripts/skill_combat/scripts/player/player_melee.rs2
+++ b/data/src/scripts/skill_combat/scripts/player/player_melee.rs2
@@ -37,7 +37,9 @@ if (~player_npc_hit_roll(%damagetype) = true) {
         %com_maxhit = divide(multiply(%com_maxhit, 160), 100);
     }
     $damage = randominc(min(%com_maxhit, npc_param(max_dealt)));
-    ~give_combat_experience(%damagestyle, $damage, %npc_combat_xp_multiplier);
+    def_int $damage_capped = min($damage, npc_stat(hitpoints));
+    ~give_combat_experience(%damagestyle, $damage_capped, %npc_combat_xp_multiplier);
+    npc_heropoints($damage_capped);
 }
 
 def_obj $weapon = inv_getobj(worn, ^wearpos_rhand);
@@ -58,7 +60,6 @@ npc_anim(npc_param(defend_anim), 20);
 if (npc_param(defend_sound) ! null) {
     sound_synth(npc_param(defend_sound), 0, 20); // delay npc this tick
 }
-npc_heropoints($damage);
 // set the skill clock depending on the weapon attack rate
 if ($weapon = null) {
     %action_delay = add(map_clock, 4);

--- a/data/src/scripts/skill_combat/scripts/player/player_melee.rs2
+++ b/data/src/scripts/skill_combat/scripts/player/player_melee.rs2
@@ -37,7 +37,6 @@ if (~player_npc_hit_roll(%damagetype) = true) {
         %com_maxhit = divide(multiply(%com_maxhit, 160), 100);
     }
     $damage = randominc(min(%com_maxhit, npc_param(max_dealt)));
-    $damage = min($damage, npc_stat(hitpoints));
     ~give_combat_experience(%damagestyle, $damage, %npc_combat_xp_multiplier);
 }
 

--- a/data/src/scripts/skill_combat/scripts/player/player_ranged.rs2
+++ b/data/src/scripts/skill_combat/scripts/player/player_ranged.rs2
@@ -39,7 +39,9 @@ if (~player_npc_hit_roll(%damagetype) = true) {
         %com_maxhit = add(%com_maxhit, 1);
     }
     $damage = randominc(min(%com_maxhit, npc_param(max_dealt)));
-    ~give_combat_experience(%damagestyle, $damage, %npc_combat_xp_multiplier);
+    def_int $damage_capped = min($damage, npc_stat(hitpoints));
+    ~give_combat_experience(%damagestyle, $damage_capped, %npc_combat_xp_multiplier);
+    npc_heropoints($damage_capped);
 }
 
 def_int $poison_severity = oc_param($ammo, poison_severity);
@@ -59,7 +61,6 @@ if (npc_param(defend_sound) ! null) {
     sound_synth(npc_param(defend_sound), 0, sub($delay, 30)); // delay 1 client tick for the hit queue
 }
 
-npc_heropoints($damage);
 p_opnpc(2);
 
 if ($ammo = holy_water) {

--- a/data/src/scripts/skill_combat/scripts/player/player_ranged.rs2
+++ b/data/src/scripts/skill_combat/scripts/player/player_ranged.rs2
@@ -35,10 +35,11 @@ if ($ammo = null) {
 // check hit, give combat xp
 def_int $damage = 0;
 if (~player_npc_hit_roll(%damagetype) = true) {
+    def_int $maxhit = %com_maxhit;
     if (npc_type = count_draynor & inv_total(inv, garlic) > 0) {
-        %com_maxhit = add(%com_maxhit, 1);
+        $maxhit = add($maxhit, 1);
     }
-    $damage = randominc(min(%com_maxhit, npc_param(max_dealt)));
+    $damage = randominc(min($maxhit, npc_param(max_dealt)));
     def_int $damage_capped = min($damage, npc_stat(hitpoints));
     ~give_combat_experience(%damagestyle, $damage_capped, %npc_combat_xp_multiplier);
     npc_heropoints($damage_capped);

--- a/data/src/scripts/skill_combat/scripts/player/player_ranged.rs2
+++ b/data/src/scripts/skill_combat/scripts/player/player_ranged.rs2
@@ -39,7 +39,6 @@ if (~player_npc_hit_roll(%damagetype) = true) {
         %com_maxhit = add(%com_maxhit, 1);
     }
     $damage = randominc(min(%com_maxhit, npc_param(max_dealt)));
-    $damage = min($damage, npc_stat(hitpoints));
     ~give_combat_experience(%damagestyle, $damage, %npc_combat_xp_multiplier);
 }
 

--- a/data/src/scripts/skill_combat/scripts/pvp/pvp_combat.rs2
+++ b/data/src/scripts/skill_combat/scripts/pvp/pvp_combat.rs2
@@ -177,6 +177,7 @@ if (inv_getobj(worn, ^wearpos_ring) = ring_of_recoil & .finduid(%pk_predator1) =
     // - "Recoil damage will now always target the entity that caused the initial damage, rather than the most recent entity to deal damage."
     // Having it here instead of the opplayer2 trigger will allow this bug to occur
     def_int $recoil_damage = add(scale(10, 100, $damage), 1);
+    $recoil_damage = min($recoil_damage, .stat(hitpoints));
     .queue(recoil_damage, 0, $recoil_damage);
     ~ring_of_recoil_lose_charge($recoil_damage);
 }

--- a/data/src/scripts/skill_combat/scripts/pvp/pvp_melee.rs2
+++ b/data/src/scripts/skill_combat/scripts/pvp/pvp_melee.rs2
@@ -28,6 +28,7 @@ if (~pvp_hit_roll(%damagetype) = true) {
     }
     $damage = min(randominc($maxhit), .stat(hitpoints)); // tick eating existed! https://oldschool.runescape.wiki/w/Update:The_Wintertodt
     ~give_combat_experience_pvp(%damagestyle, $damage, ~pvp_xp_multiplier(~.player_combat_level));
+    both_heropoints($damage);
 }
 
 anim(%com_attackanim, 0);
@@ -36,8 +37,6 @@ sound_synth(%com_attacksound, 0, 0);
 
 .queue(pvp_retaliate, 0, uid);
 ~.pvp_damage(0, $damage);
-
-both_heropoints($damage);
 
 .anim(.%com_defendanim, 20);
 // .sound_synth(.%com_defendsound, 0, 20);

--- a/data/src/scripts/skill_combat/scripts/pvp/pvp_ranged.rs2
+++ b/data/src/scripts/skill_combat/scripts/pvp/pvp_ranged.rs2
@@ -35,6 +35,7 @@ if (~pvp_hit_roll(%damagetype) = true) {
     }
     $damage = min(randominc($maxhit), .stat(hitpoints)); // tick eating existed! https://oldschool.runescape.wiki/w/Update:The_Wintertodt
     ~give_combat_experience_pvp(%damagestyle, $damage, ~pvp_xp_multiplier(~.player_combat_level));
+    both_heropoints($damage);
 }
 def_int $delay = ~pvp_ranged_use_weapon($rhand, $ammo);
 anim(%com_attackanim, 0);
@@ -43,8 +44,6 @@ sound_synth(%com_attacksound, 0, 0);
 
 .queue(pvp_retaliate, calc($delay / 30), uid);
 ~.pvp_damage(calc($delay / 30), $damage);
-
-both_heropoints($damage);
 
 .anim(.%com_defendanim, $delay);
 // .sound_synth(.%com_defendsound, 0, 20);


### PR DESCRIPTION
- Npc's can no longer tick heal incoming damage, with the exception of ring of recoil damage. However, xp gained and kill credit should still use the capped damage.

From [Video](https://gyazo.com/529a4cbcb261e758c9a4b9764c8a68dc):
![image](https://github.com/user-attachments/assets/5b336b87-71e8-49c3-89ed-6459bc32347f)
- Kill credit will now only update on successful hit

- Also fixes #1403




