### PR TITLE
fix(content): Typo in magic message

### DIFF
--- a/data/src/scripts/skill_combat/scripts/player/player_magic.rs2
+++ b/data/src/scripts/skill_combat/scripts/player/player_magic.rs2
@@ -107,7 +107,7 @@ if (db_getfield($spell_data, magic_spell_table:freeze_time, 0) > 0) {
     if (calc(%npc_stunned + 5) > map_clock) {
         // osrs wiki trivia says that snare didnt have this? No proof though
         // ive found proof of bind and entangle having this in 2006: https://imgur.com/a/jBb1awE
-        mes("Your target is currently immume to that spell.");
+        mes("Your target is currently immune to that spell.");
         return(false);
     }
 }

--- a/data/src/scripts/skill_combat/scripts/pvp/pvp_magic.rs2
+++ b/data/src/scripts/skill_combat/scripts/pvp/pvp_magic.rs2
@@ -92,7 +92,7 @@ if (db_getfield($spell_data, magic_spell_table:freeze_time, 0) > 0) {
     if (calc(.%frozen + 5) > map_clock) {
         // osrs wiki trivia says that snare didnt have this? No proof though
         // ive found proof of bind and entangle having this in 2006: https://imgur.com/a/jBb1awE
-        mes("Your target is currently immume to that spell.");
+        mes("Your target is currently immune to that spell.");
         return(false);
     }
 }


### PR DESCRIPTION
Sources in comments don't have the typo.