### PR TITLE
fix(logging): log milestone total levels even if gaining multiple lvls

### DIFF
--- a/src/engine/entity/Player.ts
+++ b/src/engine/entity/Player.ts
@@ -1724,11 +1724,17 @@ export default class Player extends PathingEntity {
                     freeTotal += this.baseLevels[stat];
                 }
             }
+            
+            const previousTotal = total - (this.baseLevels[stat] - before);
+            const milestones = [250, 500, 750, 1000, 1250, 1500, 1750];
+            for (const milestone of milestones) {
+                if (previousTotal < milestone && total >= milestone) {
+                    this.addSessionLog(LoggerEventType.ADVENTURE, `Reached total level ${milestone}`);
+                }
+            }
             if (total === 1881) {
                 this.addSessionLog(LoggerEventType.ADVENTURE, 'Reached total level 1881 - you beat p2p!');
-            } else if (total === 250 || total === 500 || total === 750 || total === 1000 || total === 1250 || total === 1500 || total === 1750) {
-                this.addSessionLog(LoggerEventType.ADVENTURE, `Reached total level ${total}`);
-            }
+            } 
             if (freeTotal === 1485) {
                 this.addSessionLog(LoggerEventType.ADVENTURE, 'Reached total level 1485 - you beat f2p!');
             }

--- a/src/engine/entity/Player.ts
+++ b/src/engine/entity/Player.ts
@@ -1724,12 +1724,12 @@ export default class Player extends PathingEntity {
                     freeTotal += this.baseLevels[stat];
                 }
             }
-            
-            const previousTotal = total - (this.baseLevels[stat] - before);
-            for (let milestoneLvl = 250; total >= milestoneLvl; milestoneLvl += 250) {
-                if (previousTotal < milestoneLvl) {
-                    this.addSessionLog(LoggerEventType.ADVENTURE, `Reached total level ${milestoneLvl}`);
-                }
+
+            const milestoneIncrements = 250; // Level milestones = multiple of this number (should be >= 100)
+            const totalMilestoneMod = total % milestoneIncrements;
+            const previousMilestoneMod = (total - (this.baseLevels[stat] - before)) % milestoneIncrements;
+            if (totalMilestoneMod < previousMilestoneMod) {
+                this.addSessionLog(LoggerEventType.ADVENTURE, `Reached total level ${total - totalMilestoneMod}`);
             }
             if (total === 1881) {
                 this.addSessionLog(LoggerEventType.ADVENTURE, 'Reached total level 1881 - you beat p2p!');

--- a/src/engine/entity/Player.ts
+++ b/src/engine/entity/Player.ts
@@ -1730,6 +1730,7 @@ export default class Player extends PathingEntity {
             for (const milestone of milestones) {
                 if (previousTotal < milestone && total >= milestone) {
                     this.addSessionLog(LoggerEventType.ADVENTURE, `Reached total level ${milestone}`);
+                    break;
                 }
             }
             if (total === 1881) {

--- a/src/engine/entity/Player.ts
+++ b/src/engine/entity/Player.ts
@@ -1725,11 +1725,11 @@ export default class Player extends PathingEntity {
                 }
             }
 
-            const milestoneIncrements = 250; // Level milestones = multiple of this number (should be >= 100)
-            const totalMilestoneMod = total % milestoneIncrements;
-            const previousMilestoneMod = (total - (this.baseLevels[stat] - before)) % milestoneIncrements;
-            if (totalMilestoneMod < previousMilestoneMod) {
-                this.addSessionLog(LoggerEventType.ADVENTURE, `Reached total level ${total - totalMilestoneMod}`);
+            const milestone = 250; // Level milestones = multiple of this number (should be >= 100)
+            const prevMilestone = ((total - (this.baseLevels[stat] - before)) / milestone) | 0;
+            const currMilestone = (total / milestone) | 0;
+            if (currMilestone > prevMilestone) {
+                this.addSessionLog(LoggerEventType.ADVENTURE, `Reached total level ${currMilestone * milestone}`);
             }
             if (total === 1881) {
                 this.addSessionLog(LoggerEventType.ADVENTURE, 'Reached total level 1881 - you beat p2p!');

--- a/src/engine/entity/Player.ts
+++ b/src/engine/entity/Player.ts
@@ -1727,10 +1727,9 @@ export default class Player extends PathingEntity {
             
             const previousTotal = total - (this.baseLevels[stat] - before);
             const milestones = [250, 500, 750, 1000, 1250, 1500, 1750];
-            for (const milestone of milestones) {
-                if (previousTotal < milestone && total >= milestone) {
-                    this.addSessionLog(LoggerEventType.ADVENTURE, `Reached total level ${milestone}`);
-                    break;
+            for (let i = 0; i < milestones.length && total >= milestones[i]; i++) {
+                if (previousTotal < milestones[i]) {
+                    this.addSessionLog(LoggerEventType.ADVENTURE, `Reached total level ${milestones[i]}`);
                 }
             }
             if (total === 1881) {

--- a/src/engine/entity/Player.ts
+++ b/src/engine/entity/Player.ts
@@ -1726,10 +1726,9 @@ export default class Player extends PathingEntity {
             }
             
             const previousTotal = total - (this.baseLevels[stat] - before);
-            const milestones = [250, 500, 750, 1000, 1250, 1500, 1750];
-            for (let i = 0; i < milestones.length && total >= milestones[i]; i++) {
-                if (previousTotal < milestones[i]) {
-                    this.addSessionLog(LoggerEventType.ADVENTURE, `Reached total level ${milestones[i]}`);
+            for (let milestoneLvl = 250; total >= milestoneLvl; milestoneLvl += 250) {
+                if (previousTotal < milestoneLvl) {
+                    this.addSessionLog(LoggerEventType.ADVENTURE, `Reached total level ${milestoneLvl}`);
                 }
             }
             if (total === 1881) {


### PR DESCRIPTION
Will make the session log about reaching 250 total, even if you were to go from 249 to 251 total in one tick