### PR TITLE
fix(content): settings will now close interfaces and player controls no longer queue if the player is delayed

### DIFF
--- a/data/src/scripts/_unpack/all.varp
+++ b/data/src/scripts/_unpack/all.varp
@@ -30,6 +30,7 @@ protect=no
 
 // not perm: https://youtu.be/HAeh4qE3WJ4?t=34
 [attackstyle]
+protect=no
 transmit=yes
 
 [com_stabattack]
@@ -118,6 +119,7 @@ transmit=yes
 
 // not perm: https://runescape.wiki/w/Update:Game_Improvements
 [attackstyle_magic]
+protect=no
 transmit=yes
 
 [trawler]

--- a/data/src/scripts/interface_controls/configs/player_controls.varp
+++ b/data/src/scripts/interface_controls/configs/player_controls.varp
@@ -1,7 +1,9 @@
 [auto_retaliate]
+protect=no
 transmit=yes
 scope=perm
 
 [run]
+protect=no
 clientcode=7
 transmit=yes

--- a/data/src/scripts/interface_controls/scripts/player_controls.rs2
+++ b/data/src/scripts/interface_controls/scripts/player_controls.rs2
@@ -9,7 +9,7 @@ if (p_finduid(uid) = true) {
     %auto_retaliate = ^player_auto_retaliate_on;
     return;
 }
-queue(set_auto_retaliate, 0, 0);
+%auto_retaliate = %auto_retaliate; // resync varp
 
 [if_button,controls:com_3]
 if_close; // might be strongqueued in osrs
@@ -18,25 +18,23 @@ if (p_finduid(uid) = true) {
     %auto_retaliate = ^player_auto_retaliate_off;
     return;
 }
-queue(set_auto_retaliate, 0, 1);
-
-[queue,set_auto_retaliate](int $value)
-%auto_retaliate = $value;
+%auto_retaliate = %auto_retaliate; // resync varp
 
 
 // Player run
 [if_button,controls:com_4] 
 if_close;
 if (p_finduid(uid) = true) {
+    p_clearpendingaction;
     p_run(^player_run_off);
     return;
 }
-queue(set_run, 0, 0);
+%run = %run; // resync varp
 
 [if_button,controls:com_5]
-
 if_close;
 if (p_finduid(uid) = true) {
+    p_clearpendingaction;
     if (runenergy < 100) {
         p_run(^player_run_off);
         return;
@@ -48,20 +46,8 @@ if (p_finduid(uid) = true) {
     p_run(^player_run_on);
     return;
 }
-queue(set_run, 0, 1);
+%run = %run; // resync varp
 
-[queue,set_run](int $value)
-if (%tutorial_progress = ^tutorial_open_player_controls) {
-    %tutorial_progress = ^tutorial_has_toggled_on_run;
-    ~set_tutorial_progress;
-}
-if ($value = ^player_run_on) {
-    if (runenergy < 100) {
-        p_run(^player_run_off);
-        return;
-    }
-}
-p_run($value);
 
 // emotes
 [if_button,controls:com_13] @controls_emote(emote_cry);

--- a/data/src/scripts/interface_controls/scripts/player_controls.rs2
+++ b/data/src/scripts/interface_controls/scripts/player_controls.rs2
@@ -25,7 +25,7 @@ if (p_finduid(uid) = true) {
 [if_button,controls:com_4] 
 if_close;
 if (p_finduid(uid) = true) {
-    p_stopaction; // probably changed to p_clearpendingaction ~aug 2006
+    p_clearpendingaction; // https://youtu.be/XhJ0tjJ9J60?t=62
     p_run(^player_run_off);
     return;
 }
@@ -34,7 +34,7 @@ if (p_finduid(uid) = true) {
 [if_button,controls:com_5]
 if_close;
 if (p_finduid(uid) = true) {
-    p_stopaction;
+    p_clearpendingaction;
     if (runenergy < 100) {
         p_run(^player_run_off);
         return;

--- a/data/src/scripts/interface_controls/scripts/player_controls.rs2
+++ b/data/src/scripts/interface_controls/scripts/player_controls.rs2
@@ -25,7 +25,7 @@ if (p_finduid(uid) = true) {
 [if_button,controls:com_4] 
 if_close;
 if (p_finduid(uid) = true) {
-    p_clearpendingaction;
+    p_stopaction; // probably changed to p_clearpendingaction ~aug 2006
     p_run(^player_run_off);
     return;
 }
@@ -34,7 +34,7 @@ if (p_finduid(uid) = true) {
 [if_button,controls:com_5]
 if_close;
 if (p_finduid(uid) = true) {
-    p_clearpendingaction;
+    p_stopaction;
     if (runenergy < 100) {
         p_run(^player_run_off);
         return;

--- a/data/src/scripts/interface_options/scripts/game_options.rs2
+++ b/data/src/scripts/interface_options/scripts/game_options.rs2
@@ -1,71 +1,98 @@
+// volume setting if_closes here (interupts the cooking weakqueue)
+// https://youtu.be/neAoU0yiGFY?t=98
+
 [if_button,options:com_0]
+if_close;
 %game_brightness = 1;
 
 [if_button,options:com_1]
+if_close;
 %game_brightness = 1;
 
 [if_button,options:com_2]
+if_close;
 %game_brightness = 2;
 
 [if_button,options:com_3]
+if_close;
 %game_brightness = 2;
 
 [if_button,options:com_4]
+if_close;
 %game_brightness = 3;
 
 [if_button,options:com_5]
+if_close;
 %game_brightness = 3;
 
 [if_button,options:com_6]
+if_close;
 %game_brightness = 4;
 
 [if_button,options:com_7]
+if_close;
 %game_brightness = 4;
 
 [if_button,options:com_8]
+if_close;
 %mouse_buttons = 0;
 
 [if_button,options:com_9]
+if_close;
 %mouse_buttons = 1;
 
 [if_button,options:com_10]
+if_close;
 %chat_effects = 0;
 
 [if_button,options:com_11]
+if_close;
 %chat_effects = 1;
 
 [if_button,options:com_25]
+if_close;
 %music_volume = 4;
 
 [if_button,options:com_26]
+if_close;
 %music_volume = 3;
 
 [if_button,options:com_27]
+if_close;
 %music_volume = 2;
 
 [if_button,options:com_28]
+if_close;
 %music_volume = 1;
 
 [if_button,options:com_29]
+if_close;
 %music_volume = 0;
 
 [if_button,options:com_36]
+if_close;
 %sound_volume = 4;
 
 [if_button,options:com_37]
+if_close;
 %sound_volume = 3;
 
 [if_button,options:com_38]
+if_close;
 %sound_volume = 2;
 
 [if_button,options:com_39]
+if_close;
 %sound_volume = 1;
 
 [if_button,options:com_40]
+if_close;
 %sound_volume = 0;
 
 [if_button,options:com_47]
+if_close;
 %split_privatechat = 1;
 
 [if_button,options:com_48]
+if_close;
 %split_privatechat = 0;

--- a/data/src/scripts/interface_options/scripts/game_options_ld.rs2
+++ b/data/src/scripts/interface_options/scripts/game_options_ld.rs2
@@ -1,43 +1,57 @@
 // low-detail game options interface, no music/sound controls
 
 [if_button,options_ld:com_0]
+if_close;
 %game_brightness = 1;
 
 [if_button,options_ld:com_1]
+if_close;
 %game_brightness = 1;
 
 [if_button,options_ld:com_2]
+if_close;
 %game_brightness = 2;
 
 [if_button,options_ld:com_3]
+if_close;
 %game_brightness = 2;
 
 [if_button,options_ld:com_4]
+if_close;
 %game_brightness = 3;
 
 [if_button,options_ld:com_5]
+if_close;
 %game_brightness = 3;
 
 [if_button,options_ld:com_6]
+if_close;
 %game_brightness = 4;
 
 [if_button,options_ld:com_7]
+if_close;
 %game_brightness = 4;
 
 [if_button,options_ld:com_8]
+if_close;
 %mouse_buttons = 0;
 
 [if_button,options_ld:com_9]
+if_close;
 %mouse_buttons = 1;
 
 [if_button,options_ld:com_10]
+if_close;
 %chat_effects = 0;
 
 [if_button,options_ld:com_11]
+if_close;
 %chat_effects = 1;
 
 [if_button,options_ld:com_28]
+if_close;
 %split_privatechat = 1;
 
 [if_button,options_ld:com_29]
+if_close;
 %split_privatechat = 0;

--- a/data/src/scripts/skill_combat/scripts/player/player_attackstyles.rs2
+++ b/data/src/scripts/skill_combat/scripts/player/player_attackstyles.rs2
@@ -76,8 +76,6 @@ if (p_finduid(uid) = true) {
     %attackstyle_magic = togglebit(%attackstyle_magic, 0);
     return;
 }
-queue(set_attack_style_magic, 0);
-
 
 [proc,set_attackstyle](int $style)
 if_close;
@@ -86,14 +84,7 @@ if (p_finduid(uid) = true) {
     ~player_combat_stat;
     return;
 }
-queue(set_attackstyle, 0, $style);
-
-[queue,set_attackstyle](int $style)
-%attackstyle = $style;
-~player_combat_stat;
-
-[queue,set_attack_style_magic]
-%attackstyle_magic = togglebit(%attackstyle_magic, 0);
+%attackstyle = %attackstyle; // resync varp
 
 // updates the attack style tab depending on the
 // weapon currently equipped or not by the player

--- a/data/src/scripts/skill_combat/scripts/player/player_magic.rs2
+++ b/data/src/scripts/skill_combat/scripts/player/player_magic.rs2
@@ -138,13 +138,6 @@ while ($i < db_getfieldcount($spell_data, magic_spell_table:stat_change) & $spel
 }
 return(true);
 
-
-// check if crumble undead & npc is undead
-if ($spell = ^crumble_undead & npc_param(undead) = ^false) {
-    mes("This spell only affects skeletons, zombies, ghosts and shades.");
-    return(false);
-}
-
 [proc,pvm_spell_cast](dbrow $spell_data)(int)
 ~delete_spell_runes($spell_data);
 ~give_spell_xp($spell_data);

--- a/data/src/scripts/skill_prayer/scripts/prayer.rs2
+++ b/data/src/scripts/skill_prayer/scripts/prayer.rs2
@@ -17,25 +17,6 @@ if (~duel_arena_prayer_check = false) {
 }
 return(true);
 
-[queue,prayer_activate](int $prayer)
-switch_int($prayer) {
-    case ^prayer_thickskin : @activate_prayer_thickskin;
-    case ^prayer_strengthburst : @activate_prayer_strengthburst;
-    case ^prayer_clarity : @activate_prayer_clarity;
-    case ^prayer_rockskin : @activate_prayer_rockskin;
-    case ^prayer_superhumanstrength : @activate_prayer_superhumanstrength;
-    case ^prayer_improvedreflexes : @activate_prayer_improvedreflexes;
-    case ^prayer_rapidrestore : @activate_prayer_rapidrestore;
-    case ^prayer_rapidheal : @activate_prayer_rapidheal;
-    case ^prayer_protectitems : @activate_prayer_protectitems;
-    case ^prayer_steelskin : @activate_prayer_steelskin;
-    case ^prayer_ultimatestrength : @activate_prayer_ultimatestrength;
-    case ^prayer_incrediblereflexes : @activate_prayer_incrediblereflexes;
-    case ^prayer_protectfrommagic : @activate_prayer_protectfrommagic;
-    case ^prayer_protectfrommissiles : @activate_prayer_protectfrommissiles;
-    case ^prayer_protectfrommelee : @activate_prayer_protectfrommelee;
-}
-
 [proc,prayer_activate](dbrow $data, int $start)
 ~prayer_deactivate_conflicting($data);
 sound_synth(db_getfield($data, prayers:sound, 0), 0, 0);

--- a/data/src/scripts/skill_prayer/scripts/prayers/clarity.rs2
+++ b/data/src/scripts/skill_prayer/scripts/prayers/clarity.rs2
@@ -2,9 +2,8 @@
 if_close;
 if (p_finduid(uid) = true) {
     @activate_prayer_clarity;
-} else {
-    queue(prayer_activate, 0, 7);
 }
+%prayer_clarity = %prayer_clarity; // resync varp
 
 [label,activate_prayer_clarity]
 def_dbrow $data = ~get_prayer_data(^prayer_clarity);

--- a/data/src/scripts/skill_prayer/scripts/prayers/improvedreflexes.rs2
+++ b/data/src/scripts/skill_prayer/scripts/prayers/improvedreflexes.rs2
@@ -2,9 +2,8 @@
 if_close;
 if (p_finduid(uid) = true) {
     @activate_prayer_improvedreflexes;
-} else {
-    queue(prayer_activate, 0, 8);
 }
+%prayer_improvedreflexes = %prayer_improvedreflexes; // resync varp
 
 [label,activate_prayer_improvedreflexes]
 def_dbrow $data = ~get_prayer_data(^prayer_improvedreflexes);

--- a/data/src/scripts/skill_prayer/scripts/prayers/incrediblereflexes.rs2
+++ b/data/src/scripts/skill_prayer/scripts/prayers/incrediblereflexes.rs2
@@ -2,9 +2,8 @@
 if_close;
 if (p_finduid(uid) = true) {
     @activate_prayer_incrediblereflexes;
-} else {
-    queue(prayer_activate, 0, 9);
 }
+%prayer_incrediblereflexes = %prayer_incrediblereflexes; // resync varp
 
 [label,activate_prayer_incrediblereflexes]
 def_dbrow $data = ~get_prayer_data(^prayer_incrediblereflexes);

--- a/data/src/scripts/skill_prayer/scripts/prayers/protectfrommagic.rs2
+++ b/data/src/scripts/skill_prayer/scripts/prayers/protectfrommagic.rs2
@@ -2,9 +2,8 @@
 if_close;
 if (p_finduid(uid) = true) {
     @activate_prayer_protectfrommagic;
-} else {
-    queue(prayer_activate, 0, 13);
 }
+%prayer_protectfrommagic = %prayer_protectfrommagic;
 
 [label,activate_prayer_protectfrommagic]
 def_dbrow $data = ~get_prayer_data(^prayer_protectfrommagic);

--- a/data/src/scripts/skill_prayer/scripts/prayers/protectfrommelee.rs2
+++ b/data/src/scripts/skill_prayer/scripts/prayers/protectfrommelee.rs2
@@ -2,9 +2,8 @@
 if_close;
 if (p_finduid(uid) = true) {
     @activate_prayer_protectfrommelee;
-} else {
-    queue(prayer_activate, 0, 15);
 }
+%prayer_protectfrommelee = %prayer_protectfrommelee;
 
 [label,activate_prayer_protectfrommelee]
 def_dbrow $data = ~get_prayer_data(^prayer_protectfrommelee);

--- a/data/src/scripts/skill_prayer/scripts/prayers/protectfrommissiles.rs2
+++ b/data/src/scripts/skill_prayer/scripts/prayers/protectfrommissiles.rs2
@@ -2,9 +2,8 @@
 if_close;
 if (p_finduid(uid) = true) {
     @activate_prayer_protectfrommissiles;
-} else {
-    queue(prayer_activate, 0, 14);
 }
+%prayer_protectfrommissiles = %prayer_protectfrommissiles;
 
 [label,activate_prayer_protectfrommissiles]
 def_dbrow $data = ~get_prayer_data(^prayer_protectfrommissiles);

--- a/data/src/scripts/skill_prayer/scripts/prayers/protectitems.rs2
+++ b/data/src/scripts/skill_prayer/scripts/prayers/protectitems.rs2
@@ -2,9 +2,8 @@
 if_close;
 if (p_finduid(uid) = true) {
     @activate_prayer_protectitems;
-} else {
-    queue(prayer_activate, 0, 12);
 }
+%prayer_protectitems = %prayer_protectitems;
 
 [label,activate_prayer_protectitems]
 def_dbrow $data = ~get_prayer_data(^prayer_protectitems);

--- a/data/src/scripts/skill_prayer/scripts/prayers/rapidheal.rs2
+++ b/data/src/scripts/skill_prayer/scripts/prayers/rapidheal.rs2
@@ -2,9 +2,8 @@
 if_close;
 if (p_finduid(uid) = true) {
     @activate_prayer_rapidheal;
-} else {
-    queue(prayer_activate, 0, 11);
 }
+%prayer_rapidheal = %prayer_rapidheal;
 
 [label,activate_prayer_rapidheal]
 def_dbrow $data = ~get_prayer_data(^prayer_rapidheal);

--- a/data/src/scripts/skill_prayer/scripts/prayers/rapidrestore.rs2
+++ b/data/src/scripts/skill_prayer/scripts/prayers/rapidrestore.rs2
@@ -2,9 +2,8 @@
 if_close;
 if (p_finduid(uid) = true) {
     @activate_prayer_rapidrestore;
-} else {
-    queue(prayer_activate, 0, 10);
 }
+%prayer_rapidrestore = %prayer_rapidrestore;
 
 
 [label,activate_prayer_rapidrestore]

--- a/data/src/scripts/skill_prayer/scripts/prayers/rockskin.rs2
+++ b/data/src/scripts/skill_prayer/scripts/prayers/rockskin.rs2
@@ -2,9 +2,8 @@
 if_close;
 if (p_finduid(uid) = true) {
     @activate_prayer_rockskin;
-} else {
-    queue(prayer_activate, 0, 2);
 }
+%prayer_rockskin = %prayer_rockskin;
 
 [label,activate_prayer_rockskin]
 def_dbrow $data = ~get_prayer_data(^prayer_rockskin);

--- a/data/src/scripts/skill_prayer/scripts/prayers/steelskin.rs2
+++ b/data/src/scripts/skill_prayer/scripts/prayers/steelskin.rs2
@@ -2,9 +2,8 @@
 if_close;
 if (p_finduid(uid) = true) {
     @activate_prayer_steelskin;
-} else {
-    queue(prayer_activate, 0, 3);
 }
+%prayer_steelskin = %prayer_steelskin;
 
 [label,activate_prayer_steelskin]
 def_dbrow $data = ~get_prayer_data(^prayer_steelskin);

--- a/data/src/scripts/skill_prayer/scripts/prayers/strengthburst.rs2
+++ b/data/src/scripts/skill_prayer/scripts/prayers/strengthburst.rs2
@@ -2,9 +2,9 @@
 if_close;
 if (p_finduid(uid) = true) {
     @activate_prayer_strengthburst;
-} else {
-    queue(prayer_activate, 0, 4);
 }
+%prayer_strengthburst = %prayer_strengthburst;
+
 [label,activate_prayer_strengthburst]
 def_dbrow $data = ~get_prayer_data(^prayer_strengthburst);
 if ($data = null) {

--- a/data/src/scripts/skill_prayer/scripts/prayers/superhumanstrength.rs2
+++ b/data/src/scripts/skill_prayer/scripts/prayers/superhumanstrength.rs2
@@ -2,9 +2,8 @@
 if_close;
 if (p_finduid(uid) = true) {
     @activate_prayer_superhumanstrength;
-} else {
-    queue(prayer_activate, 0, 5);
 }
+%prayer_superhumanstrength = %prayer_superhumanstrength;
 
 [label,activate_prayer_superhumanstrength]
 def_dbrow $data = ~get_prayer_data(^prayer_superhumanstrength);

--- a/data/src/scripts/skill_prayer/scripts/prayers/thickskin.rs2
+++ b/data/src/scripts/skill_prayer/scripts/prayers/thickskin.rs2
@@ -2,9 +2,8 @@
 if_close;
 if (p_finduid(uid) = true) {
     @activate_prayer_thickskin;
-} else {
-    queue(prayer_activate, 0, 1);
 }
+%prayer_thickskin = %prayer_thickskin;
 
 [label,activate_prayer_thickskin]
 def_dbrow $data = ~get_prayer_data(^prayer_thickskin);

--- a/data/src/scripts/skill_prayer/scripts/prayers/ultimatestrength.rs2
+++ b/data/src/scripts/skill_prayer/scripts/prayers/ultimatestrength.rs2
@@ -2,9 +2,8 @@
 if_close;
 if (p_finduid(uid) = true) {
     @activate_prayer_ultimatestrength;
-} else {
-    queue(prayer_activate, 0, 6);
 }
+%prayer_ultimatestrength = %prayer_ultimatestrength;
 
 [label,activate_prayer_ultimatestrength]
 def_dbrow $data = ~get_prayer_data(^prayer_ultimatestrength);

--- a/data/src/scripts/tutorial/scripts/tut_chatbox_steps.rs2
+++ b/data/src/scripts/tutorial/scripts/tut_chatbox_steps.rs2
@@ -112,7 +112,7 @@ if (p_finduid(uid) = true) {
     p_run(^player_run_off);
     return;
 }
-queue(set_run, 0, 0);
+%run = %run;
 ~tutorialstep("Running.", "In this menu you will see many options from waving to walking.|At the top of the panel there are two buttons. One is walk the|other one is run. Click on the run button.");
 
 [proc,tutorial_step_enter_quest_guide_house]

--- a/src/engine/script/ScriptOpcodePointers.ts
+++ b/src/engine/script/ScriptOpcodePointers.ts
@@ -501,8 +501,8 @@ const ScriptOpcodePointers: {
         require2: ['active_player2']
     },
     [ScriptOpcode.P_RUN]: {
-        require: ['active_player'],
-        require2: ['active_player2']
+        require: ['p_active_player'],
+        require2: ['p_active_player2']
     },
 
     // Npc ops

--- a/src/engine/script/handlers/PlayerOps.ts
+++ b/src/engine/script/handlers/PlayerOps.ts
@@ -1084,7 +1084,7 @@ const PlayerOps: CommandHandlers = {
         state.activePlayer.addWealthLog(isGained ? amount : -amount, event);
     }),
 
-    [ScriptOpcode.P_RUN]: checkedHandler(ActivePlayer, state => {
+    [ScriptOpcode.P_RUN]: checkedHandler(ProtectedActivePlayer, state => {
         state.activePlayer.run = state.popInt();
 
         // todo: better way to sync engine varp


### PR DESCRIPTION
- settings will now close interfaces (and disrupt future weakqueues) to match: https://youtu.be/neAoU0yiGFY?t=98
- Prayers, attack styles, run/walk, and auto retaliate buttons no longer queue if delayed to match:
    - [x] prayers: https://youtu.be/S0n4CvdgxQQ?t=200
    - [x] attack styles: https://youtu.be/ybWVCbLNOH4?t=30
    - [x] run: https://youtu.be/fu3V6gn4WWM?t=218
    - [ ] auto retal (implemented)
- Various buttons now clears interactions: 
    - [x] Run: https://youtu.be/In1lqK9SkLc?t=93, https://youtu.be/vLIp6qzwVMY?t=20, https://youtu.be/4KR2iQnH0mo?t=352
    - [x] attack styles: https://youtu.be/tASWhjUt8wg?t=25
    - [ ] unequipping a weapon (not implemented; need confirmation!!!!)
    - [x] auto retal: https://oldschool.runescape.wiki/w/Update:Slayer_Cave_%26_High_Risk_Worlds
