### PR TITLE
fix(engine): Added extra logic to safeguard devs from resurrecting stale Locs 

### DIFF
--- a/data/src/scripts/_test/scripts/cheats/cheat_zone.rs2
+++ b/data/src/scripts/_test/scripts/cheats/cheat_zone.rs2
@@ -29,6 +29,17 @@ if (p_finduid(uid) = true) {
     loc_del(100);
 }
 
+[debugproc,loc_del_change]
+if (p_finduid(uid) = true) {
+    p_telejump(0_37_55_32_30);
+    p_delay(0);
+    loc_add(0_37_55_32_30, loc_1276, 0, centrepiece_straight, 10);
+    p_delay(0);
+    loc_del(100);
+    p_delay(0);
+    loc_change(loc_2732, 10);
+}
+
 
 [debugproc,loc_add_static]
 if (p_finduid(uid) = true) {

--- a/src/engine/World.ts
+++ b/src/engine/World.ts
@@ -1331,6 +1331,10 @@ class World {
     }
 
     changeLoc(loc: Loc, typeID: number, shape: number, angle: number, duration: number) {
+        // If a dynamic loc is inactive, it should never return to the game world
+        if (loc.lifecycle === EntityLifeCycle.DESPAWN && !loc.isValid()) {
+            return;
+        }
         // Remove previous collision from game world
         const fromType: LocType = LocType.get(loc.type);
         if (fromType.blockwalk) {


### PR DESCRIPTION
Very small fix that should have been addressed in the last PR

```
[debugproc,loc_del_change]
if (p_finduid(uid) = true) {
    p_telejump(0_37_55_32_30);
    p_delay(0);
    loc_add(0_37_55_32_30, loc_1276, 0, centrepiece_straight, 10);
    p_delay(0);
    loc_del(100);
    p_delay(0);
    loc_change(loc_2732, 10);
}
```

Adding a static loc, deleting it, and then changing it would bring it back to life before this PR. This is an issue because a dynamic loc gets removed from the Zone when deleting (unlike a static Loc). Now, the `loc_change` just gets discarded via an early return 🤷