### PR TITLE
fix(engine): Npc kill credit is now determined more appropriately and will persist between login sessions

### DIFF
--- a/src/engine/entity/HeroPoints.ts
+++ b/src/engine/entity/HeroPoints.ts
@@ -1,7 +1,9 @@
+import { quicksort } from '#/util/QuickSort.js';
+
 type Hero = {
     uid: number;
     points: number;
-}
+};
 
 export default class HeroPoints extends Array<Hero> {
     constructor(length: number) {
@@ -26,13 +28,23 @@ export default class HeroPoints extends Array<Hero> {
         if (emptyIndex !== -1) {
             this[emptyIndex] = { uid, points };
         }
+
+        console.log(this);
     }
 
     findHero(): number {
         // quicksort heroes by points
-        this.sort((a, b) => {
+        quicksort(0, this.length, this, (a: Hero, b: Hero) => {
+            if (!a) {
+                a = { uid: 0, points: 0 };
+            }
+            if (!b) {
+                b = { uid: 0, points: 0 };
+            }
             return b.points - a.points;
         });
+
+        // console.log(this);
         return this[0].uid;
     }
 }

--- a/src/engine/entity/HeroPoints.ts
+++ b/src/engine/entity/HeroPoints.ts
@@ -1,7 +1,7 @@
 import { quicksort } from '#/util/QuickSort.js';
 
 type Hero = {
-    uid: number;
+    hash64: bigint;
     points: number;
 };
 
@@ -12,25 +12,25 @@ export default class HeroPoints extends Array<Hero> {
     }
 
     clear(): void {
-        this.fill({ uid: -1, points: 0 });
+        this.fill({ hash64: -1n, points: 0 });
     }
 
-    addHero(uid: number, points: number): void {
+    addHero(hash64: bigint, points: number): void {
         // Check if hero already exists, then add points
-        const index = this.findIndex(hero => hero && hero.uid === uid);
+        const index = this.findIndex(hero => hero && hero.hash64 === hash64);
         if (index !== -1) {
             this[index].points += points;
             return;
         }
 
-        // Otherwise, add a new uid
-        const emptyIndex = this.findIndex(hero => hero && hero.uid === -1);
+        // Otherwise, add a new hash64
+        const emptyIndex = this.findIndex(hero => hero && hero.hash64 === -1n);
         if (emptyIndex !== -1) {
-            this[emptyIndex] = { uid, points: 1 };
+            this[emptyIndex] = { hash64, points: 1 };
         }
     }
 
-    findHero(): number {
+    findHero(): bigint {
         // We clone the array because it should not be permanently sorted
         const clone = [...this];
 
@@ -39,6 +39,6 @@ export default class HeroPoints extends Array<Hero> {
             return b.points - a.points;
         });
 
-        return clone[0].uid;
+        return clone[0].hash64;
     }
 }

--- a/src/engine/entity/HeroPoints.ts
+++ b/src/engine/entity/HeroPoints.ts
@@ -16,6 +16,10 @@ export default class HeroPoints extends Array<Hero> {
     }
 
     addHero(hash64: bigint, points: number): void {
+        // Do nothing if no points added
+        if (points < 1) {
+            return;
+        }
         // Check if hero already exists, then add points
         const index = this.findIndex(hero => hero && hero.hash64 === hash64);
         if (index !== -1) {

--- a/src/engine/entity/HeroPoints.ts
+++ b/src/engine/entity/HeroPoints.ts
@@ -30,7 +30,7 @@ export default class HeroPoints extends Array<Hero> {
         // Otherwise, add a new hash64
         const emptyIndex = this.findIndex(hero => hero && hero.hash64 === -1n);
         if (emptyIndex !== -1) {
-            this[emptyIndex] = { hash64, points: 1 };
+            this[emptyIndex] = { hash64, points };
         }
     }
 

--- a/src/engine/entity/HeroPoints.ts
+++ b/src/engine/entity/HeroPoints.ts
@@ -23,28 +23,19 @@ export default class HeroPoints extends Array<Hero> {
             return;
         }
 
-        // otherwise, add a new uid. if all 16 spaces are taken do we replace the lowest?
+        // otherwise, add a new uid
         const emptyIndex = this.findIndex(hero => hero && hero.uid === -1);
         if (emptyIndex !== -1) {
             this[emptyIndex] = { uid, points };
         }
-
-        console.log(this);
     }
 
     findHero(): number {
         // quicksort heroes by points
-        quicksort(0, this.length, this, (a: Hero, b: Hero) => {
-            if (!a) {
-                a = { uid: 0, points: 0 };
-            }
-            if (!b) {
-                b = { uid: 0, points: 0 };
-            }
+        quicksort(0, this.length - 1, this, (a: Hero, b: Hero) => {
             return b.points - a.points;
         });
 
-        // console.log(this);
         return this[0].uid;
     }
 }

--- a/src/engine/entity/HeroPoints.ts
+++ b/src/engine/entity/HeroPoints.ts
@@ -16,26 +16,29 @@ export default class HeroPoints extends Array<Hero> {
     }
 
     addHero(uid: number, points: number): void {
-        // check if hero already exists, then add points
+        // Check if hero already exists, then add points
         const index = this.findIndex(hero => hero && hero.uid === uid);
         if (index !== -1) {
             this[index].points += points;
             return;
         }
 
-        // otherwise, add a new uid
+        // Otherwise, add a new uid
         const emptyIndex = this.findIndex(hero => hero && hero.uid === -1);
         if (emptyIndex !== -1) {
-            this[emptyIndex] = { uid, points };
+            this[emptyIndex] = { uid, points: 1 };
         }
     }
 
     findHero(): number {
-        // quicksort heroes by points
-        quicksort(0, this.length - 1, this, (a: Hero, b: Hero) => {
+        // We clone the array because it should not be permanently sorted
+        const clone = [...this];
+
+        // Quicksort heroes by points
+        quicksort(0, this.length - 1, clone, (a: Hero, b: Hero) => {
             return b.points - a.points;
         });
 
-        return this[0].uid;
+        return clone[0].uid;
     }
 }

--- a/src/engine/script/handlers/NpcOps.ts
+++ b/src/engine/script/handlers/NpcOps.ts
@@ -116,13 +116,13 @@ const NpcOps: CommandHandlers = {
     },
 
     [ScriptOpcode.NPC_FINDHERO]: checkedHandler(ActiveNpc, state => {
-        const uid = state.activeNpc.heroPoints.findHero();
-        if (uid === -1) {
+        const hash64 = state.activeNpc.heroPoints.findHero();
+        if (hash64 === -1n) {
             state.pushInt(0);
             return;
         }
 
-        const player = World.getPlayerByUid(uid);
+        const player = World.getPlayerByHash64(hash64);
         if (!player) {
             state.pushInt(0);
             return;
@@ -401,7 +401,7 @@ const NpcOps: CommandHandlers = {
 
     // https://x.com/JagexAsh/status/1704492467226091853
     [ScriptOpcode.NPC_HEROPOINTS]: checkedHandler([ScriptPointer.ActivePlayer, ...ActiveNpc], state => {
-        state.activeNpc.heroPoints.addHero(state.activePlayer.uid, check(state.popInt(), NumberNotNull));
+        state.activeNpc.heroPoints.addHero(state.activePlayer.hash64, check(state.popInt(), NumberNotNull));
     }),
 
     // https://x.com/JagexAsh/status/1780932943038345562

--- a/src/engine/script/handlers/PlayerOps.ts
+++ b/src/engine/script/handlers/PlayerOps.ts
@@ -1032,13 +1032,13 @@ const PlayerOps: CommandHandlers = {
 
     // https://x.com/JagexAsh/status/1799020087086903511
     [ScriptOpcode.FINDHERO]: checkedHandler(ActivePlayer, state => {
-        const uid = state.activePlayer.heroPoints.findHero();
-        if (uid === -1) {
+        const hash64 = state.activePlayer.heroPoints.findHero();
+        if (hash64 === -1n) {
             state.pushInt(0);
             return;
         }
 
-        const player = World.getPlayerByUid(uid);
+        const player = World.getPlayerByHash64(hash64);
         if (!player) {
             state.pushInt(0);
             return;
@@ -1060,7 +1060,7 @@ const PlayerOps: CommandHandlers = {
             throw new Error('player is null');
         }
 
-        toPlayer.heroPoints.addHero(fromPlayer.uid, damage);
+        toPlayer.heroPoints.addHero(fromPlayer.hash64, damage);
     }),
 
     // https://x.com/JagexAsh/status/1806246992797921391

--- a/src/util/QuickSort.ts
+++ b/src/util/QuickSort.ts
@@ -1,0 +1,36 @@
+// This is a quicksort implementation that matches behavior to the one used by OSRS and RS3 :)
+// Original credit Cook: https://runescape.wiki/w/MediaWiki:Gadget-perkcalc-core.js#L-1020
+// Translation into JS by Keyboard: https://github.com/qwertypedia/qwertypedia.github.io/blob/dcea5dad6043bbbecbad60f7edda6e35fc5b2c63/killcreditcalc.js#L53
+
+interface CompareInterface {
+    (a: any, b: any): number;
+}
+
+export function quicksort<T>(low: number, high: number, arr: Array<T>, compare: CompareInterface) {
+    const pivot_index = ~~((low + high) / 2); // floor division
+    const pivot_value = arr[pivot_index];
+    arr[pivot_index] = arr[high];
+    arr[high] = pivot_value;
+    let counter = low;
+    let loop_index = low;
+
+    while (loop_index < high) {
+        if (compare(arr[loop_index], pivot_value) < (loop_index & 1)) {
+            const tmp = arr[loop_index];
+            arr[loop_index] = arr[counter];
+            arr[counter] = tmp;
+            counter += 1;
+        }
+        loop_index += 1;
+    }
+
+    arr[high] = arr[counter];
+    arr[counter] = pivot_value;
+
+    if (low < counter - 1) {
+        quicksort(low, counter - 1, arr, compare);
+    }
+    if (counter + 1 < high) {
+        quicksort(counter + 1, high, arr, compare);
+    }
+}


### PR DESCRIPTION
Three big things accomplished in this PR:
- Kill credit now uses a quicksort that matches RuneScape's implementation. This is minor but the specific sort method affects tie breaker calculations
- Heropoints now uses a player's unique hash64, rather than a UID which is assigned on login. This allows heropoints to persist between login sessions
- Heropoint additions of 0 are denied from taking up a slot in the size-16 Array. In OSRS they introduced custom functionality to maintain a slot with 0 heropoints after Ironman mode came out, but we don't need to worry about that