### PR TITLE
fix(content): Several doors and gates have been reworked to match a recent engine change

### DIFF
--- a/data/src/scripts/quests/quest_itgronigen/scripts/quest_itgronigen.rs2
+++ b/data/src/scripts/quests/quest_itgronigen/scripts/quest_itgronigen.rs2
@@ -116,6 +116,9 @@ if(coordz(coord) > coordz(loc_coord)) {
 } else {
     p_teleport(movecoord(coord, 0, 0, 1));
 }
+
+def_coord $initial_coord = loc_coord;
+
 loc_findallzone(coord);
 while(loc_findnext = true) {
      if(loc_category = observatory_dungeon_gate) {
@@ -136,7 +139,7 @@ if(%keepdoor_unlocked = 0) {
     mes("The key is useless now. You discard it.");
     inv_del(inv, keep_key, 1);
 }
-if(coordz(coord) < coordz(loc_coord)) { 
+if(coordz(coord) <= coordz($initial_coord)) { 
     ~chatplayer("<p,neutral>I'd better be quick,|there may be more guards about.");
 }   
 

--- a/data/src/scripts/tutorial/scripts/tut_doors_and_gates.rs2
+++ b/data/src/scripts/tutorial/scripts/tut_doors_and_gates.rs2
@@ -162,28 +162,31 @@ if (%tutorial_progress = ^combat_instructor_opened_combat_interface) {
     %tutorial_progress = ^combat_instructor_before_attacking_melee;
     ~set_tutorial_progress;
 }
-~tut_open_rat_pit;
 
 if (coordx(coord) < coordx(loc_coord)) {
     p_teleport(movecoord(coord, 1, 0, 0));
 } else {
     p_teleport(movecoord(coord, -1, 0, 0));
 }
+
+~tut_open_rat_pit;
+
+
 p_delay(1);
 
 [proc,tut_open_rat_pit]
 loc_findallzone(coord);
 while(loc_findnext = true) {
-     if(loc_category = rat_pit_cage) {
-            def_coord $central_coord = loc_coord;
-            def_int $orig_angle = loc_angle;
-            loc_del(2);
-            if(loc_type = loc_3022) {
-                loc_add(movecoord($central_coord, -1, 0, 0), loc_1562, 3, loc_shape, 2);
-                loc_add(movecoord($central_coord, -1, 0, 1), loc_1563, 1, loc_shape, 2);
-            }
-            loc_add($central_coord, loc_83, $orig_angle, loc_shape, 2);
-     }
+    if(loc_category = rat_pit_cage) {
+        def_coord $central_coord = loc_coord;
+        def_int $orig_angle = loc_angle;
+        loc_del(2);
+        if(loc_type = loc_3022) {
+            loc_add(movecoord($central_coord, -1, 0, 0), loc_1562, 3, loc_shape, 2);
+            loc_add(movecoord($central_coord, -1, 0, 1), loc_1563, 1, loc_shape, 2);
+        }
+        loc_add($central_coord, loc_83, $orig_angle, loc_shape, 2);
+    }
 }
 sound_synth(door_open, 0, 0);
 

--- a/src/engine/zone/Zone.ts
+++ b/src/engine/zone/Zone.ts
@@ -431,7 +431,9 @@ export default class Zone {
     *getAllObjsSafe(): IterableIterator<Obj> {
         for (let obj = this.objs.head(); obj !== null; obj = this.objs.next()) {
             if (obj.isValid()) {
+                const save = this.locs.cursor;
                 yield obj;
+                this.locs.cursor = save;
             }
         }
     }
@@ -443,7 +445,9 @@ export default class Zone {
     *getObjsSafe(coord: number): IterableIterator<Obj> {
         for (let obj = this.objs.head(); obj !== null; obj = this.objs.next()) {
             if (obj.isValid() && CoordGrid.packZoneCoord(obj.x, obj.z) === coord) {
+                const save = this.locs.cursor;
                 yield obj;
+                this.locs.cursor = save;
             }
         }
     }
@@ -456,7 +460,9 @@ export default class Zone {
     *getObjsUnsafe(coord: number): IterableIterator<Obj> {
         for (let obj = this.objs.head(); obj !== null; obj = this.objs.next()) {
             if (CoordGrid.packZoneCoord(obj.x, obj.z) === coord) {
+                const save = this.locs.cursor;
                 yield obj;
+                this.locs.cursor = save;
             }
         }
     }
@@ -468,7 +474,9 @@ export default class Zone {
      */
     *getAllObjsUnsafe(reverse: boolean = false): IterableIterator<Obj> {
         for (let obj = reverse ? this.objs.tail() : this.objs.head(); obj !== null; obj = reverse ? this.objs.prev() : this.objs.next()) {
+            const save = this.locs.cursor;
             yield obj;
+            this.locs.cursor = save;
         }
     }
 
@@ -479,7 +487,9 @@ export default class Zone {
     *getAllLocsSafe(): IterableIterator<Loc> {
         for (let loc = this.locs.head(); loc !== null; loc = this.locs.next()) {
             if (loc.isValid()) {
+                const save = this.locs.cursor;
                 yield loc;
+                this.locs.cursor = save;
             }
         }
     }
@@ -491,7 +501,9 @@ export default class Zone {
     *getLocsSafe(coord: number): IterableIterator<Loc> {
         for (let loc = this.locs.head(); loc !== null; loc = this.locs.next()) {
             if (loc.isValid() && CoordGrid.packZoneCoord(loc.x, loc.z) === coord) {
+                const save = this.locs.cursor;
                 yield loc;
+                this.locs.cursor = save;
             }
         }
     }
@@ -504,7 +516,9 @@ export default class Zone {
     *getLocsUnsafe(coord: number): IterableIterator<Loc> {
         for (let loc = this.locs.head(); loc !== null; loc = this.locs.next()) {
             if (CoordGrid.packZoneCoord(loc.x, loc.z) === coord) {
+                const save = this.locs.cursor;
                 yield loc;
+                this.locs.cursor = save;
             }
         }
     }
@@ -516,7 +530,9 @@ export default class Zone {
      */
     *getAllLocsUnsafe(reverse: boolean = false): IterableIterator<Loc> {
         for (let loc = reverse ? this.locs.tail() : this.locs.head(); loc !== null; loc = reverse ? this.locs.prev() : this.locs.next()) {
+            const save = this.locs.cursor;
             yield loc;
+            this.locs.cursor = save;
         }
     }
 


### PR DESCRIPTION
This PR adds some safety at the engine level for iterating through Locs and Objs, so that our cursor doesn't get lost if we remove Locs and Objs while iterating. This matches our queue behavior

Also, in runescript some logic for a gate has been improved in response to a bug reported here: https://discord.com/channels/953326730632904844/1349358765878804561