### PR TITLE
fix(content): Shop changes

### DIFF
--- a/data/src/scripts/areas/area_ardougne_east/configs/ardougne_east.inv
+++ b/data/src/scripts/areas/area_ardougne_east/configs/ardougne_east.inv
@@ -86,6 +86,7 @@ stock5=mithril_platebody,1,3000
 
 [generalshop12]
 // empty vials could be a default stock of 300
+// There is no information about the original stack size for empty vials, but in 2006 the stack size was 500 and it is very possible that this information has unchanged.
 // https://classic.runescape.wiki/w/East_Ardougne_Adventurers%27_Store
 // https://web.archive.org/web/20120207054639im_/http://runehq.com/images/cityguides/Ardougne_East/ardougne12.jpg
 scope=shared
@@ -93,7 +94,7 @@ size=40
 restock=yes
 stackall=yes
 allstock=yes
-stock1=vial_empty,250,30
+stock1=vial_empty,500,30
 stock3=bronze_pickaxe,2,100
 stock4=iron_axe,2,100
 stock5=cooked_meat,2,100

--- a/data/src/scripts/areas/area_taverly/configs/taverly.inv
+++ b/data/src/scripts/areas/area_taverly/configs/taverly.inv
@@ -8,9 +8,9 @@ size=40
 restock=yes
 stackall=yes
 allstock=no
-stock1=vial_empty,50,100
+stock1=vial_empty,800,100
 stock3=pestle_and_mortar,3,100
-stock4=eye_of_newt,50,20
+stock4=eye_of_newt,800,20
 
 [gaius_two_handed]
 // https://classic.runescape.wiki/w/Gaius%27_Two_Handed_Sword_Shop


### PR DESCRIPTION
The shop stacks of the shops changed here now match the early 2006.
but I don't know if the stacks were the same in 2004 or 2005.
because the shops stacks are significantly different compared to the runescape classic.