### PR TITLE
fix(engine): pop_varn command & cleanup

### DIFF
--- a/src/engine/script/handlers/CoreOps.ts
+++ b/src/engine/script/handlers/CoreOps.ts
@@ -2,6 +2,8 @@ import ScriptVarType from '#/cache/config/ScriptVarType.js';
 import VarNpcType from '#/cache/config/VarNpcType.js';
 import VarPlayerType from '#/cache/config/VarPlayerType.js';
 import VarSharedType from '#/cache/config/VarSharedType.js';
+import Npc from '#/engine/entity/Npc.js';
+import Player from '#/engine/entity/Player.js';
 import ScriptFile from '#/engine/script/ScriptFile.js';
 import ScriptOpcode from '#/engine/script/ScriptOpcode.js';
 import { ProtectedActivePlayer } from '#/engine/script/ScriptPointer.js';
@@ -21,27 +23,27 @@ const CoreOps: CommandHandlers = {
     },
 
     [ScriptOpcode.PUSH_VARP]: state => {
-        const secondary = (state.intOperand >> 16) & 0x1;
-        if (secondary && !state._activePlayer2) {
-            throw new Error('No secondary active_player.');
-        } else if (!secondary && !state._activePlayer) {
-            throw new Error('No active_player.');
+        const secondary: number = (state.intOperand >> 16) & 0x1;
+        const player: Player | null = secondary ? state._activePlayer2 : state._activePlayer;
+
+        if (!player) {
+            throw new Error(`No ${secondary ? 'secondary' : 'primary'} active_player.`);
         }
 
         const varpType: VarPlayerType = check(state.intOperand & 0xffff, VarPlayerValid);
         if (varpType.type === ScriptVarType.STRING) {
-            state.pushString(secondary ? (state._activePlayer2!.getVar(varpType.id) as string) : (state._activePlayer!.getVar(varpType.id) as string));
+            state.pushString(player.getVar(varpType.id) as string);
         } else {
-            state.pushInt(secondary ? (state._activePlayer2!.getVar(varpType.id) as number) : (state._activePlayer!.getVar(varpType.id) as number));
+            state.pushInt(player.getVar(varpType.id) as number);
         }
     },
 
     [ScriptOpcode.POP_VARP]: state => {
-        const secondary = (state.intOperand >> 16) & 0x1;
-        if (secondary && !state._activePlayer2) {
-            throw new Error('No secondary active_player.');
-        } else if (!secondary && !state._activePlayer) {
-            throw new Error('No active_player.');
+        const secondary: number = (state.intOperand >> 16) & 0x1;
+        const player: Player | null = secondary ? state._activePlayer2 : state._activePlayer;
+
+        if (!player) {
+            throw new Error(`No ${secondary ? 'secondary' : 'primary'} active_player.`);
         }
 
         const varpType: VarPlayerType = check(state.intOperand & 0xffff, VarPlayerValid);
@@ -50,61 +52,41 @@ const CoreOps: CommandHandlers = {
         }
 
         if (varpType.type === ScriptVarType.STRING) {
-            const value = state.popString();
-            if (secondary) {
-                state._activePlayer2!.setVar(varpType.id, value);
-            } else {
-                state._activePlayer!.setVar(varpType.id, value);
-            }
+            player.setVar(varpType.id, state.popString());
         } else {
-            const value = state.popInt();
-            if (secondary) {
-                state._activePlayer2!.setVar(varpType.id, value);
-            } else {
-                state._activePlayer!.setVar(varpType.id, value);
-            }
+            player.setVar(varpType.id, state.popInt());
         }
     },
 
     [ScriptOpcode.PUSH_VARN]: state => {
-        const secondary = (state.intOperand >> 16) & 0x1;
-        if (secondary && !state._activeNpc2) {
-            throw new Error('No secondary active_npc.');
-        } else if (!secondary && !state._activeNpc) {
-            throw new Error('No active_npc.');
+        const secondary: number = (state.intOperand >> 16) & 0x1;
+        const npc: Npc | null = secondary ? state._activeNpc2 : state._activeNpc;
+
+        if (!npc) {
+            throw new Error(`No ${secondary ? 'secondary' : 'primary'} active_npc.`);
         }
 
         const varnType: VarNpcType = check(state.intOperand & 0xffff, VarNpcValid);
         if (varnType.type === ScriptVarType.STRING) {
-            state.pushString(secondary ? (state._activeNpc2!.getVar(varnType.id) as string) : (state._activeNpc!.getVar(varnType.id) as string));
+            state.pushString(npc.getVar(varnType.id) as string);
         } else {
-            state.pushInt(secondary ? (state._activeNpc2!.getVar(varnType.id) as number) : (state._activeNpc!.getVar(varnType.id) as number));
+            state.pushInt(npc.getVar(varnType.id) as number);
         }
     },
 
     [ScriptOpcode.POP_VARN]: state => {
-        const secondary = (state.intOperand >> 16) & 0x1;
-        if (secondary && !state._activeNpc2) {
-            throw new Error('No secondary active_npc.');
-        } else if (!secondary && !state._activeNpc) {
-            throw new Error('No active_npc.');
+        const secondary: number = (state.intOperand >> 16) & 0x1;
+        const npc: Npc | null = secondary ? state._activeNpc2 : state._activeNpc;
+
+        if (!npc) {
+            throw new Error(`No ${secondary ? 'secondary' : 'primary'} active_npc.`);
         }
 
         const varnType: VarNpcType = check(state.intOperand & 0xffff, VarNpcValid);
         if (varnType.type === ScriptVarType.STRING) {
-            const value = state.popInt();
-            if (secondary) {
-                state._activeNpc2!.setVar(varnType.id, value);
-            } else {
-                state._activeNpc!.setVar(varnType.id, value);
-            }
+            npc.setVar(varnType.id, state.popString());
         } else {
-            const value = state.popInt();
-            if (secondary) {
-                state._activeNpc2!.setVar(varnType.id, value);
-            } else {
-                state._activeNpc!.setVar(varnType.id, value);
-            }
+            npc.setVar(varnType.id, state.popInt());
         }
     },
 


### PR DESCRIPTION
- Fixes `pop_varn` was popping a number instead of a string for varn type string.
- Simplify the command impls and to no longer need the forced `!` in the code.