### PR TITLE
fix(engine): prevent sql errors on new user login

### DIFF
--- a/src/server/login/LoginServer.ts
+++ b/src/server/login/LoginServer.ts
@@ -87,7 +87,7 @@ export default class LoginServer {
 
                         if (!Environment.WEBSITE_REGISTRATION && !account) {
                             // register the user automatically
-                            await db
+                            const insertResult = await db
                                 .insertInto('account')
                                 .values({
                                     username,
@@ -95,13 +95,14 @@ export default class LoginServer {
                                     registration_ip: remoteAddress,
                                     registration_date: toDbDate(new Date())
                                 })
-                                .execute();
+                                .executeTakeFirst();
 
                             s.send(
                                 JSON.stringify({
                                     replyTo,
                                     response: 4,
-                                    staffmodlevel: 0
+                                    staffmodlevel: 0,
+                                    account_id: Number(insertResult.insertId),  // bigint
                                 })
                             );
                             return;


### PR DESCRIPTION
If a server is ran with `Environment.WEBSITE_REGISTRATION` **disabled**, meaning that users can login with any credentials and have an account created, there will be some SQL errors because the response from LoginServer.ts is missing the `account_id` property. Fix this by returning the primary key inserted for the new account.

![image](https://github.com/user-attachments/assets/f918aec7-1b73-4457-ab29-8bbb18f99b4c)
