### PR TITLE
feat(content): witch in draynor manor uses magic now to match old screenshot

### DIFF
--- a/data/src/scripts/_unpack/all.npc
+++ b/data/src/scripts/_unpack/all.npc
@@ -4434,7 +4434,12 @@ model4=model_353_idk
 model5=model_428_idk
 model6=model_361_obj_wear
 model7=model_377_obj_wear
-// TODO respawnrate
+// wanderrange, maxrange, attackrange, and respawnrate are taken from dark_wizard_earth
+wanderrange=3
+maxrange=5
+attackrange=5
+huntrange=5
+respawnrate=100
 hitpoints=10
 attack=25
 strength=25

--- a/data/src/scripts/areas/area_draynor/scripts/witch.rs2
+++ b/data/src/scripts/areas/area_draynor/scripts/witch.rs2
@@ -1,0 +1,19 @@
+// https://i.imgur.com/ZSyCzkS.png
+// https://archive.org/details/PCPowerplay-101-2004-07/page/n13/mode/2up?q=runescape
+
+[ai_queue1,witch_draynor] ~npc_default_retaliate_ap;
+[ai_opplayer2,witch_draynor] npc_setmode(applayer2);
+[ai_applayer2,witch_draynor]
+if (%npc_action_delay > map_clock) {
+    npc_setmode(applayer2);
+    return;
+}
+if (~npc_can_attack_player = false) {
+    npc_setmode(null);
+    return;
+}
+if (stat_base(strength) <= stat(strength) & random(2) = 0) { // guessed from dark wizards
+    ~npc_cast_spell(^weaken, 4);
+} else {
+    ~npc_cast_spell(^earth_strike, 4);
+}


### PR DESCRIPTION
From [archived magazine](https://archive.org/details/PCPowerplay-101-2004-07/page/n13/mode/2up?q=runescape):

![image](https://github.com/user-attachments/assets/01ea0345-1a6f-4243-91bd-7909fa48d9c4)


The witch has the same combat level as dark wizards and the screenshot shows she uses weaken, so I assume she's very similar to dark wizards. 

In rsc and from [runehq](https://web.archive.org/web/20040813232041/http://runehq.com/viewMonster.php?id=34) she drops nothing. 

One potential todo though is that runehq says she can spawn in the middle of the wilderness 👀 