### PR TITLE
chore(db): remove unused database table, low priority

### DIFF
--- a/prisma/multiworld/migrations/20250314194454_remove_input_report_event_table/migration.sql
+++ b/prisma/multiworld/migrations/20250314194454_remove_input_report_event_table/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - You are about to drop the `input_report_event` table. If the table is not empty, all the data it contains will be lost.
+
+*/
+-- DropTable
+DROP TABLE `input_report_event`;

--- a/prisma/multiworld/schema.prisma
+++ b/prisma/multiworld/schema.prisma
@@ -186,20 +186,6 @@ model input_report {
     session_uuid String
 }
 
-model input_report_event {
-    input_report_id Int
-    seq             Int
-
-    input_type Int  @default(-1)
-    delta      Int
-    coord      Int
-    mouse_x    Int?
-    mouse_y    Int?
-    key_code   Int?
-
-    @@id([input_report_id, seq])
-}
-
 model input_report_event_raw {
     input_report_id Int
     seq             Int

--- a/prisma/singleworld/migrations/20250314194559_remove_input_report_event_table/migration.sql
+++ b/prisma/singleworld/migrations/20250314194559_remove_input_report_event_table/migration.sql
@@ -1,0 +1,10 @@
+/*
+  Warnings:
+
+  - You are about to drop the `input_report_event` table. If the table is not empty, all the data it contains will be lost.
+
+*/
+-- DropTable
+PRAGMA foreign_keys=off;
+DROP TABLE "input_report_event";
+PRAGMA foreign_keys=on;

--- a/prisma/singleworld/schema.prisma
+++ b/prisma/singleworld/schema.prisma
@@ -186,20 +186,6 @@ model input_report {
     session_uuid    String
 }
 
-model input_report_event {
-    input_report_id Int
-    seq             Int
-    
-    input_type      Int    @default(-1)
-    delta           Int
-    coord           Int
-    mouse_x         Int?
-    mouse_y         Int?
-    key_code        Int?
-    
-    @@id([input_report_id, seq])
-}
-
 model input_report_event_raw {
     input_report_id Int
     seq             Int

--- a/src/db/types.ts
+++ b/src/db/types.ts
@@ -1,5 +1,7 @@
 import type { ColumnType } from 'kysely';
-export type Generated<T> = T extends ColumnType<infer S, infer I, infer U> ? ColumnType<S, I | undefined, U> : ColumnType<T, T | undefined, T>;
+export type Generated<T> = T extends ColumnType<infer S, infer I, infer U>
+  ? ColumnType<S, I | undefined, U>
+  : ColumnType<T, T | undefined, T>;
 export type Timestamp = ColumnType<Date, Date | string, Date | string>;
 
 export type account = {
@@ -62,16 +64,6 @@ export type input_report = {
     account_id: number;
     timestamp: string;
     session_uuid: string;
-};
-export type input_report_event = {
-    input_report_id: number;
-    seq: number;
-    input_type: Generated<number>;
-    delta: number;
-    coord: number;
-    mouse_x: number | null;
-    mouse_y: number | null;
-    key_code: number | null;
 };
 export type input_report_event_raw = {
     input_report_id: number;
@@ -168,7 +160,6 @@ export type DB = {
     hiscore_large: hiscore_large;
     ignorelist: ignorelist;
     input_report: input_report;
-    input_report_event: input_report_event;
     input_report_event_raw: input_report_event_raw;
     ipban: ipban;
     login: login;


### PR DESCRIPTION
Switching to raw input_report_events has proven the better play, and the older data is no longer needed at this point.