### PR TITLE
fix(content): Fix double flooring for magic defence formula

### DIFF
--- a/data/src/scripts/skill_combat/scripts/combat.rs2
+++ b/data/src/scripts/skill_combat/scripts/combat.rs2
@@ -1,8 +1,8 @@
 // https://oldschool.runescape.wiki/w/Damage_per_second/Melee
 
 // effective levels
-[proc,combat_effective_stat](int $stylebonus, int $stat_level, int $prayerbonus)(int)
-return(calc(scale(max(100, $prayerbonus), 100, $stat_level) + 8 + $stylebonus));
+[proc,combat_effective_stat](int $stat_level, int $prayerbonus)(int)
+return(scale(max(100, $prayerbonus), 100, $stat_level));
 
 [proc,combat_maxhit](int $combat_stat)(int)
 return(calc(($combat_stat + 320) / 640));

--- a/data/src/scripts/skill_combat/scripts/npc/npc_combat.rs2
+++ b/data/src/scripts/skill_combat/scripts/npc/npc_combat.rs2
@@ -290,7 +290,8 @@ if ($damagetype = ^magic_style) {
     $stat = magic;
 }
 def_int $defencebonus = ~npc_combat_defencebonus($damagetype);
-def_int $effective_defence = ~combat_effective_stat(1, npc_stat($stat), 100); // no prayerbonus
+def_int $effective_defence = ~combat_effective_stat(npc_stat($stat), 100); // no prayerbonus
+$effective_defence = add($effective_defence, 9); // 'style bonus' of 1
 def_int $defence_roll = ~combat_stat($effective_defence, $defencebonus);
 return($defence_roll);
 

--- a/data/src/scripts/skill_combat/scripts/npc/npc_combat_magic.rs2
+++ b/data/src/scripts/skill_combat/scripts/npc/npc_combat_magic.rs2
@@ -3,12 +3,14 @@ if (~check_protect_prayer(^magic_style) = true) {
     return(0);
 }
 def_int $magicattack = npc_param(magicattack);
-def_int $effective_magic = ~combat_effective_stat(1, npc_stat(magic), 100); // no prayerbonus
+def_int $effective_magic = ~combat_effective_stat(npc_stat(magic), 100); // no prayerbonus
+$effective_magic = add($effective_magic, 9); // 'style bonus' of 1
 return(~combat_stat($effective_magic, $magicattack));
 
 [proc,npc_magic_attack_roll_no_prot]()(int)
 def_int $magicattack = npc_param(magicattack);
-def_int $effective_magic = ~combat_effective_stat(1, npc_stat(magic), 100); // no prayerbonus
+def_int $effective_magic = ~combat_effective_stat(npc_stat(magic), 100); // no prayerbonus
+$effective_magic = add($effective_magic, 9); // 'style bonus' of 1
 return(~combat_stat($effective_magic, $magicattack));
 
 [walktrigger,frozen]

--- a/data/src/scripts/skill_combat/scripts/npc/npc_combat_melee.rs2
+++ b/data/src/scripts/skill_combat/scripts/npc/npc_combat_melee.rs2
@@ -2,7 +2,8 @@
 [proc,npc_melee_maxhit]()(int)
 def_int $strengthbonus = npc_param(strengthbonus);
 //npcs are essentially always on controlled
-def_int $effective_strength = ~combat_effective_stat(1, npc_stat(strength), 100); // no prayerbonus
+def_int $effective_strength = ~combat_effective_stat(npc_stat(strength), 100); // no prayerbonus
+$effective_strength = add($effective_strength, 9); // 'style bonus' of 1
 def_int $melee_strength = ~combat_stat($effective_strength, $strengthbonus);
 return(~combat_maxhit($melee_strength));
 
@@ -13,7 +14,8 @@ if (~check_protect_prayer(^melee_style) = true) {
     return(0);
 }
 def_int $attackbonus = npc_param(attackbonus);
-def_int $effective_attack = ~combat_effective_stat(1, npc_stat(attack), 100); // no prayerbonus
+def_int $effective_attack = ~combat_effective_stat(npc_stat(attack), 100); // no prayerbonus
+$effective_attack = add($effective_attack, 9); // 'style bonus' of 1
 //npcs are essentially always on controlled
 return(~combat_stat($effective_attack, $attackbonus));
 

--- a/data/src/scripts/skill_combat/scripts/npc/npc_combat_ranged.rs2
+++ b/data/src/scripts/skill_combat/scripts/npc/npc_combat_ranged.rs2
@@ -3,14 +3,16 @@ if (~check_protect_prayer(^ranged_style) = true) {
     return(0);
 }
 def_int $rangeattack = npc_param(rangeattack);
-def_int $effective_ranged = ~combat_effective_stat(1, npc_stat(ranged), 100); // no prayerbonus
+def_int $effective_ranged = ~combat_effective_stat(npc_stat(ranged), 100); // no prayerbonus
+$effective_ranged = add($effective_ranged, 9); // 'style bonus' of 1
 return(~combat_stat($effective_ranged, $rangeattack));
 
 [proc,npc_ranged_maxhit]()(int)
 def_int $rangebonus = npc_param(rangebonus);
 //npcs are essentially always on controlled
-def_int $effective_strength = ~combat_effective_stat(1, npc_stat(ranged), 100); // no prayerbonus
-def_int $range_strength = ~combat_stat($effective_strength, $rangebonus);
+def_int $effective_ranged = ~combat_effective_stat(npc_stat(ranged), 100); // no prayerbonus
+$effective_ranged = add($effective_ranged, 9); // 'style bonus' of 1
+def_int $range_strength = ~combat_stat($effective_ranged, $rangebonus);
 return(~combat_maxhit($range_strength));
 
 [proc,npc_rangeattack]

--- a/data/src/scripts/skill_combat/scripts/player/player_combat_stat.rs2
+++ b/data/src/scripts/skill_combat/scripts/player/player_combat_stat.rs2
@@ -74,13 +74,6 @@ $effective_ranged = add(add($effective_ranged, 8), $ranged_stylebonus);
 $effective_magic = add(add($effective_magic, 8), 1); // magic always has a style bonus of 1: https://x.com/JagexAsh/status/1395736740888031235
 $effective_magic_defence = add($effective_magic_defence, 8); // no idea if theres supposed to be a style bonus here?
 
-mes("effective_attack: <tostring($effective_attack)>");
-mes("effective_strength: <tostring($effective_strength)>");
-mes("effective_defence: <tostring($effective_defence)>");
-mes("effective_ranged: <tostring($effective_ranged)>");
-mes("effective_magic: <tostring($effective_magic)>");
-mes("effective_magic_defence: <tostring($effective_magic_defence)>");
-
 // style related varps
 %damagetype = $damagetype;
 %damagestyle = $damagestyle;

--- a/data/src/scripts/skill_combat/scripts/player/player_combat_stat.rs2
+++ b/data/src/scripts/skill_combat/scripts/player/player_combat_stat.rs2
@@ -48,9 +48,6 @@ def_dbrow $data = ~combat_get_weapon_style_data($weapon);
 def_int $damagetype = ~combat_get_damagetype($data, %attackstyle);
 def_int $damagestyle = ~combat_get_damagestyle($data, %attackstyle);
 
-// attack range
-
-
 // style bonuses
 def_int $attack_stylebonus;
 def_int $strength_stylebonus;
@@ -62,12 +59,27 @@ $defence_stylebonus,
 $ranged_stylebonus = ~combat_get_damagestyle_bonuses($damagestyle);
 
 // effective levels
-def_int $effective_attack = ~combat_effective_stat($attack_stylebonus, $attack_level, $attack_prayer);
-def_int $effective_strength = ~combat_effective_stat($strength_stylebonus, $strength_level, $strength_prayer);
-def_int $effective_defence = ~combat_effective_stat($defence_stylebonus, $defence_level, $defence_prayer);
-def_int $effective_magic = ~combat_effective_stat(1, $magic_level, 100); // no magic prayers
-def_int $effective_magic_defence = calc(scale(7, 10, sub($effective_magic, 8)) + scale(3, 10, sub($effective_defence, 8)) + 8); // sub 8 here because ~combat_effective_stat already adds 8
-def_int $effective_ranged = ~combat_effective_stat($ranged_stylebonus, $ranged_level, 100); // no ranged prayers
+def_int $effective_attack = ~combat_effective_stat($attack_level, $attack_prayer);
+def_int $effective_strength = ~combat_effective_stat($strength_level, $strength_prayer);
+def_int $effective_defence = ~combat_effective_stat($defence_level, $defence_prayer);
+def_int $effective_magic = ~combat_effective_stat($magic_level, 100); // no magic prayers
+def_int $effective_magic_defence = divide(add(multiply(7, $effective_magic), multiply(3, $effective_defence)), 10);
+def_int $effective_ranged = ~combat_effective_stat($ranged_level, 100); // no ranged prayers
+
+// apply style bonuses
+$effective_attack = add(add($effective_attack, 8), $attack_stylebonus);
+$effective_strength = add(add($effective_strength, 8), $strength_stylebonus);
+$effective_defence = add(add($effective_defence, 8), $defence_stylebonus);
+$effective_ranged = add(add($effective_ranged, 8), $ranged_stylebonus);
+$effective_magic = add(add($effective_magic, 8), 1); // magic always has a style bonus of 1: https://x.com/JagexAsh/status/1395736740888031235
+$effective_magic_defence = add($effective_magic_defence, 8); // no idea if theres supposed to be a style bonus here?
+
+mes("effective_attack: <tostring($effective_attack)>");
+mes("effective_strength: <tostring($effective_strength)>");
+mes("effective_defence: <tostring($effective_defence)>");
+mes("effective_ranged: <tostring($effective_ranged)>");
+mes("effective_magic: <tostring($effective_magic)>");
+mes("effective_magic_defence: <tostring($effective_magic_defence)>");
 
 // style related varps
 %damagetype = $damagetype;
@@ -144,12 +156,8 @@ def_obj $weapon = .inv_getobj(worn, ^wearpos_rhand);
 // get style data
 def_dbrow $data = ~combat_get_weapon_style_data($weapon);
 
-// might be worth having a %damagetype, and %damagestyle varp
 def_int $damagetype = ~combat_get_damagetype($data, .%attackstyle);
 def_int $damagestyle = ~combat_get_damagestyle($data, .%attackstyle);
-
-// attack range
-
 
 // style bonuses
 def_int $attack_stylebonus;
@@ -162,12 +170,20 @@ $defence_stylebonus,
 $ranged_stylebonus = ~combat_get_damagestyle_bonuses($damagestyle);
 
 // effective levels
-def_int $effective_attack = ~combat_effective_stat($attack_stylebonus, $attack_level, $attack_prayer);
-def_int $effective_strength = ~combat_effective_stat($strength_stylebonus, $strength_level, $strength_prayer);
-def_int $effective_defence = ~combat_effective_stat($defence_stylebonus, $defence_level, $defence_prayer);
-def_int $effective_magic = ~combat_effective_stat(1, $magic_level, 100); // no magic prayers
-def_int $effective_magic_defence = calc(scale(7, 10, sub($effective_magic, 8)) + scale(3, 10, sub($effective_defence, 8)) + 8); // sub 8 here because ~combat_effective_stat already adds 8
-def_int $effective_ranged = ~combat_effective_stat($ranged_stylebonus, $ranged_level, 100); // no ranged prayers
+def_int $effective_attack = ~combat_effective_stat($attack_level, $attack_prayer);
+def_int $effective_strength = ~combat_effective_stat($strength_level, $strength_prayer);
+def_int $effective_defence = ~combat_effective_stat($defence_level, $defence_prayer);
+def_int $effective_magic = ~combat_effective_stat($magic_level, 100); // no magic prayers
+def_int $effective_magic_defence = divide(add(multiply(7, $effective_magic), multiply(3, $effective_defence)), 10);
+def_int $effective_ranged = ~combat_effective_stat($ranged_level, 100); // no ranged prayers
+
+// apply style bonuses
+$effective_attack = add(add($effective_attack, 8), $attack_stylebonus);
+$effective_strength = add(add($effective_strength, 8), $strength_stylebonus);
+$effective_defence = add(add($effective_defence, 8), $defence_stylebonus);
+$effective_ranged = add(add($effective_ranged, 8), $ranged_stylebonus);
+$effective_magic = add(add($effective_magic, 8), 1); // magic always has a style bonus of 1: https://x.com/JagexAsh/status/1395736740888031235
+$effective_magic_defence = add($effective_magic_defence, 8); // no idea if theres supposed to be a style bonus here?
 
 // style related varps
 .%damagetype = $damagetype;
@@ -245,3 +261,9 @@ if (($style = ^melee_style | $style = ^stab_style | $style = ^slash_style | $sty
 if (($style = ^ranged_style) & .%prayer_protectfrommissiles = ^true) return (true);
 if (($style = ^magic_style) & .%prayer_protectfrommagic = ^true) return (true);
 else return (false);
+
+[debugproc,pcs]
+if (p_finduid(uid) = false) {
+    return;
+}
+~player_combat_stat;


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/7d6a65b3-9586-485b-ac1f-4d5e726da7d3)

Separation of 'style bonus' and +8 from ~combat_effective_stat, makes it easier to implement void in the future... Restructuring it in a way where style bonuses are applied at the end prevents us from having to -8 to $effective magic and $effective_defence, for effective magic defence.

Our previous effective magic defence would double floor since we used `scale()`. Now the question is, did jagex implement the 30/70 split like: 
`divide(add(multiply(7, $effective_magic), multiply(3, $effective_defence)), 10);` 
or 
`add(scale(3, 10, $effective_defence), scale(7, 10, $effective_magic));`


My guess is *without* `scale()`. this will only have very minor differences