### PR TITLE
fix(content): ranged combat fix

### DIFF
--- a/data/src/scripts/skill_combat/scripts/player/player_magic.rs2
+++ b/data/src/scripts/skill_combat/scripts/player/player_magic.rs2
@@ -177,11 +177,9 @@ return($duration);
 
 [proc,pvm_spell_success](dbrow $spell_data, int $maxhit, int $duration)
 def_obj $weapon = inv_getobj(worn, ^wearpos_rhand);
-def_int $damagestyle = %damagestyle;
-if ($damagestyle = ^style_melee_defensive & $weapon ! null & oc_category($weapon) = weapon_staff) {
+def_int $damagestyle = ^style_magic_normal;
+if (%damagestyle = ^style_melee_defensive) { // check varp directly
     $damagestyle = ^style_magic_defensive; // casting a spell with defensive on gives mage + def xp
-} else {
-    $damagestyle = ^style_magic_normal; // if this script is running they have to be using a spell, so assume magic style
 }
 // play spell success sound
 sound_synth(db_getfield($spell_data, magic_spell_table:sound_success, 0), 0, 0);

--- a/data/src/scripts/skill_combat/scripts/player/player_magic.rs2
+++ b/data/src/scripts/skill_combat/scripts/player/player_magic.rs2
@@ -152,11 +152,6 @@ if ($spell = ^crumble_undead & npc_param(undead) = ^false) {
 // in osrs you can only defensive cast with a staff. Not sure if this is the case in 2004
 // Might be confusing for players if they just so happen to have their non-magic weapon on defensive, and end up gaining def xp from manual casting.
 // so maybe jagex did it this way?
-if (%damagestyle = ^style_melee_defensive & inv_getobj(worn, ^wearpos_rhand) ! null & oc_category(inv_getobj(worn, ^wearpos_rhand)) = weapon_staff) {
-    %damagestyle = ^style_magic_defensive; // casting a spell with defensive on gives mage + def xp
-} else {
-    %damagestyle = ^style_magic_normal; // if this script is running they have to be using a spell, so assume magic style
-}
 
 // spell anim
 anim(db_getfield($spell_data, magic_spell_table:anim, 0), 0);
@@ -181,6 +176,13 @@ return($duration);
 
 
 [proc,pvm_spell_success](dbrow $spell_data, int $maxhit, int $duration)
+def_obj $weapon = inv_getobj(worn, ^wearpos_rhand);
+def_int $damagestyle = %damagestyle;
+if ($damagestyle = ^style_melee_defensive & $weapon ! null & oc_category($weapon) = weapon_staff) {
+    $damagestyle = ^style_magic_defensive; // casting a spell with defensive on gives mage + def xp
+} else {
+    $damagestyle = ^style_magic_normal; // if this script is running they have to be using a spell, so assume magic style
+}
 // play spell success sound
 sound_synth(db_getfield($spell_data, magic_spell_table:sound_success, 0), 0, 0);
 // roll 0-maxhit
@@ -213,7 +215,7 @@ if ($maxhit ! null) {
         sound_synth(npc_param(defend_sound), 0, $duration); // delay 1 client tick for the hit queue
     }
     def_int $damage_capped = min($damage, npc_stat(hitpoints));
-    ~give_combat_experience(%damagestyle, $damage_capped, %npc_combat_xp_multiplier);
+    ~give_combat_experience($damagestyle, $damage_capped, %npc_combat_xp_multiplier);
     npc_heropoints($damage_capped);
 }
 // spell visual

--- a/data/src/scripts/skill_combat/scripts/pvp/pvp_combat.rs2
+++ b/data/src/scripts/skill_combat/scripts/pvp/pvp_combat.rs2
@@ -162,9 +162,6 @@ if ($damage < 0) {
 
 // needs to be a queue
 [queue,pvp_damage](int $damage)
-if (.finduid(%pk_predator1) = true) {
-    .mes("<tostring(map_clock)>: damage");
-}
 if (inv_getobj(worn, ^wearpos_ring) = ring_of_recoil & .finduid(%pk_predator1) = true & $damage > 0 & stat(hitpoints) > 0) {
     // https://oldschool.runescape.wiki/w/Update:Clue_Scroll_Step_Counter
     // - "Recoil damage will now always target the entity that caused the initial damage, rather than the most recent entity to deal damage."

--- a/data/src/scripts/skill_combat/scripts/pvp/pvp_magic.rs2
+++ b/data/src/scripts/skill_combat/scripts/pvp/pvp_magic.rs2
@@ -164,6 +164,13 @@ if ($freeze_time > 0) {
 }
 
 [proc,pvp_spell_success](dbrow $spell_data, int $maxhit, int $duration)
+def_obj $weapon = inv_getobj(worn, ^wearpos_rhand);
+def_int $damagestyle = %damagestyle;
+if ($damagestyle = ^style_melee_defensive & $weapon ! null & oc_category($weapon) = weapon_staff) {
+    $damagestyle = ^style_magic_defensive; // casting a spell with defensive on gives mage + def xp
+} else {
+    $damagestyle = ^style_magic_normal; // if this script is running they have to be using a spell, so assume magic style
+}
 def_synth $sound = db_getfield($spell_data, magic_spell_table:sound_success, 0);
 sound_synth($sound, 0, 0);
 .sound_synth($sound, 0, 0);
@@ -180,7 +187,7 @@ def_int $damage = randominc($maxhit); // tick eating existed! https://oldschool.
 $damage = min($damage, .stat(hitpoints));
 ~.pvp_damage(calc($duration / 30 + 1), $damage); // delayed an extra tick: https://youtu.be/eEdE0mvglM4?t=62
 // didnt have a flinch anim until sept 20 2006: https://oldschool.runescape.wiki/w/Update:Slug_Menace
-~give_combat_experience_pvp(%damagestyle, $damage, ~pvp_xp_multiplier(~.player_combat_level));
+~give_combat_experience_pvp($damagestyle, $damage, ~pvp_xp_multiplier(~.player_combat_level));
 both_heropoints($damage);
 
 .spotanim_pl(db_getfield($spell_data, magic_spell_table:spotanim_target, 0), $duration);
@@ -208,12 +215,6 @@ sound_synth($sound, 0, 0);
 .if_close;
 ~delete_spell_runes($spell_data);
 ~give_spell_xp($spell_data);
-
-if (%damagestyle = ^style_melee_defensive & inv_getobj(worn, ^wearpos_rhand) ! null & oc_category(inv_getobj(worn, ^wearpos_rhand)) = weapon_staff) {
-    %damagestyle = ^style_magic_defensive; // casting a spell with defensive on gives mage + def xp
-} else {
-    %damagestyle = ^style_magic_normal; // if this script is running they have to be using a spell, so assume magic style
-}
 
 // spell anim
 anim(db_getfield($spell_data, magic_spell_table:anim, 0), 0);

--- a/data/src/scripts/skill_combat/scripts/pvp/pvp_magic.rs2
+++ b/data/src/scripts/skill_combat/scripts/pvp/pvp_magic.rs2
@@ -165,11 +165,9 @@ if ($freeze_time > 0) {
 
 [proc,pvp_spell_success](dbrow $spell_data, int $maxhit, int $duration)
 def_obj $weapon = inv_getobj(worn, ^wearpos_rhand);
-def_int $damagestyle = %damagestyle;
-if ($damagestyle = ^style_melee_defensive & $weapon ! null & oc_category($weapon) = weapon_staff) {
+def_int $damagestyle = ^style_magic_normal;
+if (%damagestyle = ^style_melee_defensive) { // check varp directly
     $damagestyle = ^style_magic_defensive; // casting a spell with defensive on gives mage + def xp
-} else {
-    $damagestyle = ^style_magic_normal; // if this script is running they have to be using a spell, so assume magic style
 }
 def_synth $sound = db_getfield($spell_data, magic_spell_table:sound_success, 0);
 sound_synth($sound, 0, 0);

--- a/data/src/scripts/tutorial/scripts/skills/tut_player_magic.rs2
+++ b/data/src/scripts/tutorial/scripts/skills/tut_player_magic.rs2
@@ -44,10 +44,6 @@ if (npc_type = tut_chicken & %tutorial_progress < ^tutorial_successful_wind_stri
 [proc,tut_pvm_spell_cast](dbrow $spell_data)(int)
 ~delete_spell_runes($spell_data);
 ~tut_give_spell_xp($spell_data);
-def_int $damagestyle = ^style_magic_normal;
-if (%damagestyle = ^style_melee_defensive) { // check varp directly
-    $damagestyle = ^style_magic_defensive; // casting a spell with defensive on gives mage + def xp
-}
 // spell anim
 anim(db_getfield($spell_data, magic_spell_table:anim, 0), 0);
 // player spell visual effect

--- a/data/src/scripts/tutorial/scripts/skills/tut_player_magic.rs2
+++ b/data/src/scripts/tutorial/scripts/skills/tut_player_magic.rs2
@@ -44,17 +44,10 @@ if (npc_type = tut_chicken & %tutorial_progress < ^tutorial_successful_wind_stri
 [proc,tut_pvm_spell_cast](dbrow $spell_data)(int)
 ~delete_spell_runes($spell_data);
 ~tut_give_spell_xp($spell_data);
-
-// in osrs you can only defensive cast with a staff. Not sure if this is the case in 2004
-// Might be confusing for players if they just so happen to have their non-magic weapon on defensive, and end up gaining def xp from manual casting.
-// so maybe jagex did it this way?
-def_int $damagestyle = %damagestyle;
-if ($damagestyle = ^style_melee_defensive & inv_getobj(worn, ^wearpos_rhand) ! null & oc_category(inv_getobj(worn, ^wearpos_rhand)) = weapon_staff) {
+def_int $damagestyle = ^style_magic_normal;
+if (%damagestyle = ^style_melee_defensive) { // check varp directly
     $damagestyle = ^style_magic_defensive; // casting a spell with defensive on gives mage + def xp
-} else {
-    $damagestyle = ^style_magic_normal; // if this script is running they have to be using a spell, so assume magic style
 }
-
 // spell anim
 anim(db_getfield($spell_data, magic_spell_table:anim, 0), 0);
 // player spell visual effect

--- a/data/src/scripts/tutorial/scripts/skills/tut_player_magic.rs2
+++ b/data/src/scripts/tutorial/scripts/skills/tut_player_magic.rs2
@@ -48,10 +48,11 @@ if (npc_type = tut_chicken & %tutorial_progress < ^tutorial_successful_wind_stri
 // in osrs you can only defensive cast with a staff. Not sure if this is the case in 2004
 // Might be confusing for players if they just so happen to have their non-magic weapon on defensive, and end up gaining def xp from manual casting.
 // so maybe jagex did it this way?
-if (%damagestyle = ^style_melee_defensive & inv_getobj(worn, ^wearpos_rhand) ! null & oc_category(inv_getobj(worn, ^wearpos_rhand)) = weapon_staff) {
-    %damagestyle = ^style_magic_defensive; // casting a spell with defensive on gives mage + def xp
+def_int $damagestyle = %damagestyle;
+if ($damagestyle = ^style_melee_defensive & inv_getobj(worn, ^wearpos_rhand) ! null & oc_category(inv_getobj(worn, ^wearpos_rhand)) = weapon_staff) {
+    $damagestyle = ^style_magic_defensive; // casting a spell with defensive on gives mage + def xp
 } else {
-    %damagestyle = ^style_magic_normal; // if this script is running they have to be using a spell, so assume magic style
+    $damagestyle = ^style_magic_normal; // if this script is running they have to be using a spell, so assume magic style
 }
 
 // spell anim


### PR DESCRIPTION
- wrongfully writing to %damagestyle
- Also removes the arbitrary weapon staff check for defensive magic casting. In 2006-2007, they reworked the defensive cast entirely by integrating it into autocast. So by design, they *require* autocast for defensive cast to work. Our defensive casting is separate from autocast, hence why the weapon staff check makes no sense to me.