### PR TITLE
feat(engine): Report review migrations

### DIFF
--- a/prisma/multiworld/migrations/20250304021857_add_reviewed_column_to_report/migration.sql
+++ b/prisma/multiworld/migrations/20250304021857_add_reviewed_column_to_report/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE `report` ADD COLUMN `reviewed` BOOLEAN NOT NULL DEFAULT false;

--- a/prisma/multiworld/schema.prisma
+++ b/prisma/multiworld/schema.prisma
@@ -175,6 +175,8 @@ model report {
 
     offender String
     reason   Int
+
+    reviewed Boolean @default(false)
 }
 
 model input_report {

--- a/prisma/singleworld/migrations/20250304021849_add_reviewed_column_to_report/migration.sql
+++ b/prisma/singleworld/migrations/20250304021849_add_reviewed_column_to_report/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE `report` ADD COLUMN `reviewed` BOOLEAN NOT NULL DEFAULT false;

--- a/prisma/singleworld/schema.prisma
+++ b/prisma/singleworld/schema.prisma
@@ -175,6 +175,8 @@ model report {
 
     offender String
     reason   Int
+
+    reviewed Boolean @default(false)
 }
 
 model input_report {

--- a/src/db/types.ts
+++ b/src/db/types.ts
@@ -151,6 +151,7 @@ export type report = {
     coord: number;
     offender: string;
     reason: number;
+    reviewed: Generated<number>;
 };
 export type session = {
     uuid: string;


### PR DESCRIPTION
Adds a new `reviewed` column to the `report` table to track whether a report has been reviewed.

## Changes
- Added `reviewed BOOLEAN NOT NULL DEFAULT FALSE` to the `report` model in Prisma schema.
- Generated and included the necessary Prisma migrations.