### PR TITLE
fix(content): Genie and mysterious old man were missing special dialogue

### DIFF
--- a/data/src/scripts/macro events/scripts/general/macro_event_genie.rs2
+++ b/data/src/scripts/macro events/scripts/general/macro_event_genie.rs2
@@ -57,11 +57,12 @@ npc_delay(2);
 
 [opnpc1,macro_event_genie]
 if (uid ! %npc_macro_event_target) {
+    // https://youtu.be/qNQYgiNMBes?t=134
     if (.finduid(%npc_macro_event_target) = true) {
-        ~chatnpc("<p,sad>Sorry, I'm trying to talk to <.text_gender("Master", "Mistress")> <.displayname>, but <.text_gender("he", "she")> seems to be ignoring me."); // osrs
+        ~chatnpc("<p,sad>Sorry, but I'm trying to talk to <.displayname>. However, <.text_gender("he", "she")> appears to be ignoring me..."); 
         return;
     }
-    ~chatnpc("<p,neutral>Have a nice day, <text_gender("master", "mistress")>.");
+    ~chatnpc("<p,sad>Sorry, but I'm trying to talk to another player.|However, they appear to be ignoring me...");
     return;
 }
 if (%npc_int = ^genie_happy) {

--- a/data/src/scripts/macro events/scripts/general/macro_event_mysterious_old_man.rs2
+++ b/data/src/scripts/macro events/scripts/general/macro_event_mysterious_old_man.rs2
@@ -59,10 +59,10 @@ npc_delay(2);
 if (uid ! %npc_macro_event_target) {
     // https://youtu.be/U_TRFGTfIY0?t=276
     if (.finduid(%npc_macro_event_target) = true) {
-        ~chatnpc("<p,neutral>Sorry, but I'm trying to talk to <.displayname>. However <.text_gender("he", "she")> appears to be ignoring me...");
+        ~chatnpc("<p,sad>Sorry, but I'm trying to talk to <.displayname>. However, <.text_gender("he", "she")> appears to be ignoring me..."); // same as genie
         return;
     }
-    ~chatnpc("<p,neutral>Goodbye.");
+    ~chatnpc("<p,sad>Sorry, but I'm trying to talk to another player.|However, they appear to be ignoring me...");
     return;
 }
 if (%npc_int = ^mysterious_old_man_happy) {


### PR DESCRIPTION
Since mysterious old man has the same dialogue here as genie, its safe to assume that they have the same 'no target' dialogue.

- Talking to a mysterious old man that isnt yours, from [video](https://youtu.be/U_TRFGTfIY0?t=276):

![VS--YouTube-RunescapefishingTrippoonage-4’36”](https://github.com/user-attachments/assets/b57821e2-86b5-46cb-85dc-94cef57c08a2)


- Talking to a genie that isnt yours *and* talking to a genie that cant find it's target, from [video](https://youtu.be/qNQYgiNMBes?t=134):

![VS--YouTube-RunescapeGenieGlitch-2’14”](https://github.com/user-attachments/assets/fb93ac15-9edc-49a9-9ed4-177947eae2f6)
![VS--YouTube-RunescapeGenieGlitch-2’00”](https://github.com/user-attachments/assets/e11d3a02-f714-4055-8559-21950d3aba61)
