### PR TITLE
feat(engine): enable tracking on macro/bug-abuse reports

### DIFF
--- a/src/engine/World.ts
+++ b/src/engine/World.ts
@@ -61,6 +61,7 @@ import WorldStat from '#/engine/WorldStat.js';
 import Zone from '#/engine/zone/Zone.js';
 import Isaac from '#/io/Isaac.js';
 import Packet from '#/io/Packet.js';
+import { ReportAbuseReason } from '#/network/client/model/ReportAbuse.js';
 import InfoProt from '#/network/rs225/server/prot/InfoProt.js';
 import MessagePrivate from '#/network/server/model/MessagePrivate.js';
 import UpdateFriendList from '#/network/server/model/UpdateFriendList.js';
@@ -2123,7 +2124,14 @@ class World {
         });
     }
 
-    notifyPlayerReport(player: Player, offender: string, reason: number) {
+    notifyPlayerReport(player: Player, offender: string, reason: ReportAbuseReason) {
+        if (reason === ReportAbuseReason.MACROING || reason === ReportAbuseReason.BUG_ABUSE) {
+            const offenderPlayer = this.getPlayerByUsername(offender);
+            if (offenderPlayer) {
+                // Immediately turn on tracking when a user is reported as macroing or abusing a bug.
+                offenderPlayer.input.enable();
+            }
+        }
         this.loggerThread.postMessage({
             type: 'report',
             username: player.username,

--- a/src/network/client/model/ReportAbuse.ts
+++ b/src/network/client/model/ReportAbuse.ts
@@ -1,12 +1,27 @@
 import IncomingMessage from '#/network/client/IncomingMessage.js';
 import ClientProtCategory from '#/network/client/prot/ClientProtCategory.js';
 
+export enum ReportAbuseReason {
+    OFFENSIVE_LANGUAGE,  // 0
+    ITEM_SCAMMING,  // 1
+    PASSWORD_SCAMMING,  // 2
+    BUG_ABUSE,  // 3
+    STAFF_IMPERSONATION,  // 4
+    ACCOUNT_SHARING,  // 5
+    MACROING,  // 6
+    MULTI_LOGGING,  // 7
+    ENCOURAGING_BREAK_RULES,  // 8
+    MISUSE_CUSTOMER_SUPPORT,  // 9
+    ADVERTISING_WEBSITE,  // 10
+    REAL_WORLD_TRADING  // 11
+};
+
 export default class ReportAbuse extends IncomingMessage {
     category = ClientProtCategory.USER_EVENT;
 
     constructor(
         readonly offender: bigint,
-        readonly reason: number,
+        readonly reason: ReportAbuseReason,
         readonly moderatorMute: boolean
     ) {
         super();

--- a/src/network/rs225/client/handler/ReportAbuseHandler.ts
+++ b/src/network/rs225/client/handler/ReportAbuseHandler.ts
@@ -1,7 +1,7 @@
 import Player from '#/engine/entity/Player.js';
 import World from '#/engine/World.js';
 import MessageHandler from '#/network/client/handler/MessageHandler.js';
-import ReportAbuse from '#/network/client/model/ReportAbuse.js';
+import ReportAbuse, { ReportAbuseReason } from '#/network/client/model/ReportAbuse.js';
 import { fromBase37 } from '#/util/JString.js';
 
 export default class ReportAbuseHandler extends MessageHandler<ReportAbuse> {
@@ -10,7 +10,7 @@ export default class ReportAbuseHandler extends MessageHandler<ReportAbuse> {
             return false;
         }
 
-        if (message.reason > 11) {
+        if (message.reason < ReportAbuseReason.OFFENSIVE_LANGUAGE || message.reason > ReportAbuseReason.REAL_WORLD_TRADING) {
             World.notifyPlayerBan('automated', player.username, Date.now() + 172800000);
             return false;
         }


### PR DESCRIPTION
Automatically and immediately start tracking a player's inputs if they are reported for either macroing or abusing a bug.

Also improves types for the ReportAbuse ClientProt.