### PR TITLE
fix(content): A particular dead tree would display "Nothing interesting happens."

### DIFF
--- a/data/src/scripts/_unpack/all.loc
+++ b/data/src/scripts/_unpack/all.loc
@@ -359,6 +359,7 @@ model=model_loc_154
 width=2
 length=2
 op1=Chop down
+param=next_loc_stage,loc_1348
 
 [loc_157]
 name=Bookcase

--- a/data/src/scripts/skill_woodcutting/scripts/old_woodcut.rs2
+++ b/data/src/scripts/skill_woodcutting/scripts/old_woodcut.rs2
@@ -20,7 +20,8 @@ if ($axe = null) {
 }
 if (%action_delay = add(map_clock, 2)) {
     anim(struct_param(oc_param($axe, woodcutting_struct), skill_anim), 0);
-    sound_synth(woodchop, 0, 0); // no idea if this should exist?
+    sound_synth(woodchop, 0, 0);
+    mes("You swing your axe at the tree."); // No idea if this should exist?
 }
 
 if (%action_delay = map_clock) {

--- a/data/src/scripts/skill_woodcutting/scripts/old_woodcut.rs2
+++ b/data/src/scripts/skill_woodcutting/scripts/old_woodcut.rs2
@@ -1,0 +1,48 @@
+// this tree loc has no op3...
+// so i assume it works the same as normal trees, except no "You swing your axe at the tree."
+// So the theory is that this is old woodcutting - so no macro event check?
+[oploc1,loc_154]
+if (inv_freespace(inv) < 1) {
+    anim(null, 0);
+    // osrs specifies the log name, but old videos do not.
+    // https://youtu.be/str4rRd9mt8?t=152
+    mes("Your inventory is too full to hold any more logs.");
+    return;
+}
+if (%action_delay < map_clock) {
+    %action_delay = calc(map_clock + 3);
+    p_oploc(1);
+    return;
+}
+def_obj $axe = ~woodcutting_axe_checker;
+if ($axe = null) {
+    return;
+}
+if (%action_delay = add(map_clock, 2)) {
+    anim(struct_param(oc_param($axe, woodcutting_struct), skill_anim), 0);
+    sound_synth(woodchop, 0, 0); // no idea if this should exist?
+}
+
+if (%action_delay = map_clock) {
+    if (stat_random(stat(woodcutting), ~loc_154_chance($axe)) = true) {
+        mes("You get some logs.");
+        stat_advance(woodcutting, 250);
+        inv_add(inv, logs, 1);
+        loc_change(loc_param(next_loc_stage), ~scale_by_playercount(~random_range(120, 198)));
+        anim(null, 0);
+        return;
+    }
+}
+p_oploc(1);
+
+[proc,loc_154_chance](obj $axe)(int, int)
+switch_obj($axe) {
+    case bronze_axe : return(64, 200);
+    case iron_axe : return(96, 300);
+    case steel_axe : return(128, 400);
+    case black_axe : return(144, 450);
+    case mithril_axe : return(160, 500);
+    case adamant_axe : return(192, 600);
+    case rune_axe : return(224, 700);
+}
+return(64, 200);


### PR DESCRIPTION
We have no idea how this tree is supposed to work since it has no op3. It was removed in rev 270 (Nov 2004)