### PR TITLE
fix(content): family crest changes, more members restrictions, and anainabarrelfix

### DIFF
--- a/data/src/scripts/areas/area_alkharid/scripts/gem_trader.rs2
+++ b/data/src/scripts/areas/area_alkharid/scripts/gem_trader.rs2
@@ -16,8 +16,8 @@ else {
 ~chatnpc("<p,neutral>Eh, suit yourself.");
 
 [label,gem_trader_crest]
-~chatplayer("<p,neutral>I'm in search of a man named Avan Fitzharmon.");
-~chatnpc("<p,shifty>Fitzharmon eh? Hmmm.... If I'm not mistaken that's the family name of a member of the Varrockian nobility. You know, I HAVE seen someone of that");
+~chatplayer("<p,quiz>I'm in search of a man named Avan Fitzharmon.");
+~chatnpc("<p,confused>Fitzharmon eh? Hmmm.... If I'm not mistaken that's the family name of a member of the Varrockian nobility. You know, I HAVE seen someone of that");
 ~chatnpc("<p,neutral>persuasion around here recently... Wearing a poncey yellow cape he was! Came in here all la-di-dah, high and mighty, asking for jewelry made");
 ~chatnpc("<p,neutral>from 'perfect gold' - whatever that is - like 'normal' golds just not good enough for little lord fancy pants there! I told him to head to the desert");
 ~chatnpc("<p,neutral>'Cos I know theres gold out there, in them there sand dunes... and if it's not up to his lordships high standards of 'gold perfection'...");

--- a/data/src/scripts/areas/area_falador/scripts/sir_amik_varze.rs2
+++ b/data/src/scripts/areas/area_falador/scripts/sir_amik_varze.rs2
@@ -33,7 +33,7 @@ if ($option = 1) {
     @black_knights_fortress_sir_amik_come_along_at_the_right_time;
 } else {
     ~chatplayer("<p,quiz>I go and cower in a corner at the first sign of danger!");
-    ~chatnpc("<p,confused>Err...");
+    ~chatnpc("<p,shock>Err...");
     ~chatnpc("<p,confused>Well.");
     ~chatnpc("<p,quiz>Spy work does involve a little hiding in corners I suppose.");
     def_int $give_it_a_go_or_no = ~p_choice2("Oh, I suppose I'll give it a go then.", 1, "No, I'm not convinced.", 2);
@@ -51,7 +51,7 @@ if ($option = 1) {
 ~chatplayer("<p,quiz>So what needs doing?");
 ~chatnpc("<p,angry>Well the Black Knights have started making strange threats to us. Demanding large amounts of money and land, and threatening to invade Falador if we don't pay.");
 ~chatnpc("<p,neutral>Now normally this wouldn't be a problem.");
-~chatnpc("<p,sad>But they claim to have a powerful new secret weapon.");
+~chatnpc("<p,angry>But they claim to have a powerful new secret weapon.");
 ~chatnpc("<p,neutral>What I want you to do is get inside their fortress.|Find out what their secret weapon is.|And then sabotage it. You will be well paid.");
 ~chatplayer("<p,neutral>Ok, I'll give it a try.");
 ~update_blackknight_progress;
@@ -59,15 +59,15 @@ if ($option = 1) {
 [label,black_knights_fortress_sir_amik_in_progress]
 if (%blackknight_progress = 1) {
     ~chatnpc("<p,quiz>How's the mission going?");
-    ~chatplayer("<p,neutral>I haven't managed to find what the secret weapon is yet.");
+    ~chatplayer("<p,sad>I haven't managed to find what the secret weapon is yet.");
 } else if (%blackknight_progress = 2) {
     ~chatnpc("<p,quiz>How's the mission going?");
     ~chatplayer("<p,neutral>I've found out what the Black Knight's secret weapon is. It's a potion of invincibility.");
-    ~chatnpc("<p,sad>That is bad news.|If you can sabotage it somehow, you will be paid well.");
+    ~chatnpc("<p,angry>That is bad news.|If you can sabotage it somehow, you will be paid well.");
 } else if (%blackknight_progress = 3) {
-    ~chatplayer("<p,neutral>I have ruined the Black Knight's invincibility potion.|That should put a stop to your problem.");
-    ~chatnpc("<p,quiz>Yes we have just received a message from the Black Knights saying they withdraw their demands. Which confirms your story.");
-    ~chatplayer("<p,neutral>You said you were going to pay me.");
+    ~chatplayer("<p,happy>I have ruined the Black Knight's invincibility potion.|That should put a stop to your problem.");
+    ~chatnpc("<p,neutral>Yes we have just received a message from the Black Knights saying they withdraw their demands. Which confirms your story.");
+    ~chatplayer("<p,quiz>You said you were going to pay me.");
     ~chatnpc("<p,happy>Yes, that's right.");
     ~update_blackknight_progress;
     queue(black_knights_fortress_quest_complete, 0);

--- a/data/src/scripts/areas/area_port_sarim/scripts/monk_of_entrana.rs2
+++ b/data/src/scripts/areas/area_port_sarim/scripts/monk_of_entrana.rs2
@@ -1,6 +1,6 @@
 [opnpc1,monk_of_entrana_sarim]
-if(map_members = false) { // guessing, OSRS has the new member mesbox, RS3 has a members only message, this is RSC's
-    mes("The Monk of Entrana does not appear interested in talking.");
+if(map_members = false) { // RS3
+    mes("You need to be on a members' world to access this content.");
     return;
 }
 ~chatnpc("<p,quiz>Do you seek passage to holy Entrana? If so, you must leave your weaponry and armour behind. This is Saradomin's will.");

--- a/data/src/scripts/areas/area_varrock/scripts/fancy_dress_shop_owner.rs2
+++ b/data/src/scripts/areas/area_varrock/scripts/fancy_dress_shop_owner.rs2
@@ -1,4 +1,8 @@
 [opnpc1,fancy_dress_shop_owner]
+if(map_members = false) {
+    ~chatnpc("<p,sad>Sorry, we're closed at the moment.");
+    return;
+}
 ~chatnpc("<p,happy>Now you look like someone who goes to a lot of fancy dress parties.");
 ~chatplayer("<p,confused>Errr...what are you saying exactly?");
 ~chatnpc("<p,happy>I'm just saying that perhaps you would like to peruse my selection of garments.");
@@ -10,3 +14,10 @@ if($option = 1) {
     ~chatplayer("<p,happy>Okay, lets see what you've got then.");
     ~openshop_activenpc;
 }
+
+[opnpc3,fancy_dress_shop_owner]
+if(map_members = false) {
+    ~chatnpc("<p,sad>Sorry, we're closed at the moment.");
+    return;
+}
+~openshop_activenpc;

--- a/data/src/scripts/player/scripts/death.rs2
+++ b/data/src/scripts/player/scripts/death.rs2
@@ -154,7 +154,7 @@ def_int $i = 0;
 while ($i < $size_inv) {
     if (inv_getnum(inv, $i) > 0) {
         $currentitem = inv_getobj(inv, $i);
-        if (oc_category($currentitem) ! armour_godcape & $currentitem ! anainabarrel) { // TODO: param or property for items that can not be kept on death?
+        if (oc_category($currentitem) ! armour_godcape) { // TODO: param or property for items that can not be kept on death?
             if (oc_cost($currentitem) > $biggest_price) {
                 $biggest_price = oc_cost($currentitem);
                 $priciest_item = $currentitem;
@@ -167,7 +167,7 @@ $i = 0;
 while ($i < $size_worn) {
     if (inv_getnum(worn, $i) > 0) {
         $currentitem = inv_getobj(worn, $i);
-        if (oc_category($currentitem) ! armour_godcape & $currentitem ! anainabarrel) {
+        if (oc_category($currentitem) ! armour_godcape) {
             if (oc_cost($currentitem) > $biggest_price) {
                 $is_worn = true;
                 $biggest_price = oc_cost($currentitem);

--- a/data/src/scripts/quests/quest_crest/scripts/crest_boot.rs2
+++ b/data/src/scripts/quests/quest_crest/scripts/crest_boot.rs2
@@ -1,6 +1,6 @@
 [opnpc1,crest_boot]
 ~chatnpc("<p,neutral>Hello tall person.");
-if (%crest_progress = ^crest_spoken_avan) {
+if (%crest_progress >= ^crest_spoken_avan & %crest_progress < ^crest_avan_piece) {
     @multi3(
         "Hello. I'm in search of very high quality gold.", crest_boot_gold,
         "Hello short person.", crest_boot_hello,
@@ -16,8 +16,8 @@ else {
 
 [label,crest_boot_gold]
 ~chatplayer("<p,neutral>Hello. I'm in search of very high quality gold.");
+if(%crest_progress = ^crest_spoken_avan) %crest_progress = ^crest_spoken_boot;
 ~chatnpc("<p,quiz>High quality gold eh? Hmmm... Well, the very best quality gold that I know of, is just East of the large city Ardougne, underground somewhere.");
-%crest_progress = ^crest_spoken_boot;
 ~chatnpc("<p,neutral>I don't believe it's exactly easy to get to though...");
 
 [label,crest_boot_hello]

--- a/data/src/scripts/quests/quest_crest/scripts/crest_caleb.rs2
+++ b/data/src/scripts/quests/quest_crest/scripts/crest_caleb.rs2
@@ -27,7 +27,7 @@ switch_int(%crest_progress) {
 @multi2("Uh... what happened to the rest of it?", crest_caleb_rest, "So can I have your bit?", crest_caleb_bit);
 
 [label,crest_caleb_rest]
-~chatplayer("<p,neutral>Uh... what happened to the rest of it?");
+~chatplayer("<p,quiz>Uh... what happened to the rest of it?");
 ~chatnpc("<p,sad>Well... my brothers and I had a slight disagreement about it... we all wanted to be heir to my fathers' lands, and we each ended up with a piece of the crest.");
 ~chatnpc("<p,sad>None of us wanted to give up our rights to our brothers, so we didn't want to give up our pieces of the crest, but none of us wanted to face our father by");
 ~chatnpc("<p,sad>returning to him with an incomplete crest... We each went our seperate ways many years past, none of us seeing our father or willing to give up our fragments.");
@@ -35,28 +35,29 @@ switch_int(%crest_progress) {
 // https://youtu.be/e8btuenT4nE?t=167
 if (%crest_progress = ^crest_caleb_piece) {
     ~chatplayer("<p,quiz>So do you know where I could find any of your brothers?");
-    ~chatnpc("<p,neutral>Well, we haven't really kept in touch... what with the dispute over the crest and all... I did hear from my brother Avan a while ago though.");
-    ~chatnpc("<p,neutral>He said he was on some kind of search for treasure, or gold, or something out in the desert. You might want to ask around there for him.");
+    ~chatnpc("<p,neutral>Well, we haven't really kept in touch... what with the dispute over the crest and all... I did hear from my brother Avan a while ago though..");
     %crest_progress = ^crest_caleb_where;
+    ~chatnpc("<p,neutral>He said he was on some kind of search for treasure, or gold, or something out in the desert. You might want to ask around there for him.");
     ~chatnpc("<p,neutral>Avan always did have expensive tastes however. You may find he is not prepared to hand over his crest piece to you as easily as I have.");
 }
 
 [label,crest_caleb_bit]
-~chatplayer("<p,neutral>So can I have your bit?");
+~chatplayer("<p,quiz>So can I have your bit?");
 ~chatnpc("<p,neutral>Well, I am the oldest son, so by the rules of chivalry, I am most entitled to be rightful bearer of the crest.");
-~chatplayer("<p,neutral>It's not really much use without the other fragments is it though?");
+~chatplayer("<p,confused>It's not really much use without the other fragments is it though?");
 ~chatnpc("<p,sad>Well that is true... perhaps it is time to put my pride aside... I'll tell you what: I'm struggling to complete this fish salad of mine,");
 ~chatnpc("<p,neutral>so if you will assist me in my search for the ingredients, then I will let you take my piece as reward for your assistance.");
-~chatplayer("<p,neutral>So what ingredients are you missing?");
+~chatplayer("<p,quiz>So what ingredients are you missing?");
 ~chatnpc("<p,neutral>I require the following cooked fish: Swordfish, Bass, Tuna, Salmon and Shrimp.");
 def_int $op = ~p_choice2("Ok, I will get those.", 1, "Why don't you just give me the crest?", 2);
 if ($op = 1) {
+    %crest_progress = ^crest_spoken_caleb;
     ~chatplayer("<p,neutral>Ok, I will get those.");
     ~chatnpc("<p,happy>You will? It would help me a lot!");
-    %crest_progress = ^crest_spoken_caleb;
 }
 else {
-    ~chatplayer("<p,neutral>Why don't you just give me the crest?");
+    ~chatplayer("<p,quiz>Why don't you just give me the crest?");
+    %crest_progress = ^crest_spoken_caleb;
     ~chatnpc("<p,angry>It's a valuable family heirloom. I think the least you can do is prove you're worthy of it before I hand it over.");
 }
 
@@ -68,6 +69,7 @@ if (inv_total(inv, swordfish) >= 1 &
     inv_total(inv, salmon) >= 1 &
     inv_total(inv, shrimps) >= 1) {
         ~chatplayer("<p,neutral>Got them all with me.");
+        ~mesbox("You exchange the fish for Caleb's piece of the crest.");
         %crest_progress = ^crest_caleb_piece;
         inv_del(inv, swordfish, 1);
         inv_del(inv, bass, 1);
@@ -75,33 +77,32 @@ if (inv_total(inv, swordfish) >= 1 &
         inv_del(inv, salmon, 1);
         inv_del(inv, shrimps, 1);
         inv_add(inv, crest_part_1, 1);
-        ~mesbox("You exchange the fish for Caleb's piece of the crest.");
         @multi2("Uh... what happened to the rest of it?", crest_caleb_rest, "Thank you very much!", crest_caleb_thanks);
     }
 else {
-    ~chatplayer("<p,neutral>I didn't manage to get them all yet...");
+    ~chatplayer("<p,sad>I didn't manage to get them all yet...");
     ~chatnpc("<p,neutral>Remember, I want the following cooked fish: Swordfish, Bass, Tuna, Salmon, and Shrimp.");
 }
 
 [label,crest_caleb_thanks]
 ~chatplayer("<p,happy>Thank you very much.");
-~chatnpc("<p,neutral>You're welcome.");
+~chatnpc("<p,happy>You're welcome.");
 
 [label,crest_caleb_salad]
 ~chatnpc("<p,neutral>Hello again. I'm just putting the finishing touches to my masterful salad.");
-@multi2("Uh... what happened to the rest of the crest?", crest_caleb_rest, "Good luck with that then.", crest_caleb_luck);
+@multi2("Uh... what happened to the rest of it?", crest_caleb_rest, "Good luck with that then.", crest_caleb_luck);
 
 [label,crest_caleb_luck]
 ~chatplayer("<p,neutral>Good luck with that then.");
-~chatnpc("<p,angry>Luck? LUCK? With my cooking skill, I don't really need LUCK.");
+~chatnpc("<p,neutral>Luck? LUCK? With my cooking skill, I don't really need LUCK.");
 
 [label,crest_caleb_avan]
-~chatplayer("<p,neutral>Where did you say I could find Avan again?");
+~chatplayer("<p,quiz>Where did you say I could find Avan again?");
 ~chatnpc("<p,neutral>Last I heard he was on some stupid treasure hunt out in the desert somewhere. Your best bet is asking around there.");
 @crest_caleb_pieces;
 
 [label,crest_caleb_pieces]
-~chatnpc("<p,neutral>How are you doing getting the crest pieces?");
+~chatnpc("<p,quiz>How are you doing getting the crest pieces?");
 if (inv_total(inv, family_crest) >= 1) {
     ~chatplayer("<p,neutral>I've got it right here!");
     ~chatnpc("<p,neutral>Excellent work! Please take it to my father immediately.");
@@ -115,29 +116,29 @@ else {
 
 [label,crest_caleb_working]
 ~chatplayer("<p,neutral>I am still working on it.");
-~chatnpc("<p,neutral>Then why are you wasting your time here?");
+~chatnpc("<p,quiz>Then why are you wasting your time here?");
 
 [label,crest_caleb_lost]
-~chatplayer("<p,neutral>I have lost the piece you gave me...");
-~chatnpc("<p,neutral>I have some good news for you then. One of my customers found this on their travels and recognised it as mine and returned it to me here.");
-inv_add(inv, crest_part_1, 1);
+~chatplayer("<p,neutral>I have lost the fragment you gave me...");
+~chatnpc("<p,confused>I have some good news for you then. One of my customers found this on their travels and recognised it as mine and returned it to me here.");
 ~mesbox("Caleb hands over his crest piece again.");
+inv_add(inv, crest_part_1, 1);
 ~chatnpc("<p,neutral>I suggest you be less careless in the future. The crest is extremely valuable, and utterly irreplaceable.");
 
 [label,crest_caleb_nothing]
 ~chatplayer("<p,neutral>Nothing, I will be on my way.");
 
 [label,crest_caleb_chef]
-~chatplayer("<p,neutral>I see you are a chef, will you cook me anything?");
+~chatplayer("<p,quiz>I see you are a chef... Could you cook me something?");
 // "reknown" is verbatim
 ~chatnpc("<p,neutral>I would, but I am very busy. I am trying to increase my reknown as one of the worlds' leading chefs by preparing a special and unique fish salad.");
 
 [label,crest_caleb_gauntlets]
 // Ability to change gauntlets for 25k was added 30/08/05, so this decision is permanent
 // https://oldschool.runescape.wiki/w/Update:Garden_Of_Tranquillity
-~chatnpc("<p,neutral>I hear you brought the completed crest to my father. I must say, that was awfully impressive work.");
+~chatnpc("<p,happy>I hear you brought the completed crest to my father. I must say, that was awfully impressive work.");
 if (inv_total(inv, steel_gauntlets) >= 1) {
-    ~chatplayer("<p,quiz>I believe your father mentioned you would be able to improve these gauntlets for me...");
+    ~chatplayer("<p,neutral>I believe your father mentioned you would be able to improve these gauntlets for me...");
     ~chatnpc("<p,neutral>Yes, that is correct. I can slightly alter these gauntlets to allow you some of my skill at preparing seafood by making them cooking gauntlets.");
     ~chatnpc("<p,neutral>When you wear them you will burn lobsters, sharks and swordfish a lot less. It will be a permanent modification however, so make sure this is what you want.");
     def_int $op = ~p_choice2("Yes, please do that for me.", 1, "I'll see what your brothers have to offer first.", 2);
@@ -155,14 +156,14 @@ if (inv_total(inv, steel_gauntlets) >= 1) {
 }
 else if (testbit(%crest_spells_levers_gauntlets, ^crest_cooking_gauntlets_chosen) = true)  {
     if (inv_total(inv, gauntlets_of_cooking) >= 1) {
-        ~chatplayer("<p,quiz>I believe your father mentioned you would be able to improve these gauntlets for me...");
+        ~chatplayer("<p,neutral>I believe your father mentioned you would be able to improve these gauntlets for me...");
     }
     else {
-        ~chatplayer("<p,quiz>I believe your father mentioned you would be able to improve some gauntlets for me...");
+        ~chatplayer("<p,neutral>I believe your father mentioned you would be able to improve some gauntlets for me...");
     }
     ~chatnpc("<p,neutral>Your gauntlets have already been treated with my potions.");
 }
 else {
-    ~chatplayer("<p,quiz>I believe your father mentioned you would be able to improve some gauntlets for me...");
-    ~chatnpc("<p,neutral>Bring them to me, and I'll see what I can do.");
+    ~chatplayer("<p,neutral>I believe your father mentioned you would be able to improve some gauntlets for me...");
+    ~chatnpc("<p,happy>Bring them to me, and I'll see what I can do.");
 }

--- a/data/src/scripts/quests/quest_crest/scripts/crest_chronozon.rs2
+++ b/data/src/scripts/quests/quest_crest/scripts/crest_chronozon.rs2
@@ -1,11 +1,11 @@
 [ai_queue3,crest_chronozon]
 if (finduid(%npc_aggressive_player) = true) {
     if (getbit_range(%crest_spells_levers_gauntlets, ^crest_wind_blast_used, ^crest_fire_blast_used) = ^crest_all_spells_cast) {
+        if (%crest_progress = ^crest_cured_johnathon) { // before npc death, no heropoints check
+            obj_add(npc_coord, crest_part_3, 1, ^lootdrop_duration);
+        }
         gosub(npc_death);
         if (npc_findhero = true){
-            if (%crest_progress = ^crest_cured_johnathon) {
-                obj_add(npc_coord, crest_part_3, 1, ^lootdrop_duration);
-            }
             obj_add(npc_coord, npc_param(death_drop), 1, ^lootdrop_duration);
         }
     }

--- a/data/src/scripts/quests/quest_crest/scripts/crest_dimintheis.rs2
+++ b/data/src/scripts/quests/quest_crest/scripts/crest_dimintheis.rs2
@@ -1,4 +1,15 @@
 [opnpc1,crest_dimintheis]
+if(map_members = false) {
+    if(%crest_progress = ^crest_not_started) {
+        ~chatnpc("<p,neutral>Hello. My name is Dimintheis, of the noble family Fitzharmon.");
+        ~chatplayer("<p,confused>Why would a nobleman live in a place like this?");
+        ~chatnpc("<p,sad>The King has taken my estate from me until such time as I can show my family crest to him.");
+        ~chatplayer("<p,quiz>And where is this crest?");
+        ~chatnpc("<p,sad>Well, my three sons took it with them many years ago. Sadly, I do not know where they are now.");
+    }
+    mes(^mes_members_do_that); // guess based off OSRS
+    return;
+}
 if (%crest_progress = ^crest_complete) {
     @crest_dimintheis_gauntlets;
 }
@@ -11,7 +22,7 @@ else if (%crest_progress > ^crest_spoken_caleb) {
         @crest_dimintheis_complete;
     }
     else {
-        ~chatnpc("<p,neutral>Have you any news on my crest yet?");
+        ~chatnpc("<p,quiz>Have you any news on my crest yet?");
         ~chatplayer("<p,neutral>I'm still looking for it.");
     }
 }
@@ -21,7 +32,7 @@ else {
 }
 
 [label,crest_dimintheis_dump]
-~chatplayer("<p,quiz>Why would a nobleman live in a dump like this?");
+~chatplayer("<p,confused>Why would a nobleman live in a dump like this?");
 ~chatnpc("<p,sad>The King has taken my estate from me until such time as I can show my family crest to him.");
 @multi2("Why would he do that?", crest_dimintheis_why, "So where is this crest?", crest_dimintheis_where);
 
@@ -30,36 +41,36 @@ else {
 @crest_dimintheis_lore;
 
 [label,crest_dimintheis_lore]
-~chatnpc("<p,neutral>Well, there is a long standing rule of chivalry amongst the Varrockian aristocracy, where each noble family is in possession of a unique crest, which signifies the honour and lineage of the family. More than this");
-~chatnpc("<p,neutral>however, it also represents the lawful rights of each family to prove their ownership of their wealth and lands. If the family crest is lost, then the family's estate is handed over to the current monarch until the crest is");
-~chatnpc("<p,neutral>restored.");
-~chatnpc("<p,neutral>This dates back to the times when there was much in- fighting amongst the noble families and their clans, and was introduced as a way of reducing the bloodshed that was devestating the ranks of the ruling classes at that");
-~chatnpc("<p,neutral>time. When you captured a rival family's clan, you also captured their lands and wealth.");
+~chatnpc("<p,neutral>Well, there is a long standing rule of chivalry amongst the Varrockian aristocracy, where each noble family is in");
+~chatnpc("<p,neutral>possession of a unique crest, which signifies the honour and lineage of the family. More than this however, it also represents the lawful rights of each family");
+~chatnpc("<p,neutral>to prove their ownership of their wealth and lands. If the family crest is lost, then the family's estate is handed over to the current monarch until the crest is restored.");
+~chatnpc("<p,neutral>This dates back to the times when there was much in- fighting amongst the noble families and their clans, and was introduced as a way of reducing the");
+~chatnpc("<p,neutral>bloodshed that was devestating the ranks of the ruling classes at that time. When you captured a rival family's clan, you also captured their lands and wealth.");
 @crest_dimintheis_where;
 
 [label,crest_dimintheis_where]
 ~chatplayer("<p,neutral>So where is this crest?");
-~chatnpc("<p,sad>Well, my three sons took it with them many years ago when they rode out to fight in the war against the undead necromancer and his army in the battle to save Varrock.");
-~chatnpc("<p,neutral>For many years I had assumed them all dead, as I had heard no word from them, but recently I heard word that my son Caleb is alive and well, and trying to earn his fortune as a great chef in the lands beyond White");
-~chatnpc("<p,neutral>Wolf Mountain, although I know not where.");
+~chatnpc("<p,sad>Well, my three sons took it with them many years ago when they rode out to fight in the war against the undead necromancer and his army in");
+~chatnpc("<p,sad>the battle to save Varrock. For many years I had assumed them all dead, as I had heard no word from them, but recently I heard word that my son");
+~chatnpc("<p,neutral>Caleb is alive and well, and trying to earn his fortune as a great chef in the lands beyond White Wolf Mountain, although I know not where.");
 @multi2("Ok, I will help you.", crest_dimintheis_accept, "I'm not interested in that adventure right now.", crest_dimintheis_decline);
 
 [label,crest_dimintheis_accept]
 %crest_progress = ^crest_spoken_dimintheis;
 ~send_quest_progress(questlist:crest, %crest_progress, ^crest_complete);
 ~chatplayer("<p,neutral>Ok, I will help you.");
-~chatnpc("<p,neutral>I thank you greatly adventurer! Also... if you find Caleb... please... let him know his father still loves him....");
+~chatnpc("<p,happy>I thank you greatly adventurer! Also... if you find Caleb... please... let him know his father still loves him....");
 
 [label,crest_dimintheis_decline]
 ~chatplayer("<p,neutral>I'm not interested in that adventure right now.");
 ~chatnpc("<p,sad>I realise it was a lot to ask of a stranger.");
 
 [label,crest_dimintheis_rich]
-~chatplayer("<p,quiz>You're rich then? Can I have some money?");
+~chatplayer("<p,happy>You're rich then? Can I have some money?");
 ~chatnpc("<p,angry>Gah! Lousy Beggar! Your sort is what's ruining this great land! Why don't you just go and get a job if you need the money so badly?");
 
 [label,crest_dimintheis_adventurer]
-~chatplayer("<p,neutral>Hi, I am a bold adventurer.");
+~chatplayer("<p,happy>Hi, I am a bold adventurer.");
 ~chatnpc("<p,neutral>An adventurer hmmm? How lucky. I may have an adventure for you. I desperately need my family crest returning to me. It is of utmost importance.");
 @multi3("Why are you so desperate for it?", crest_dimintheis_desperate, "So where is this crest?", crest_dimintheis_where, "I'm not interested in that adventure right now.", crest_dimintheis_decline);
 
@@ -69,25 +80,18 @@ else {
 
 [label,crest_dimintheis_complete]
 ~chatplayer("<p,neutral>I have retrieved your crest.");
+// https://youtu.be/e8btuenT4nE?si=1d0Zf6EvXq90iMco&t=1169, OSRS takes all crest pieces from bank/inv, rs3 + classic doesn't though so assuming that was an OSRS change
+inv_del(inv, family_crest, 1);
+queue(crest_complete, 0);
 ~chatnpc("<p,happy>Adventurer... I can only thank you for your kindness, although the words are insufficient to express the gratitude I feel!");
 ~chatnpc("<p,happy>You are truly a hero in every sense, and perhaps your efforts can begin to patch the wounds that have torn this family apart...");
-~chatnpc("<p,neutral>I know not how I can adequately reward you for your efforts... although I do have these mystical gauntlets, a family heirloom that through some power unknown to me, have always returned to the head of the family");
+~chatnpc("<p,neutral>I know not how I can adequately reward you for your efforts... although");
+~chatnpc("<p,neutral>I do have these mystical gauntlets, a family heirloom that through some power unknown to me, have always returned to the head of the family");
 ~chatnpc("<p,neutral>whenever lost, or if the owner has died. I will pledge these to you, and if you should lose them return to me, and they will be here.");
 ~chatnpc("<p,neutral>They can also be granted extra powers. Take them to one of my sons, they should be able to imbue them with a skill for you.");
-// Takes all crests and pieces from bank and inventory (based on OSRS wiki and Youtube comments on guide video)
-// https://oldschool.runescape.wiki/w/Family_crest_(item)
-~del_all_if_exists(inv, family_crest);
-~del_all_if_exists(bank, family_crest);
-~del_all_if_exists(inv, crest_part_1);
-~del_all_if_exists(bank, crest_part_1);
-~del_all_if_exists(inv, crest_part_2);
-~del_all_if_exists(bank, crest_part_2);
-~del_all_if_exists(inv, crest_part_3);
-~del_all_if_exists(bank, crest_part_3);
-queue(crest_complete, 0);
 
 [label,crest_dimintheis_gauntlets]
-~chatnpc("<p,neutral>You have my eternal gratitude adventurer, for all you have done in saving my family's honour. Perhaps some day my sons will overcome their differences.");
+~chatnpc("<p,happy>You have my eternal gratitude adventurer, for all you have done in saving my family's honour. Perhaps some day my sons will overcome their differences.");
 if (testbit(%crest_spells_levers_gauntlets, ^crest_cooking_gauntlets_chosen) = true) {
     if (~obj_gettotal(gauntlets_of_cooking) = 0) {
         @crest_dimintheis_offer_gauntlets(gauntlets_of_cooking);
@@ -118,15 +122,15 @@ switch_obj($gauntlets) {
         $gauntlets_name = "chaos gauntlets";
 }
 if(inv_freespace(inv) = 0) {
-    ~chatnpc("<p,neutral>Your <$gauntlets_name> returned to me through their magic power recently. Clear some space and you can have them back."); 
+    ~chatnpc("<p,happy>Your <$gauntlets_name> returned to me through their magic power recently. Clear some space and you can have them back."); 
 }
 else {
-    ~chatnpc("<p,neutral>Your <$gauntlets_name> returned to me through their magic power recently. Would you like them back?");
+    ~chatnpc("<p,happy>Your <$gauntlets_name> returned to me through their magic power recently. Would you like them back?");
     def_int $op = ~p_choice2("Yes please.", 1, "Not right now.", 2);
     if ($op = 1) {
-        ~chatplayer("<p,neutral>Yes please.");
-        inv_add(inv, $gauntlets, 1);
+        ~chatplayer("<p,happy>Yes please.");
         ~chatnpc("<p,neutral>Here you go.");
+        inv_add(inv, $gauntlets, 1);
     }
     else {
         ~chatplayer("<p,neutral>Not right now.");

--- a/data/src/scripts/quests/quest_crest/scripts/crest_johnathon.rs2
+++ b/data/src/scripts/quests/quest_crest/scripts/crest_johnathon.rs2
@@ -1,6 +1,6 @@
 [opnpc1,crest_johnathon]
 if (%crest_progress < ^crest_avan_piece) {
-    ~chatnpc("<p,neutral>I am so very tired... Leave me be... to rest...");
+    ~chatnpc("<p,sad>I am so very tired... Leave me be... to rest...");
 }
 else {
     switch_int(%crest_progress) {
@@ -12,16 +12,19 @@ else {
 }
 
 [opnpcu,crest_johnathon]
-if (oc_param(last_useitem, cures_poison) = true) {
+// https://runescape.wiki/w/Update:This_Week_In_RuneScape_-_07/09/20#Patch_Notes
+// https://oldschool.runescape.wiki/w/Family_Crest?oldid=3908008, should be only standard antipoison originally
+if (last_useitem = 1doseantipoison | last_useitem = 2doseantipoison | last_useitem = 3doseantipoison | last_useitem = 4doseantipoison) {
     if (%crest_progress >= ^crest_cured_johnathon) {
         ~chatnpc("<p,neutral>I'm feeling alright now, thanks.");
-        return;
-    }
-    else if (%crest_progress = ^crest_spoken_johnathon) {   
+    } else if (%crest_progress = ^crest_spoken_johnathon) {   
         inv_del(inv, last_useitem, 1);
         %crest_progress = ^crest_cured_johnathon;
         @crest_johnathon_cured;
+    } else {
+        ~chatplayer("<p,confused>Why would I do that?");
     }
+    return;
 }
 ~displaymessage(^dm_default);
 
@@ -29,16 +32,16 @@ if (oc_param(last_useitem, cures_poison) = true) {
 ~chatplayer("<p,neutral>Greetings. Would you happen to be Johnathon Fitzharmon?");
 ~chatnpc("<p,sad>That... I am...");
 ~chatplayer("<p,neutral>I am here to retrieve your fragment of the Fitzharmon family crest.");
-~chatnpc("<p,neutral>The.. poison.. it is all.. too much... My head... will not... stop spinning...");
 %crest_progress = ^crest_spoken_johnathon;
+~chatnpc("<p,neutral>The.. poison.. it is all.. too much... My head... will not... stop spinning...");
 ~mesbox("Sweat is pouring down Johnathons' face.");
 
 [label,crest_johnathon_spider]
-~chatnpc("<p,sad>What... what did that spider... DO to me? I... I feel so weak... I can hardly... think at all...");
+~chatnpc("<p,neutral>What... what did that spider... DO to me? I... I feel so weak... I can hardly... think at all...");
 
 [label,crest_johnathon_cured]
-~chatnpc("<p,neutral>Ooooh... thank you... Wow! That's completely cured me!");
-~chatnpc("<p,neutral>How can I reward you?");
+~chatnpc("<p,happy>Ooooh... thank you... Wow! That's completely cured me!");
+~chatnpc("<p,quiz>How can I reward you?");
 ~chatplayer("<p,neutral>I've come here for your piece of the Fitzharmon family crest.");
 ~chatnpc("<p,sad>You have? Unfortunately I don't have it any more... in my attempts to slay the fiendish Chronozon, the blood demon, I lost a lot of equipment in");
 ~chatnpc("<p,sad>our last battle when he bested me and forced me away from his den. He probably still has it now.");
@@ -49,7 +52,7 @@ if (oc_param(last_useitem, cures_poison) = true) {
 
 [label,crest_johnathon_postcure]
 if (inv_total(inv, crest_part_3) >= 1) {
-    ~chatplayer("<p,neutral>I have your piece of the crest!");
+    ~chatplayer("<p,happy>I have your piece of the crest!");
     ~chatnpc("<p,neutral>Well done! Now return it to my father!");
 }
 else {
@@ -101,14 +104,14 @@ if (inv_total(inv, steel_gauntlets) >= 1) {
     ~chatnpc("<p,neutral>If you give me your gauntlets I will bestow upon them some of my power, and make any bolt spells you wish to cast more effective.");
     def_int $op = ~p_choice2("That sounds good to me.", 1, "I shall see what options your brothers can offer me first.", 2);
     if ($op = 1) {
-        ~chatplayer("<p,neutral>That sounds good to me!");
+        ~chatplayer("<p,happy>That sounds good to me!");
         ~mesbox("Johnathon takes your gauntlets from you, and begins a low chant over them. You see them begin to glow and sparkle, before he returns them to you.");
         %crest_spells_levers_gauntlets = setbit(%crest_spells_levers_gauntlets, ^crest_chaos_gauntlets_chosen);
         inv_del(inv, steel_gauntlets, 1);
         inv_add(inv, gauntlets_of_chaos, 1);
     }
     else {
-        ~chatplayer("<p,neutral>I think I'll check my other options with your brothers before committing myself.");
+        ~chatplayer("<p,confused>I think I'll check my other options with your brothers before committing myself.");
         ~chatnpc("<p,neutral>I doubt they will offer anything as useful as my magical boost, but as you wish.");
     }
 }
@@ -122,7 +125,7 @@ else if (testbit(%crest_spells_levers_gauntlets, ^crest_chaos_gauntlets_chosen) 
     ~chatnpc("<p,neutral>Your gauntlets are already imbued with my powers.");
 }
 else {
-    ~chatplayer("<p,quiz>Your father told me you could improve some gauntlets for me.");
-    ~chatnpc("<p,neutral>Bring them to me, and I'll see what I can do.");
+    ~chatplayer("<p,neutral>Your father told me you could improve some gauntlets for me.");
+    ~chatnpc("<p,happy>Bring them to me, and I'll see what I can do.");
 }
 

--- a/data/src/scripts/quests/quest_crest/scripts/crest_man.rs2
+++ b/data/src/scripts/quests/quest_crest/scripts/crest_man.rs2
@@ -43,13 +43,13 @@ else {
 ~chatplayer("<p,neutral>Well, I'll see what I can do.");
 
 [label,crest_man_gold]
-~chatnpc("<p,neutral>So how are you doing getting me my perfect gold jewelry?");
-~chatplayer("<p,neutral>I'm still after that 'perfect gold'.");
+~chatnpc("<p,quiz>So how are you doing getting me my perfect gold jewelry?");
+~chatplayer("<p,sad>I'm still after that 'perfect gold'.");
 ~chatnpc("<p,sad>I know how you feel... for such a long time I have searched and searched for the elusive perfect gold... I thought I had gotten a good lead on finding it");
 ~chatnpc("<p,sad>when I heard talk of a dwarven expert on gold named Boot some time back, but unfortunately for me, he has returned to his mountain home, which I cannot find.");
 
 [label,crest_man_jewelry]
-~chatnpc("<p,neutral>So how are you doing making me my perfect gold jewelry?");
+~chatnpc("<p,quiz>So how are you doing getting me my perfect gold jewelry?");
 if (inv_total(inv, perfect_ring) >= 1 & inv_total(inv, perfect_necklace) >= 1) {
     ~chatplayer("<p,neutral>I have the ring and necklace right here.");
     ~mesbox("You hand Avan the perfect gold ring and necklace.");
@@ -61,22 +61,21 @@ if (inv_total(inv, perfect_ring) >= 1 & inv_total(inv, perfect_necklace) >= 1) {
     ~chatnpc("<p,neutral>Now, I suppose you will be wanting to find my brother Johnathon who is in possession of the final piece of the family's crest?");
     ~chatplayer("<p,neutral>That's correct.");
     @crest_man_johnathon;
-}
-else {
+} else {
     ~chatplayer("<p,neutral>I have spoken to Boot the dwarf about the location of 'perfect gold' but haven't managed to make you your jewelry yet.");
     ~chatnpc("<p,neutral>Well, I won't entrust you with my piece of the crest until you have brought me a necklace of perfect gold with a red precious stone, and a perfect gold ring to match.");
 }
 
 [label,crest_man_where]
 // Second crest piece is not reobtainable until after Johnathon's section
-~chatplayer("<p,neutral>Where did you say I could find your brother Johnathon again?");
+~chatplayer("<p,quiz>Where did you say I could find your brother Johnathon again?");
 @crest_man_johnathon;
 
 [label,crest_man_johnathon]
 ~chatnpc("<p,neutral>Well, the last I heard of my brother Johnathon, he was studying the magical arts, and trying to hunt some demon or other out in The Wilderness.");
 ~chatnpc("<p,neutral>Unsurprisingly, I do not believe he is doing a particularly good job of things, and spends most of his time recovering from his injuries in");
 ~chatnpc("<p,neutral>some tavern or other near the edge of The Wilderness. You'll probably find him still there.");
-~chatplayer("<p,neutral>Thanks Avan.");
+~chatplayer("<p,happy>Thanks Avan.");
 
 [label,crest_man_pieces]
 ~chatnpc("<p,neutral>Greetings again, adventurer. How are you doing on retrieving the crest pieces?");
@@ -96,13 +95,13 @@ else {
 ~chatnpc("<p,neutral>I hope you succeed for my father's sake.");
 
 [label,crest_man_lost]
-~chatplayer("<p,neutral>I have lost the piece you gave me...");
-~chatnpc("<p,neutral>I have a confession myself adventurer... I did not fully trust you with the actual part of my family's crest before, and gave you a worthless replica before...");
+~chatplayer("<p,neutral>I have lost the fragment that you gave me...");
+~chatnpc("<p,confused>I have a confession myself adventurer... I did not fully trust you with the actual part of my family's crest before, and gave you a worthless replica before...");
 ~chatnpc("<p,neutral>In hindsight, it seems I was right. I will give you the real piece now, but PLEASE try not to lose it; it is a priceless family heirloom.");
 inv_add(inv, crest_part_2, 1);
 
 [label,crest_man_gauntlets]
-~chatnpc("<p,neutral>I have received word from my father of your assistance to our family in this matter. You have my thanks for restoring our honour.");
+~chatnpc("<p,happy>I have received word from my father of your assistance to our family in this matter. You have my thanks for restoring our honour.");
 if (inv_total(inv, steel_gauntlets) >= 1) {
     ~chatplayer("<p,quiz>Your father mentioned that you could improve these gauntlets in some way for me...");
     ~chatnpc("<p,neutral>Indeed I can. In my long time searching for the 'perfect' gold I learned a lot about gold items. I can improve these gauntlets so that they provide more than normal.");
@@ -116,7 +115,7 @@ if (inv_total(inv, steel_gauntlets) >= 1) {
         inv_add(inv, gauntlets_of_goldsmithing, 1);
     }
     else {
-        ~chatplayer("<p,neutral>I think I'll check my other options with your brothers before committing myself.");
+        ~chatplayer("<p,confused>I think I'll check my other options with your brothers before committing myself.");
         ~chatnpc("<p,neutral>If you feel you really must consort with the likes of them. I await your decision.");
     }
 }
@@ -126,13 +125,13 @@ else if (testbit(%crest_spells_levers_gauntlets, ^crest_goldsmithing_gauntlets_c
         ~chatplayer("<p,quiz>Your father mentioned that you could improve these gauntlets in some way for me...");
     }
     else {
-        ~chatplayer("<p,quiz>Your father mentioned that you could improve some gauntlets for me.");
+        ~chatplayer("<p,neutral>Your father mentioned that you could improve some gauntlets for me.");
     }
     ~chatnpc("<p,neutral>Your gauntlets have already been forged by me.");
 }
 else {
     // https://chisel.weirdgloop.org/dialogue/content/39108
-    ~chatplayer("<p,quiz>Your father mentioned that you could improve some gauntlets for me.");
-    ~chatnpc("<p,neutral>Bring them to me, and I'll see what I can do.");
+    ~chatplayer("<p,neutral>Your father mentioned that you could improve some gauntlets for me.");
+    ~chatnpc("<p,happy>Bring them to me, and I'll see what I can do.");
 }
 

--- a/data/src/scripts/quests/quest_crest/scripts/quest_crest.rs2
+++ b/data/src/scripts/quests/quest_crest/scripts/quest_crest.rs2
@@ -4,6 +4,8 @@
 
 [queue,crest_complete]
 %crest_progress = ^crest_complete;
+// resets this var after completion (choronozon needs to be hit with all 4 blasts to kill again, gold door is always unlocked but lever puzzle resets)
+%crest_spells_levers_gauntlets = 0;
 inv_add(inv, steel_gauntlets, 1);
 session_log(^log_adventure, "Quest complete: Family Crest");
 ~send_quest_complete(questlist:crest, steel_gauntlets, 250, ^squire_questpoints, "You have completed the\\nFamily Crest Quest!");
@@ -31,7 +33,7 @@ session_log(^log_adventure, "Quest complete: Family Crest");
     anim(human_leverdown, 0);
     sound_synth(lever, 0, 0);
     // Tested on OSRS, levers revert to original state after 5 mins
-    loc_change($new_loc, 300);
+    loc_change($new_loc, 500);
     if ($up = true) {
         %crest_spells_levers_gauntlets = setbit(%crest_spells_levers_gauntlets, $lever);
         mes("The lever is now up.");
@@ -46,7 +48,7 @@ session_log(^log_adventure, "Quest complete: Family Crest");
 [oploc1,witchaven_north_door]
 if (testbit(%crest_spells_levers_gauntlets, ^crest_north_lever) = false &
     testbit(%crest_spells_levers_gauntlets, ^crest_south_lever) = true) {
-    ~open_and_close_door(witchaven_door_open, ~check_axis(coord, loc_coord, loc_angle), false);
+    ~open_and_close_door2(witchaven_door_open, ~check_axis(coord, loc_coord, loc_angle), door_open);
 } 
 else {
     mes("This door is locked.");
@@ -56,7 +58,7 @@ else {
 [oploc1,witchaven_south_west_door]
 if (testbit(%crest_spells_levers_gauntlets, ^crest_north_lever) = true &
     testbit(%crest_spells_levers_gauntlets, ^crest_south_lever) = true) {
-    ~open_and_close_door(witchaven_door_open, ~check_axis(coord, loc_coord, loc_angle), false);
+    ~open_and_close_door2(witchaven_door_open, ~check_axis(coord, loc_coord, loc_angle), door_open);
 }
 else {
     mes("This door is locked.");
@@ -66,7 +68,7 @@ else {
 [oploc1,witchaven_south_east_door]
 if (testbit(%crest_spells_levers_gauntlets, ^crest_north_lever) = true &
     testbit(%crest_spells_levers_gauntlets, ^crest_south_lever) = false) {
-    ~open_and_close_door(witchaven_door_open, ~check_axis(coord, loc_coord, loc_angle), false);
+    ~open_and_close_door2(witchaven_door_open, ~check_axis(coord, loc_coord, loc_angle), door_open);
 }
 else {
     mes("This door is locked.");
@@ -74,10 +76,10 @@ else {
 
 // Opens if north lever is up, south lever is down, and the north room lever is up
 [oploc1,witchaven_goldmine_door]
-if (testbit(%crest_spells_levers_gauntlets, ^crest_north_lever) = true &
+if (%crest_progress = ^crest_complete | (testbit(%crest_spells_levers_gauntlets, ^crest_north_lever) = true &
     testbit(%crest_spells_levers_gauntlets, ^crest_south_lever) = false &
-    testbit(%crest_spells_levers_gauntlets, ^crest_north_room_lever) = true) {
-    ~open_and_close_door(witchaven_door_open, ~check_axis(coord, loc_coord, loc_angle), false);
+    testbit(%crest_spells_levers_gauntlets, ^crest_north_room_lever) = true)) {
+    ~open_and_close_door2(witchaven_door_open, ~check_axis(coord, loc_coord, loc_angle), door_open);
 }
 else {
     mes("This door is locked.");
@@ -86,23 +88,30 @@ else {
 [opheldu,crest_part_1]
 if (last_useitem = crest_part_2 | last_useitem = crest_part_3) {
     @combine_crest_parts;
-} else {
+} else if (last_useitem ! crest_part_1) { // no NIH when using a piece on itself
     ~displaymessage(^dm_default);
 }
 
 [opheldu,crest_part_2]
 if (last_useitem = crest_part_1 | last_useitem = crest_part_3) {
     @combine_crest_parts;
-} else {
+} else if (last_useitem ! crest_part_2) {
     ~displaymessage(^dm_default);
 }
 
 [opheldu,crest_part_3]
 if (last_useitem = crest_part_1 | last_useitem = crest_part_2) {
     @combine_crest_parts;
-} else {
+} else if (last_useitem ! crest_part_3) {
     ~displaymessage(^dm_default);
 }
+
+[opheldu,family_crest]
+// OSRS behaviour
+if (last_useitem = crest_part_1 | last_useitem = crest_part_2 | last_useitem = crest_part_3) {
+    return;
+}
+~displaymessage(^dm_default);
 
 [label,combine_crest_parts]
 if (inv_total(inv, crest_part_1) > 0 & inv_total(inv, crest_part_2) > 0 & inv_total(inv, crest_part_3) > 0) {

--- a/data/src/scripts/quests/quest_scorpcatcher/scripts/quest_scorpcatcher.rs2
+++ b/data/src/scripts/quests/quest_scorpcatcher/scripts/quest_scorpcatcher.rs2
@@ -3,7 +3,7 @@ mes("You've already caught this scorpion");
 
 [label,scorpion_sting]
 mes("The scorpion stings you!");
-~damage_self(3);
+queue(damage_player, 0, 3);
 
 [label,catch_scorp](namedobj $next_cage)
 inv_del(inv, last_useitem, 1);

--- a/data/src/scripts/quests/quest_sheepherder/scripts/npcs/councillor_halgrive.rs2
+++ b/data/src/scripts/quests/quest_sheepherder/scripts/npcs/councillor_halgrive.rs2
@@ -34,9 +34,11 @@ switch_int(%sheepherder_progress) {
 
 [label,halgrive_i_can_do_that_for_you]
 ~chatplayer("<p,neutral>I can do that for you.");
-~chatnpc("<p,neutral>Y-you will??? That is excellent news! Head to the enclosure we have set up on Farmer Brumty's land to the north of the city; the four infected sheep should still be somewhere in that vicinity.|Before you will be allowed to enter the enclosure, however, you must ensure you have some kind of protective clothing to prevent contagion.");
+~chatnpc("<p,happy>Y-you will??? That is excellent news! Head to the enclosure we have set up on Farmer Brumty's land to the north of the city; the four infected sheep should still be somewhere in that vicinity.");
+~chatnpc("<p,neutral>Before you will be allowed to enter the enclosure, however, you must ensure you have some kind of protective clothing to prevent contagion.");
 ~chatplayer("<p,quiz>Where can I find some protective clothing then?");
-~chatnpc("<p,neutral>Doctor Orbon wears it when conducting mercy missions to the infected parts of the city. You should be able to find him in the chapel just north of here. Please also take this poisoned sheep feed; we believe poisoning the sheep will minimise the risk of airborne contamination, and is of course also more humane to the sheep.");
+~chatnpc("<p,neutral>Doctor Orbon wears it when conducting mercy missions to the infected parts of the city. You should be able to find him in the chapel just north of here.");
+~chatnpc("<p,neutral>Please also take this poisoned sheep feed; we believe poisoning the sheep will minimise the risk of airborne contamination, and is of course also more humane to the sheep.");
 ~mesbox("The councillor gives you some poisoned sheep feed.");
 inv_add(inv, poisoned_feed, 1);
 if (%sheepherder_progress = ^sheepherder_not_started) {
@@ -59,8 +61,8 @@ if (inv_total(inv, poisoned_feed) < 1) {
 // test bit here
 if (getbit_range(%sheepherder_disposal, 0, 12) = 7020) {
     ~chatplayer("<p,neutral>Yes, I have.");
-    ~chatnpc("<p,happy>Excellent work adventurer!|Please let me reimburse you the 100 gold|it cost you to purchase your protective clothing.");
-    ~chatnpc("<p,happy>And in recognition of your service to the|public health of Ardougne please accept this|further 3000 coins as a reward.");
+    ~chatnpc("<p,neutral>Excellent work adventurer!|Please let me reimburse you the 100 gold|it cost you to purchase your protective clothing.");
+    ~chatnpc("<p,neutral>And in recognition of your service to the|public health of Ardougne please accept this|further 3000 coins as a reward.");
     queue(sheepherder_complete, 0);
 } else {
     ~chatplayer("<p,confused>Uh... yeah... not quite just yet...");
@@ -75,12 +77,12 @@ if (getbit_range(%sheepherder_disposal, 0, 12) = 7020) {
 inv_add(inv, poisoned_feed, 1);
 
 [label,halgrive_thats_not_a_job_for_me]
-~chatplayer("<p,neutral>That's not a job for me.");
+~chatplayer("<p,shock>That's not a job for me.");
 ~chatnpc("<p,sad>I do not blame you adventurer. It is not particularly pleasant work. My problem remains however. If you know anyone suitable please send them this way; time is of the essence.");
 
 // Using the RSC variant. I think the OSRS "More sheep have shown up" is in reference to MEP1 releasing.
 [label,halgrive_after_sheep_herder]
 ~chatplayer("<p,neutral>Hello again sir.");
 ~chatnpc("<p,happy>Well hello again adventurer!|How are you today?");
-~chatplayer("<p,neutral>Fine thank you.|And yourself?");
+~chatplayer("<p,happy>Fine thank you.|And yourself?");
 ~chatnpc("<p,happy>Much better now I don't have to worry about those sheep.");

--- a/data/src/scripts/quests/quest_sheepherder/scripts/npcs/doctor_orbon.rs2
+++ b/data/src/scripts/quests/quest_sheepherder/scripts/npcs/doctor_orbon.rs2
@@ -56,7 +56,7 @@ if (inv_total(inv, coins) < 100) {
     if (%sheepherder_progress = ^sheepherder_tasked_with_talking_to_dr_orbon) {
         %sheepherder_progress = ^sheepherder_tasked_with_disposing_of_sheep;
     }
-    ~chatnpc("<p,happy>These should protect you from infection.");
+    ~chatnpc("<p,neutral>These should protect you from infection.");
 }
 
 [label,doctor_orbon_sorry_doc_thats_too_much]

--- a/data/src/scripts/skill_herblore/scripts/brewing/brew_potion.rs2
+++ b/data/src/scripts/skill_herblore/scripts/brewing/brew_potion.rs2
@@ -95,6 +95,10 @@ if (map_members = false) {
 def_int $current_level = stat(herblore);
 def_int $herb_level = struct_param($struct, brew_potion_level);
 if ($current_level < $herb_level) {
+    if($struct = blamish_oil) {
+        ~mesbox("You need level 25 Herblore to make this potion.");
+        return(false);
+    }
     // https://youtu.be/VthR9A85TQU?t=159
     ~mesbox("You need a Herblore level of at least <tostring($herb_level)> to make this potion.");
     return(false);

--- a/data/src/scripts/skill_magic/scripts/spells/teleport.rs2
+++ b/data/src/scripts/skill_magic/scripts/spells/teleport.rs2
@@ -51,6 +51,10 @@ if (p_finduid(uid) = true) {
 [proc,player_teleport_normal](coord $coord)
 if_close;
 p_stopaction;
+if(inv_total(inv, anainabarrel) > 0) {
+    ~chatnpc_specific("Ana (in a Barrel)", anabarrel, "<p,silent>@dbl@-- You can't teleport while holding the barrel, it's just @dbl@too difficult to concentrate. --");
+    return;
+}
 sound_synth(teleport_all, 0, 0);
 anim(human_castteleport, 0);
 spotanim_pl(teleport_casting, 92, 0);
@@ -59,10 +63,6 @@ p_delay(2);
 
 [proc,p_telejump_safe](coord $coord)
 if (stat(hitpoints) = 0) {
-    return;
-}
-if(inv_total(inv, anainabarrel) > 0) {
-    ~chatnpc_specific("Ana (in a Barrel)", anabarrel, "<p,silent>@dbl@-- You can't teleport while holding the barrel, it's just @dbl@too difficult to concentrate. --");
     return;
 }
 p_telejump($coord);

--- a/data/src/scripts/skill_magic/scripts/spells/teleport.rs2
+++ b/data/src/scripts/skill_magic/scripts/spells/teleport.rs2
@@ -61,6 +61,10 @@ p_delay(2);
 if (stat(hitpoints) = 0) {
     return;
 }
+if(inv_total(inv, anainabarrel) > 0) {
+    ~chatnpc_specific("Ana (in a Barrel)", anabarrel, "<p,silent>@dbl@-- You can't teleport while holding the barrel, it's just @dbl@too difficult to concentrate. --");
+    return;
+}
 p_telejump($coord);
 anim(null, 0);
 // todo: ensure this proc is used for other teleports too
@@ -72,10 +76,6 @@ if ($rum > 0) {
 if(inv_total(inv, plague_sample) > 0) {
     inv_del(inv, plague_sample, ^max_32bit_int);
     mes("The plague sample is too delicate...it disintegrates in the crossing.");
-    return;
-}
-if(inv_total(inv, anainabarrel) > 0) {
-    ~chatnpc_specific("Ana (in a Barrel)", anabarrel, "@dbl@-- You can't teleport while holding the barrel, it's just @dbl@too difficult to concentrate. --");
     return;
 }
 


### PR DESCRIPTION
- Changes to family crest:
  - Fix some mesanims/dialogue, add a couple missing interactions with using crest
  - Change Chronozon crest shield drop to happen before death seq, remove heropoints req
  - Change Johnathon script to only accept standard antipoison
  - Reset var used for the quest after completion as the lever puzzle and chronozons state will reset

- Fix incorrect check order when teleporting with ana in a barrel
- change level req mesbox used for blamish oil during heros quest
- fix some incorrect mesanims in various quests
- add members restriction to dimintheis and the fancy clothes shop