### PR TITLE
fix(content): heros and grandtree fixes, extra safety for some quest queues

### DIFF
--- a/data/src/scripts/areas/area_brimhaven/scripts/alfonse_the_waiter.rs2
+++ b/data/src/scripts/areas/area_brimhaven/scripts/alfonse_the_waiter.rs2
@@ -1,7 +1,7 @@
 [opnpc1,alfonse_the_waiter]
 ~chatnpc("<p,neutral>Welcome to the Shrimp and Parrot.|Would you like to order, sir?");
 def_int $option;
-if (~hero_phoenix_in_progress = true) {
+if (%hero_progress = ^hero_phoenix_gangmember_spoken) {
     $option = ~p_choice3("Yes please.", 1, "No thank you.", 2, "Do you sell Gherkins?", 3);
 } else {
     $option = ~p_choice2("Yes please.", 1, "No thank you.", 2);
@@ -15,9 +15,7 @@ switch_int($option) {
         ~chatplayer("<p,neutral>No thank you.");
     case 3 :
         ~chatplayer("<p,quiz>Do you sell Gherkins?");
-        ~chatnpc("<p,neutral>Hmmmm Gherkins eh? Ask Charlie the cook, round the|back. He may have some 'gherkins' for you!");
+        ~chatnpc("<p,happy>Hmmmm Gherkins eh? Ask Charlie the cook, round the|back. He may have some 'gherkins' for you!");
+        %hero_progress = ^hero_phoenix_talked_alfonse;
         ~mesbox("Alfonse winks at you.");
-        if (%hero_progress = ^hero_phoenix_gangmember_spoken) {
-            %hero_progress = ^hero_phoenix_talked_alfonse;
-        }
 }

--- a/data/src/scripts/areas/area_entrana/scripts/high_priest.rs2
+++ b/data/src/scripts/areas/area_entrana/scripts/high_priest.rs2
@@ -11,7 +11,7 @@ if(%grail_progress < ^grail_finding_percival & %grail_progress >= ^grail_spoken_
     }
     @crone_the_grail;
 }
-if (~hero_in_progress = true) {
+if (%hero_progress = ^hero_started) { // only checks starting stage (OSRS)
     // OSRS https://youtu.be/9wwjNvDXjFw?t=121 
     ~chatplayer("<p,neutral>Hello, I am in search of an Entranan Firebird. Can you help me?");
     ~chatnpc("<p,neutral>Well adventurer, I have heard that they exist on this|island, but have not ever seen one myself.");

--- a/data/src/scripts/areas/area_entrana/scripts/monk_entrana.rs2
+++ b/data/src/scripts/areas/area_entrana/scripts/monk_entrana.rs2
@@ -9,7 +9,7 @@ if ($heal = 0) {
 
 [opnpc1,monk_entrana]
 ~chatnpc("<p,neutral>Greetings traveller.");
-if (~hero_in_progress = true) {
+if (%hero_progress = ^hero_started) { // only seems to be on this stage
     ~chatplayer("<p,quiz>Hello, I am in search of an Entranan Firebird. Can you help me?");
     ~chatnpc("<p,neutral>Oh ho! Another one! I don't think they exist, but you'd probably ask the head monk about it. If anyone would know, he would!");
     ~chatplayer("<p,happy>Thanks!");

--- a/data/src/scripts/areas/area_port_sarim/scripts/gerrant.rs2
+++ b/data/src/scripts/areas/area_port_sarim/scripts/gerrant.rs2
@@ -6,7 +6,7 @@ if(map_members = true & inv_total(inv, trail_clue_hard_riddle_exp004) > 0) {
 }
 ~chatnpc("<p,happy>Welcome! You can buy fishing equipment at my store.|We'll also buy anything you catch off you.");
 def_int $option;
-if (~hero_in_progress = true) {
+if (map_members = true & ~hero_in_progress = true) {
     $option = ~p_choice3("Let's see what you've got then.", 1, "Sorry, I'm not interested.", 2, "I want to find out how to catch a lava eel.", 3);
 } else {
     $option = ~p_choice2("Let's see what you've got then.", 1, "Sorry, I'm not interested.", 2);
@@ -18,12 +18,19 @@ switch_int($option) {
     case 2 :
         ~chatplayer("<p,neutral>Sorry, I'm not interested.");
     case 3 :
+        // https://youtu.be/2M-W0tUicdw?si=aM4KnZe9G3Qj3UyW&t=557, mesanims are slightly diff, maybe the checks were changed?
         ~chatplayer("<p,neutral>I want to find out how to catch a lava eel.");
-        ~chatnpc("<p,neutral>Lava eels eh? That's a tricky one that is, you'll need a|lava-proof fishing line. The method for making this would|be to take an ordinary fishing rod, and then cover it|with the fire-proof Blamish Oil.");
-        if(inv_total(inv, blamish_snail_slime) = 0) {
-            ~chatnpc("<p,neutral>You know... thinking about it... I may have a jar of|Blamish Slime around here somewhere... Now where did|I put it?");
-            ~mesbox("Gerrant searches around a bit.");
-            inv_add(inv, blamish_snail_slime, 1);
-            ~chatnpc("<p,neutral>Aha! Here it is! Take this slime, mix it with some|Harralander and water and you'll have the Blamish Oil|you need for treating your fishing rod.");
+        if(~obj_gettotal(blamish_snail_slime) > 0 | ~obj_gettotal(blamish_oil) > 0 | ~obj_gettotal(oily_fishing_rod) > 0) {
+            ~chatnpc("<p,confused>You'll need a lava-proof fishing line. I'm sure I already gave you what you need for this - take an ordinary fishing rod, and then cover it with the fire-proof Blamish Oil.");
+            return;
         }
+        ~chatnpc("<p,neutral>Lava eels eh? That's a tricky one that is, you'll need a|lava-proof fishing line. The method for making this would|be to take an ordinary fishing rod, and then cover it|with the fire-proof Blamish Oil.");
+        ~chatnpc("<p,neutral>You know... thinking about it... I may have a jar of|Blamish Slime around here somewhere... Now where did|I put it?");
+        if(inv_freespace(inv) = 0) {
+            ~chatplayer("<p,sad>Don't worry about that for now. I don't have space to take anything from you.");
+            return;
+        }
+        ~mesbox("Gerrant searches around a bit.");
+        inv_add(inv, blamish_snail_slime, 1);
+        ~chatnpc("<p,happy>Aha! Here it is! Take this slime, mix it with some|Harralander and water and you'll have the Blamish Oil|you need for treating your fishing rod.");
 }

--- a/data/src/scripts/areas/area_varrock/scripts/katrine.rs2
+++ b/data/src/scripts/areas/area_varrock/scripts/katrine.rs2
@@ -132,18 +132,19 @@ switch_int (~determine_katrine_option) {
             %hero_progress = ^hero_blackarm_gangmember_spoken;
         }
     case 4 : // Showing candlestick
-        ~chatplayer("<p,neutral>I have a candlestick now!");
+        // https://youtu.be/KRhwwgo8YHM?si=L2w_eELFNMxWG88A&t=570
+        ~chatplayer("<p,happy>I have a candlestick now!");
         ~chatnpc("<p,shock>Wow.... is... it REALLY it?");
-        ~chatnpc("<p,shock>This really is a FINE bit of thievery.");
-        ~chatnpc("<p,shock>Us thieves have been trying to get ahold of this one for a while!");
-        ~chatnpc("<p,shock>You wanted to be ranked as a master thief didn't you? Well, I guess this just about ranks as good enough!");
+        ~chatnpc("<p,happy>This really is a FINE bit of thievery.");
+        ~chatnpc("<p,happy>Us thieves have been trying to get ahold of this one for a while!");
+        ~chatnpc("<p,happy>You wanted to be ranked as a master thief didn't you? Well, I guess this just about ranks as good enough!");
+        ~mesbox("Katrine gives you a master thief armband.");
         inv_del(inv, petes_candlestick, 1);
         inv_add(inv, thieves_armband, 1);
         %hero_progress = ^hero_blackarm_obtained_armband;
-        ~mesbox("Katrine gives you a master thief armband.");
     case 5 : // Showing candlestick (did not progress quest correctly)
         ~chatplayer("<p,neutral>I have a candlestick now!");
-        ~chatnpc("<p,angry>Good for you. I'll give a master thief's armband to the one who retrieved that. I know it wasn't you.");
+        ~chatnpc("<p,neutral>Good for you. I'll give a master thief's armband to the one who retrieved that. I know it wasn't you.");
     case 6 : // Lost armband
         ~chatplayer("<p,sad>I have lost my master thief's armband...");
         ~chatnpc("<p,neutral>Lucky I 'ave a spare ain't it? Don't lose it again.");

--- a/data/src/scripts/areas/area_varrock/scripts/straven.rs2
+++ b/data/src/scripts/areas/area_varrock/scripts/straven.rs2
@@ -139,7 +139,7 @@ switch_int($option) {
     case 6 : // After heroes started, brought back valid candlestick
         ~chatnpc("<p,neutral>Hmmm. Not bad, not bad. Let's see it, make sure it's|genuine.");
         ~mesbox("You hand Straven the candlestick.");
-        ~chatplayer("<p,neutral>So is this enough to get me a master thief armband?");
+        ~chatplayer("<p,quiz>So is this enough to get me a master thief armband?");
         ~chatnpc("<p,neutral>Hmm...");
         ~chatnpc("<p,neutral>I dunno...");
         ~chatnpc("<p,neutral>Aww, go on then. I suppose I'm in a generous mood|today.");
@@ -147,8 +147,8 @@ switch_int($option) {
         inv_del(inv, petes_candlestick, 1);
         inv_add(inv, thieves_armband, 1);
         %hero_progress = ^hero_phoenix_obtained_armband;
-    case 7 : // After heroes started, brought back invalid candlestick [todo : Need real dialgue for this one]
-        ~chatnpc("<p,angry>That's not real! Come back when you get the real one.");
+    case 7 : // After heroes started, brought back invalid candlestick
+        ~chatnpc("<p,neutral>Well, in all honesty, you didn't actually retrieve it yourself, did you? You don't qualify as a master thief unless you actually steal it yourself, you know...");
     case 8 : // First chat after heroes started
         ~chatplayer("<p,quiz>How would I go about getting a master thief armband?");
         ~chatnpc("<p,neutral>Ooh... tricky stuff. Took me YEARS to get that rank.");

--- a/data/src/scripts/areas/areas_heroes_guild/scripts/achietties.rs2
+++ b/data/src/scripts/areas/areas_heroes_guild/scripts/achietties.rs2
@@ -10,9 +10,9 @@ if (%hero_progress >= ^hero_complete) {
 if (~hero_in_progress = true) {
   ~chatnpc("<p,quiz>How goes thy quest adventurer?");
   if ((inv_total(inv, fire_feather) >= 1) & (inv_total(inv, lava_eel) >= 1) & (inv_total(inv, thieves_armband) >= 1)) {
-    ~chatplayer("<p,neutral>I have all the required items.");
+    ~chatplayer("<p,happy>I have all the required items.");
     ~chatnpc("<p,neutral>I see that you have. Well done; Now, to complete the|quest, and gain entry to the Hero's Guild in your final|task all that you have to do is...");
-    ~chatplayer("<p,angry>W-what? What do you mean? There's MORE???");
+    ~chatplayer("<p,shock>W-what? What do you mean? There's MORE???");
     ~chatnpc("<p,neutral>I'm sorry, I was just having a little fun with you. Just|a little Hero's Guild humour there. What I really|meant was");
     ~chatnpc("<p,happy>Congratulations! You have completed the Hero's Guild|entry requirements! You will find the door now open|for you! Enter, Hero! And take this reward!");
     queue(hero_quest_complete, 0);
@@ -20,7 +20,7 @@ if (~hero_in_progress = true) {
     inv_del(inv, thieves_armband, 1);
     inv_del(inv, lava_eel, 1);
   } else {
-    ~chatplayer("<p,neutral>It's tough. I've not done it yet.");
+    ~chatplayer("<p,confused>It's tough. I've not done it yet.");
     ~chatnpc("<p,neutral>Remember, the items you need to enter are:");
     ~chatnpc("<p,neutral>An Entranan Firebirds' feather, A Master Thieves armband, and a cooked Lava Eel.");
     @achietties_help_dialogue;

--- a/data/src/scripts/drop tables/scripts/entrana_firebird.rs2
+++ b/data/src/scripts/drop tables/scripts/entrana_firebird.rs2
@@ -7,5 +7,5 @@ if (npc_findhero = false) {
 obj_add(npc_coord, npc_param(death_drop), 1, ^lootdrop_duration);
 // Unobtainable after hero quest
 if(%hero_progress < ^hero_complete) {
-  obj_add(npc_coord, fire_feather, 1, ^lootdrop_duration);
+  obj_add(npc_coord, fire_feather, 1, calc(^lootdrop_duration / 2));
 }

--- a/data/src/scripts/drop tables/scripts/grip.rs2
+++ b/data/src/scripts/drop tables/scripts/grip.rs2
@@ -1,13 +1,13 @@
 [ai_queue3,grip]
 gosub(npc_death);
-if (npc_findhero = false) {
-    return;
-} 
-
-if (p_finduid(uid) = true & %hero_progress = ^hero_phoenix_talked_charlie) {
-    // todo  Wiki - is this true? - "Grip's Keyring is unique to the player you are doing the quest with" 
-    %hero_progress = ^hero_phoenix_killed_grip;
+// no heropoints check
+if (finduid(%npc_aggressive_player) = true & %hero_progress = ^hero_phoenix_talked_charlie) {
+    if(p_finduid(uid) = true) %hero_progress = ^hero_phoenix_killed_grip;
+    else queue(grip_queue_progress, 0);
 }
 
 // Key appears for anyone
 obj_addall(npc_coord, npc_param(death_drop), 1, ^lootdrop_duration);
+
+[queue,grip_queue_progress]
+%hero_progress = ^hero_phoenix_killed_grip;

--- a/data/src/scripts/general_use/scripts/spade.rs2
+++ b/data/src/scripts/general_use/scripts/spade.rs2
@@ -40,7 +40,7 @@ if(map_members = true & ~trail_hasclue_inv = true) {
             if(oc_param($clue, trail_guardian) ! null) {
                 def_npc $guard = oc_param($clue, trail_guardian);
                 if($guard = zamorak_wizard & testbit(%trail_clue, 4) = false) {
-                    if(npc_find(coord, zamorak_wizard, 8, 0) = true & %npc_attacking_uid = uid) {
+                    if(npc_find(coord, zamorak_wizard, 8, 0) = true & %npc_aggressive_player = uid) {
                         return;
                     }
                     // los not low: https://www.youtube.com/watch?v=AoozFVuxWx8&t=88s, https://youtu.be/K8IepVULXYM?si=-phA8d-3sJ1ohS9H&t=26
@@ -49,7 +49,9 @@ if(map_members = true & ~trail_hasclue_inv = true) {
                     spotanim_map(smokepuff_large, npc_coord, 124, 0);
                     npc_say("Die, human!");
                     %aggressive_npc = npc_uid;
-                    %npc_attacking_uid = uid;
+                    // this prevents other players from attacking w/manual cast, this might've been a later change
+                    %npc_lastcombat = ^max_32bit_int;
+                    %npc_aggressive_player = uid;
                     npc_setmode(applayer2);
                     return;
                 }

--- a/data/src/scripts/minigames/game_trail/scripts/hard/zamorak_wizard.rs2
+++ b/data/src/scripts/minigames/game_trail/scripts/hard/zamorak_wizard.rs2
@@ -1,3 +1,17 @@
+[opnpc2,zamorak_wizard]
+if (%npc_aggressive_player ! uid) {
+    mes("It's not after you...");
+    return;
+}
+@player_combat_start;
+
+[apnpc2,zamorak_wizard] 
+if (%npc_aggressive_player ! uid) {
+    mes("It's not after you...");
+    return;
+}
+@player_combat_start_ap;
+
 [ai_applayer2,zamorak_wizard]
 npc_setmode(opplayer2);
 ~npc_cast_spell(^flames_of_zamorak, 4);
@@ -6,7 +20,7 @@ npc_setmode(opplayer2);
 ~npc_cast_spell(^flames_of_zamorak, 4);
 
 [ai_timer,zamorak_wizard]
-if(finduid(%npc_attacking_uid) = false) {
+if(finduid(%npc_aggressive_player) = false) {
     npc_del;
     return;
 }

--- a/data/src/scripts/quests/quest_arena/scripts/bouncer.rs2
+++ b/data/src/scripts/quests/quest_arena/scripts/bouncer.rs2
@@ -10,7 +10,7 @@ if(npc_findhero = true) {
 
 [queue,queue_defeat_bouncer](npc_uid $npc)
 if (npc_finduid($npc) = true) {
-    @defeat_bouncer;
+    if(distance(coord, npc_coord) < 17) @defeat_bouncer;
 }
 
 [label,defeat_bouncer]

--- a/data/src/scripts/quests/quest_arena/scripts/khazard_ogre.rs2
+++ b/data/src/scripts/quests/quest_arena/scripts/khazard_ogre.rs2
@@ -10,7 +10,7 @@ if(npc_findhero = true) {
 
 [queue,queue_defeat_khazard_ogre](npc_uid $npc)
 if (npc_finduid($npc) = true) {
-    @defeat_khazard_ogre;
+    if(distance(coord, npc_coord) < 17) @defeat_khazard_ogre;
 }
 
 [label,defeat_khazard_ogre]

--- a/data/src/scripts/quests/quest_arena/scripts/khazard_scorpion.rs2
+++ b/data/src/scripts/quests/quest_arena/scripts/khazard_scorpion.rs2
@@ -10,7 +10,7 @@ if(npc_findhero = true) {
 
 [queue,queue_defeat_khazard_scorpion](npc_uid $npc)
 if (npc_finduid($npc) = true) {
-    @defeat_khazard_scorpion;
+    if(distance(coord, npc_coord) < 17) @defeat_khazard_scorpion;
 }
 
 [label,defeat_khazard_scorpion]

--- a/data/src/scripts/quests/quest_grail/scripts/black_knight_titan.rs2
+++ b/data/src/scripts/quests/quest_grail/scripts/black_knight_titan.rs2
@@ -17,6 +17,9 @@ if(npc_findhero = true) {
 }
 
 [queue,queue_defeat_titan](npc_uid $npc)
+if(inzone(0_41_73_0_0, 2_43_73_63_63, coord) = false) { // doesn't run if you've teleported out
+    return;
+}
 if (npc_finduid($npc) = true) {
     @defeat_titan;
 }

--- a/data/src/scripts/quests/quest_grail/scripts/crone.rs2
+++ b/data/src/scripts/quests/quest_grail/scripts/crone.rs2
@@ -4,7 +4,7 @@
 
 [label,crone_the_grail]
 ~chatnpc("<p,quiz>Did you say the Grail?|You are a Grail knight, yes?|Well you'd better hurry. A Fisher King is in pain.");
-~chatplayer("<p,sad>Well I would, but I don't know where I am going!");
+~chatplayer("<p,angry>Well I would, but I don't know where I am going!");
 ~chatnpc("<p,neutral>Go to where the six heads face,|blow the whistle and away you go!");
 if(%grail_progress = ^grail_spoken_merlin) {
     %grail_progress = 4;

--- a/data/src/scripts/quests/quest_grandtree/scripts/charlie.rs2
+++ b/data/src/scripts/quests/quest_grandtree/scripts/charlie.rs2
@@ -15,9 +15,9 @@ switch_int(%grandtree_progress) {
         // https://youtu.be/LFvLBRCxFwk?si=jZsV07Dsc1uTR1WH&t=997
         ~chatnpc("<p,neutral>Hmm...you could be in luck! Before Glough had me|locked up I heard him mention that he'd left his|chest keys at his girlfriend's.");
         ~chatplayer("<p,quiz>Where does she live?");
-        %grandtree_progress = ^grandtree_clue_charlie;
         ~chatnpc("<p,neutral>Just west of the toad swamp.");
         ~chatplayer("<p,neutral>OK, I'll see what I can find.");
+        %grandtree_progress = ^grandtree_clue_charlie; // OSRS increments this earlier
     case ^grandtree_released_prison :
         ~chatplayer("<p,sad>I can't figure this out Charlie!");
         ~chatnpc("<p,neutral>Go and see the foreman in the Karamja jungle, there's a shipyard there, you might find some clues. Don't forget the password is Ka-Lu-Min; if they realise that you're not working for Glough there'll be trouble!");

--- a/data/src/scripts/quests/quest_grandtree/scripts/grandtree_black_demon.rs2
+++ b/data/src/scripts/quests/quest_grandtree/scripts/grandtree_black_demon.rs2
@@ -1,5 +1,19 @@
+[opnpc2,grandtree_black_demon]
+if (%npc_aggressive_player ! uid) {
+    mes("It's not after you...");
+    return;
+}
+@player_combat_start;
+
+[apnpc2,grandtree_black_demon] 
+if (%npc_aggressive_player ! uid) {
+    mes("It's not after you...");
+    return;
+}
+@player_combat_start_ap;
+
 [ai_timer,grandtree_black_demon]
-if(finduid(%npc_attacking_uid) = false) {
+if(finduid(%npc_aggressive_player) = false) {
     npc_del;
     return;
 }

--- a/data/src/scripts/quests/quest_grandtree/scripts/king_narnode.rs2
+++ b/data/src/scripts/quests/quest_grandtree/scripts/king_narnode.rs2
@@ -88,6 +88,12 @@ switch_int(%grandtree_progress) {
             inv_del(bank, twigs_o, ^max_32bit_int);
             @narnode_add_twigs;
         }
+        if(~obj_gettotal(translation_book) = 0) { // this one checks bank
+            ~chatplayer("<p,neutral>I've lost the translation book.");
+            ~chatnpc("<p,neutral>Don't worry, I have more.");
+            ~objbox(translation_book, "The king gives you another translation book.", 250, 0, divide(^objbox_height, 2));
+            inv_add(inv, translation_book, 1);
+        }
     case ^grandtree_found_invasion_plans :
         ~chatplayer("<p,neutral>Hi, your highness, did you think about what I said?");
         ~chatnpc("<p,neutral>Look, if you're right about Glough I would have him arrested but there's no reason for me to think he's lying.");

--- a/data/src/scripts/quests/quest_grandtree/scripts/quest_grandtree.rs2
+++ b/data/src/scripts/quests/quest_grandtree/scripts/quest_grandtree.rs2
@@ -32,21 +32,21 @@ p_arrivedelay;
 ~agility_climb_up(0, movecoord(loc_coord, -1, -1, -1));
 
 [oplocu,_grandtree_pillar]
-if(last_useitem = twigs_t | last_useitem = twigs_u | last_useitem = twigs_z | last_useitem = twigs_o) {
-    anim(human_pickuptable, 0);
-    sound_synth(put_down, 0, 0);
-    inv_dropslot(inv, loc_coord, last_useslot, 500); // 500t osrs
-    if(%grandtree_progress = ^grandtree_given_twigs & 
-        obj_find(2_38_54_53_11, twigs_t) = true & 
-        obj_find(2_38_54_54_11, twigs_u) = true & 
-        obj_find(2_38_54_55_11, twigs_z) = true & 
-        obj_find(2_38_54_56_11, twigs_o) = true) {
-        %grandtree_progress = ^grandtree_unlocked_trapdoor;
-        sound_synth(machinery, 0, 0); 
-        ~mesbox("You hear the grinding of an ancient pulley system.");
-    }
-} else {
-    mes("You cannot put that on the pillar.");
+if (oc_tradeable(last_useitem) = false) {
+    mes("You cannot put that on a pillar.");
+    return;
+}
+anim(human_pickuptable, 0);
+sound_synth(put_down, 0, 0);
+inv_dropslot(inv, loc_coord, last_useslot, 500); // 500t osrs
+if(%grandtree_progress = ^grandtree_given_twigs & 
+    obj_find(2_38_54_53_11, twigs_t) = true & 
+    obj_find(2_38_54_54_11, twigs_u) = true & 
+    obj_find(2_38_54_55_11, twigs_z) = true & 
+    obj_find(2_38_54_56_11, twigs_o) = true) {
+    %grandtree_progress = ^grandtree_unlocked_trapdoor;
+    sound_synth(machinery, 0, 0); 
+    ~mesbox("You hear the grinding of an ancient pulley system.");
 }
 
 [oploc1,loc_2444]
@@ -73,7 +73,7 @@ if(last_useitem = gloughs_key) {
     sound_synth(chest_open, 0, 0);
     p_delay(0);
     loc_change(loc_3368, 4);
-    if((%grandtree_progress = ^grandtree_found_invasion_plans | %grandtree_progress = ^grandtree_clue_charlie) & inv_total(inv, invasion_plans) = 0) {
+    if((%grandtree_progress = ^grandtree_found_invasion_plans | %grandtree_progress = ^grandtree_clue_charlie) & ~obj_gettotal(invasion_plans) = 0) {
         ~objbox(invasion_plans, "You have found a scroll!", 250, 0, 0);
         if(inv_freespace(inv) = 0) { 
             // https://youtu.be/ZNgxsI_jH_E?si=wuOkSTdEAuYDoeTc&t=697

--- a/data/src/scripts/quests/quest_hero/scripts/locs/brimhaven_restaurant.rs2
+++ b/data/src/scripts/quests/quest_hero/scripts/locs/brimhaven_restaurant.rs2
@@ -3,7 +3,7 @@ if (%hero_progress >= ^hero_phoenix_talked_alfonse & %phoenixgang_progress = ^ph
   ~open_and_close_door(loc_type, ~check_axis(coord, loc_coord, loc_angle), false);
   return;
 }
-mes("This door seems to be locked.");
+mes("This door seems to be locked...");
 
 [oploc1,brimhaven_restaurant_walldoor]
 if (%hero_progress >= ^hero_phoenix_talked_charlie) { // Only opens after talking to Charlie (https://youtu.be/kDACyq673wM?t=778)

--- a/data/src/scripts/quests/quest_hero/scripts/locs/brimhaven_scarface_mansion.rs2
+++ b/data/src/scripts/quests/quest_hero/scripts/locs/brimhaven_scarface_mansion.rs2
@@ -16,7 +16,7 @@ loc_change(grips_cupboard_opened, 500); // todo - how long to keep open?
 [label,summon_grip]
 if (npc_find(coord, pirate_guard, 4, 0) = true) {
   facesquare(npc_coord);
-  ~chatnpc("<p,neutral>I don't think Mr Grip will like you opening that. That's his private drinking cabinet.");
+  ~chatnpc("<p,confused>I don't think Mr Grip will like you opening that. That's his private drinking cabinet.");
   switch_int(~p_choice2("He won't notice me having a quick look.", 1, "Ok, I'll leave it.", 2)) {
     case 1 :
       ~chatplayer("<p,neutral>He won't notice me having a quick look.");
@@ -26,7 +26,7 @@ if (npc_find(coord, pirate_guard, 4, 0) = true) {
         npc_say("Stay out of my drinks cabinet!");
         if_close;
         p_delay(6);
-        npc_queue(10, 0, 1);
+        npc_setmode(null);
       }
     case 2 :
       ~chatplayer("<p,neutral>Ok, I'll leave it.");
@@ -76,7 +76,10 @@ loc_change(scarface_pete_candlestick_chest_open, 500); // todo - how long to kee
 
 [oploc1,scarface_pete_candlestick_chest_open]
 if (~obj_gettotal(petes_candlestick) > 0) {
-  mes("The chest is empty.");
+  ~mesbox("The chest is empty.");
+  if(inv_total(bank, petes_candlestick) > 0) {
+    ~chatplayer("<p,happy>I'm sure I've got a candlestick from this chest somewhere in my bank.");
+  }
 } else {
   ~mesbox("You find two candlesticks in the chest. So that will be one for you, and one for the person who killed Grip for you.");
   inv_add(inv, petes_candlestick, 2);

--- a/data/src/scripts/quests/quest_hero/scripts/npcs/charlie_the_cook.rs2
+++ b/data/src/scripts/quests/quest_hero/scripts/npcs/charlie_the_cook.rs2
@@ -13,18 +13,18 @@ switch_int(~p_choice3("I'm looking for a gherkin...", 1, "I'm a fellow member of
 }
 
 [label,charlie_phoenix_dialogue]
-~chatnpc("<p,neutral>Aaaaaah... a fellow Phoenix! So, tell me compadre... what|brings you to sunny Brimhaven?");
+~chatnpc("<p,happy>Aaaaaah... a fellow Phoenix! So, tell me compadre... what|brings you to sunny Brimhaven?");
 switch_int(~p_choice2("Sun, sand and the fresh sea air!", 1, "I want to steal Scarface Pete's candlesticks.", 2)) {
   case 1 :
-    ~chatplayer("<p,happy>Sun, sand and the fresh sea air!");
-    ~chatnpc("<p,nuetral>Well, can't say I blame you compadre. I used to be a|city boy myself, but have to admit it's a lot nicer living|here nowadays. Brimhaven's certainly good for it.");
+    ~chatplayer("<p,neutral>Sun, sand and the fresh sea air!");
+    ~chatnpc("<p,happy>Well, can't say I blame you compadre. I used to be a|city boy myself, but have to admit it's a lot nicer living|here nowadays. Brimhaven's certainly good for it.");
   case 2 :
     ~chatplayer("<p,neutral>I want to steal Scarface Pete's candlesticks.");
-    ~chatnpc("<p,nuetral>Ah yes, of course. The candlesticks. Well, I have to be|honest with you compadre, we haven't made much|progress in that task ourselves so far. We can however|offer");
-    ~chatnpc("<p,nuetral>a little assistance. The setting up of this restaurant was|the start of things; we have a secret door out the back|of here that leads through the back of Mr Olbors'|garden.");
-    ~chatnpc("<p,nuetral>Now, at the other side of Mr Olbors' garden, is an old|side entrance to Scarface Pete's mansion. It seems to|have been blocked off from the rest of the mansion|some years ago");
-    ~chatnpc("<p,nuetral>and we can't seem to find a way through. We're|positive this is the key to entering the house undetected|however, and I promise to let you know if we find|anything there.");
+    ~chatnpc("<p,neutral>Ah yes, of course. The candlesticks. Well, I have to be|honest with you compadre, we haven't made much|progress in that task ourselves so far. We can however|offer");
+    ~chatnpc("<p,neutral>a little assistance. The setting up of this restaurant was|the start of things; we have a secret door out the back|of here that leads through the back of Mr Olbors'|garden.");
+    if(%hero_progress < ^hero_phoenix_talked_charlie) %hero_progress = ^hero_phoenix_talked_charlie;
+    ~chatnpc("<p,neutral>Now, at the other side of Mr Olbors' garden, is an old|side entrance to Scarface Pete's mansion. It seems to|have been blocked off from the rest of the mansion|some years ago");
+    ~chatnpc("<p,neutral>and we can't seem to find a way through. We're|positive this is the key to entering the house undetected|however, and I promise to let you know if we find|anything there.");
     ~chatplayer("<p,neutral>Mind if I check it out for myself?");
-    ~chatnpc("<p,nuetral>Not at all! The more minds we have working on the|problem, the quicker we get that loot!");
-    %hero_progress = ^hero_phoenix_talked_charlie;
+    ~chatnpc("<p,neutral>Not at all! The more minds we have working on the|problem, the quicker we get that loot!");
 }

--- a/data/src/scripts/quests/quest_hero/scripts/npcs/garv.rs2
+++ b/data/src/scripts/quests/quest_hero/scripts/npcs/garv.rs2
@@ -3,13 +3,19 @@ if (~unlock_brimhaven_mansion = true) {
   return;
 }
 ~chatnpc("<p,neutral>Hello. What do you want?");
-switch_int(~p_choice2("Can I go in there?", 1, "I want for nothing!", 2)) {
+def_int $choice;
+if(%hero_progress = ^hero_complete) {
+  $choice = 2;
+} else {
+  $choice = ~p_choice2("Can I go in there?", 1, "I want for nothing!", 2);
+}
+switch_int($choice) {
   case 1 :
     ~chatplayer("<p,quiz>Can I go in there?");
     if (%hero_progress >= ^hero_blackarm_mansion_unlocked & %blackarmgang_progress >= ^blackarmgang_complete) {
-      ~chatnpc("<p,neutral>Sure."); // todo need dialogue if you talk to Garv after unlocking the door
+      ~chatnpc("<p,neutral>Yes, of course you can. You DO work here."); // todo need dialogue if you talk to Garv after unlocking the door
     } else {
-      ~chatnpc("<p,neutral>No. In there is private");
+      ~chatnpc("<p,neutral>No. In there is private.");
     }
   case 2 :
     ~chatplayer("<p,neutral>I want for nothing!");
@@ -17,6 +23,10 @@ switch_int(~p_choice2("Can I go in there?", 1, "I want for nothing!", 2)) {
 }
 
 [label,attempt_open_brimhaven_mansion_door]
+if(%hero_progress = ^hero_complete & %phoenixgang_progress >= ^phoenixgang_complete) {
+  mes("You don't have any reason to go in there.");
+  return;
+}
 if (npc_find(coord, garv, 7, 0) = true) {
   facesquare(npc_coord);
   ~chatnpc("<p,angry>Oi! Where do you think you're going pal?");
@@ -30,7 +40,7 @@ if (npc_find(coord, garv, 7, 0) = true) {
 if (%hero_progress = ^hero_blackarm_id_papers_obtained) { 
   ~chatplayer("<p,neutral>Hi. I'm Hertigen. I've come to work here.");
   if(~wearing_black_armour = false) { // https://youtu.be/rEzuCix51aM?t=1503 
-    ~chatnpc("<p,neutral>Hartigen the Black Knight? I don't think so. He doesn't dress like that"); 
+    ~chatnpc("<p,angry>Hartigen the Black Knight? I don't think so. He doesn't dress like that."); 
     return(false);
   }
   ~chatnpc("<p,neutral>I assume you have your I.D. papers then?");
@@ -39,7 +49,7 @@ if (%hero_progress = ^hero_blackarm_id_papers_obtained) {
     %hero_progress = ^hero_blackarm_mansion_unlocked;
     return(true);
   } else {
-    ~chatplayer("<p,neutral>Uh... Yeah. About that...I must have left them in my other suit of armour.");
+    ~chatplayer("<p,neutral>Uh... yeeeeaaaaah.... about that.... I must have left them in my other suit of armour....");
     return(false);
   }
 } else {

--- a/data/src/scripts/quests/quest_hero/scripts/npcs/grip.rs2
+++ b/data/src/scripts/quests/quest_hero/scripts/npcs/grip.rs2
@@ -6,8 +6,8 @@ if (%hero_progress < ^hero_blackarm_id_papers_given) {
   ~chatnpc("<p,neutral>I'll get your hours and duty roster sorted out in a while. Oh, and do you have your I.D. papers with you? Internal security is almost as important as external security for a guard.");
   if(inv_total(inv, id_papers) < 1) {
     // https://youtu.be/KRhwwgo8YHM?t=424 - OSRS talking to grip without ID paper
-    ~chatplayer("<p,neutral>Oh dear... I don't have that with me anymore..");
-    ~chatnpc("<p,neutral>Well that's no good! Go get them immediately, then report back for duty.");
+    ~chatplayer("<p,sad>Oh dear... I don't have that with me anymore..");
+    ~chatnpc("<p,angry>Well that's no good! Go get them immediately, then report back for duty.");
     return;
   }
   ~chatplayer("<p,neutral>Right here sir!");
@@ -38,7 +38,7 @@ switch_int($option) {
     ~chatplayer("<p,quiz>So what do my duties involve?");
     ~chatnpc("<p,neutral>You'll have various guard related duties on various shifts. I'll assign specific duties as the are required as and when they become necessary. Just so you know, if anything happens to me");
     ~chatnpc("<p,neutral>you'll need to take over as head guard here. You'll find important keys to the treasure room and Pete's quarters inside my jacket - although I doubt anything bad's going to happen to");
-    ~chatnpc("<p,neutral>me anytime soon!");
+    ~chatnpc("<p,laugh>me anytime soon!");
     ~mesbox("Grip laughs to himself at the thought.");
     @grip_chat_options(^grip_stage_asked_duties);
   case 3 :
@@ -49,8 +49,8 @@ switch_int($option) {
     ~chatplayer("<p,quiz>Anything I can do now?");
     if (~obj_gettotal(miscellaneous_key) < 1) {
       ~chatnpc("<p,neutral>Hmm. Well, you could find out what this key opens for me. Apparently it's for something in this building, but for the life of me I can't find what.");
-      inv_add(inv, miscellaneous_key, 1);
       ~mesbox("Grip hands you a key.");
+      inv_add(inv, miscellaneous_key, 1);
     } else {
       ~chatnpc("<p,neutral>Can't think of anything right now.");
     }
@@ -61,8 +61,5 @@ if (%hero_progress >= ^hero_phoenix_talked_charlie & %phoenixgang_progress >= ^p
   return(true);
 }
 ~chatplayer("<p,neutral>I can't attack the head guard here! There are too many witnesses around to see me do it! I'd have the whole of Brimhaven after me! Besides, if he dies I want the promotion!");
-// todo - I think theres a ~mesbox("") after the chatplayer, but I can't find the source anymore, something about find another player to help
+~mesbox("Perhaps you need another player's help...?");
 return(false);
-
-[ai_queue10,grip]
-npc_setmode(null);

--- a/data/src/scripts/quests/quest_hero/scripts/npcs/grubor.rs2
+++ b/data/src/scripts/quests/quest_hero/scripts/npcs/grubor.rs2
@@ -7,17 +7,17 @@ if (npc_find(coord, grubor, 10, 0) = true) {
   facesquare(npc_coord);
   ~chatnpc("<p,quiz>Yes? What do you want?");
   if (%hero_progress < ^hero_blackarm_gangmember_spoken | %phoenixgang_progress >= ^phoenixgang_joined) { 
-    switch_int(~p_choice3("Would you like your hedges trimming?", 1, "I want to come in", 2, "Do you want to trade?", 3)) {
+    switch_int(~p_choice3("Would you like your hedges trimming?", 1, "I want to come in.", 2, "Do you want to trade?", 3)) {
       case 1 :
         // RSC: "Would you like to have your windows refitting?" // "Don't be daft, we don't have any windows"
         ~chatplayer("<p,quiz>Would you like your hedges trimming?");
-        ~chatnpc("<p,neutral>Eh? Don't be daft! We don't even HAVE any hedges!");
+        ~chatnpc("<p,confused>Eh? Don't be daft! We don't even HAVE any hedges!");
       case 2 :
-        ~chatplayer("<p,neutral>I want to come in.");
+        ~chatplayer("<p,angry>I want to come in.");
         ~chatnpc("<p,neutral>No, go away.");
       case 3 :
         ~chatplayer("<p,quiz>Do you want to trade?");
-        ~chatnpc("<p,neutral>No I'm busy.");
+        ~chatnpc("<p,neutral>No, I'm busy.");
     }
   } else {
     switch_int(~p_choice4("Rabbit's foot.", 1, "Four leaved clover.", 2, "Lucky horseshoe.", 3, "Black cat.", 4)) {

--- a/data/src/scripts/quests/quest_hero/scripts/objs/oily_fishing_rod.rs2
+++ b/data/src/scripts/quests/quest_hero/scripts/objs/oily_fishing_rod.rs2
@@ -1,5 +1,5 @@
 [opheld1,blamish_oil]
-~chatplayer("<p,neutral>You know... I'd really rather not.");
+~chatplayer("<p,confused>You know... I'd really rather not.");
 
 [opheldu,blamish_oil]
 def_obj $used_on = inv_getobj(inv, last_slot);

--- a/data/src/scripts/quests/quest_zombiequeen/scripts/nazastarool.rs2
+++ b/data/src/scripts/quests/quest_zombiequeen/scripts/nazastarool.rs2
@@ -34,18 +34,27 @@ if (finduid(%npc_aggressive_player) = true) {
 }
 
 [queue,defeat_nazastarool1]
+if(inzone(0_45_148_0_0, 0_45_148_63_63, coord) = false) {
+    return;
+}
 %zq_map_mechanisms = setbit(%zq_map_mechanisms, ^zq_defeated_nazastarool1);
 ~mesbox("You defeat Nazastarool and the corpse falls to the ground. The bones start to move again and soon they reform into a grisly giant skeleton.");
 if_close;
 @summon_nazastarool;
 
 [queue,defeat_nazastarool2]
+if(inzone(0_45_148_0_0, 0_45_148_63_63, coord) = false) {
+    return;
+}
 %zq_map_mechanisms = setbit(%zq_map_mechanisms, ^zq_defeated_nazastarool2);
 ~mesbox("You defeat Nazastarool and the skeleton falls to the ground. An ethereal form starts taking shape above the bones and you soon face the vengeful ghost of Nazastarool.");
 if_close;
 @summon_nazastarool;
 
 [queue,defeat_nazastarool3]
+if(inzone(0_45_148_0_0, 0_45_148_63_63, coord) = false) {
+    return;
+}
 %zq_map_mechanisms = setbit(%zq_map_mechanisms, ^zq_defeated_nazastarool3);
 obj_add(0_45_148_13_15, rashiliya_corpse, 1, ^lootdrop_duration);
 queue(zq_corpseappear, 0);

--- a/data/src/scripts/quests/quest_zombiequeen/scripts/quest_zombiequeen.rs2
+++ b/data/src/scripts/quests/quest_zombiequeen/scripts/quest_zombiequeen.rs2
@@ -277,7 +277,6 @@ while(loc_findnext = true) {
      }
 }
 sound_synth(grate_open, 0, 0);
-// this moves 2 tiles in 1t on osrs w/walking speed so we can't really recreate
 if(coordz(coord) > coordz($loc_coord)) {
     p_teleport(0_45_148_49_43);
 } else {

--- a/data/src/scripts/skill_combat/scripts/npc/npc_combat.rs2
+++ b/data/src/scripts/skill_combat/scripts/npc/npc_combat.rs2
@@ -119,11 +119,6 @@ if (~player_autocast_enabled = false & ~inzone_coord_pair_table(mage_arena, coor
     return(false);
 }
 
-if ((npc_type = zamorak_wizard | npc_type = grandtree_black_demon) & %npc_attacking_uid ! uid) {
-    mes("It's not after you...");
-    return(false);
-}
-
 if(npc_type = general_khazard & %arena_progress < ^arena_freed_servils) {
     mes("I don't have time. I'm here to rescue Sir Servil and Jeremy.");
     return (false);


### PR DESCRIPTION
- Fix some mesanims/dialogue in heros quest (black arm side still needs to be looked at with rsprox)
- Made a few small updates to grandtree based on RS3
- changed grandtree_black_demon + zamorak_wizard combat checks to match OSRS
- Changed a few quest-related queues to have distance/area safety before executing