### PR TITLE
fix(config): set no-unused-vars to error

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -40,21 +40,14 @@ export default [
              * Allows constant conditions in loops but not in if statements
              */
             'no-constant-condition': ['error', { checkLoops: false }],
-
-            /**
-             * (jkm) this rule is included in the default ruleset, we should consider
-             * resolving the issues and setting it to error
-             * https://eslint.org/docs/latest/rules/no-case-declarations
-             */
-            'no-case-declarations': 'warn',
-
+            'no-case-declarations': 'error',
+            '@typescript-eslint/no-namespace': 'error',
             /**
              * (jkm)
-             * The following rules are included in @typescript-eslint/recommended
-             * I have set them to warn instead of error, to avoid having to fix them
-             * We should consider fixing them and setting them to error
+             * The following rule is included in @typescript-eslint/recommended
+             * I have set it to warn instead of error, to avoid having to fix it
+             * We should consider fixing it and setting it to error
              */
-            '@typescript-eslint/no-namespace': 'warn',
             '@typescript-eslint/no-explicit-any': 'warn',
 
             '@typescript-eslint/no-unused-vars': [

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -23,8 +23,8 @@ export default [
     {
         settings: {
             'import/resolver': {
-                'node': true,
-                'typescript': true
+                node: true,
+                typescript: true
             }
         }
     },
@@ -58,22 +58,23 @@ export default [
             '@typescript-eslint/no-explicit-any': 'warn',
 
             '@typescript-eslint/no-unused-vars': [
-                // TODO: Set to error
-                'warn',
+                'error',
                 {
                     /**
                      * Allow variables prefixed with underscores to skip this rule.
                      * There aren't many good reasons to have unused variables,
                      * but the codebase has 100s of them.
                      */
-                    'vars': 'all',
-                    'varsIgnorePattern': '^_',
+                    vars: 'all',
+                    varsIgnorePattern: '^_',
                     /**
-                    * Allow parameters prefixed with underscores to skip this rule.
-                    * This is a common practice for router methods with req and res parameters.
-                    */
-                    'args': 'all',
-                    'argsIgnorePattern': '^_',
+                     * Allow parameters prefixed with underscores to skip this rule.
+                     * This is a common practice for router methods with req and res parameters.
+                     */
+                    args: 'all',
+                    argsIgnorePattern: '^_',
+                    caughtErrors: 'all',
+                    caughtErrorsIgnorePattern: '^_'
                 }
             ],
 

--- a/src/db/query.ts
+++ b/src/db/query.ts
@@ -34,22 +34,7 @@ function logVerbose(event: LogEvent) {
 }
 
 export const db = new Kysely<DB>({
-    dialect:
-        Environment.DB_BACKEND === 'sqlite'
-            ? new SqliteDialect({
-                database: async () => new Database('db.sqlite')
-            })
-            : new MysqlDialect({
-                pool: async () =>
-                    createPool({
-                        database: Environment.DB_NAME,
-                        host: Environment.DB_HOST,
-                        port: Environment.DB_PORT,
-                        user: Environment.DB_USER,
-                        password: Environment.DB_PASS,
-                        timezone: 'Z'
-                    })
-            }),
+    dialect,
     log: Environment.KYSELY_VERBOSE ? logVerbose : []
 });
 

--- a/src/engine/World.ts
+++ b/src/engine/World.ts
@@ -323,7 +323,7 @@ class World {
             this.loginThread.postMessage({
                 type: 'world_startup'
             });
-    
+
             this.friendThread.postMessage({
                 type: 'connect'
             });

--- a/src/engine/entity/NonPathingEntity.ts
+++ b/src/engine/entity/NonPathingEntity.ts
@@ -1,5 +1,4 @@
 import Entity from '#/engine/entity/Entity.js';
-import World from '#/engine/World.js';
 export default abstract class NonPathingEntity extends Entity {
     resetEntity(_respawn: boolean) {
         // nothing happens here

--- a/src/engine/entity/Player.ts
+++ b/src/engine/entity/Player.ts
@@ -63,7 +63,6 @@ import UpdateUid192 from '#/network/server/model/UpdatePid.js';
 import UpdateRebootTimer from '#/network/server/model/UpdateRebootTimer.js';
 import UpdateRunEnergy from '#/network/server/model/UpdateRunEnergy.js';
 import UpdateStat from '#/network/server/model/UpdateStat.js';
-import UpdateZoneFullFollows from '#/network/server/model/UpdateZoneFullFollows.js';
 import VarpLarge from '#/network/server/model/VarpLarge.js';
 import VarpSmall from '#/network/server/model/VarpSmall.js';
 import OutgoingMessage from '#/network/server/OutgoingMessage.js';

--- a/src/engine/script/handlers/LocOps.ts
+++ b/src/engine/script/handlers/LocOps.ts
@@ -60,7 +60,6 @@ const LocOps: CommandHandlers = {
     [ScriptOpcode.LOC_CHANGE]: checkedHandler(ActiveLoc, state => {
         const [id, duration] = state.popInts(2);
 
-        const locType: LocType = check(id, LocTypeValid);
         check(duration, DurationValid);
 
         World.changeLoc(state.activeLoc, id, state.activeLoc.shape, state.activeLoc.angle, duration);

--- a/src/engine/zone/Zone.ts
+++ b/src/engine/zone/Zone.ts
@@ -229,14 +229,12 @@ export default class Zone {
     // ---- static locs/objs are added during world init ----
 
     addStaticLoc(loc: Loc): void {
-        const coord: number = CoordGrid.packZoneCoord(loc.x, loc.z);
         this.locs.addTail(loc);
         this.locsCount++;
         loc.isActive = true;
     }
 
     addStaticObj(obj: Obj): void {
-        const coord: number = CoordGrid.packZoneCoord(obj.x, obj.z);
         this.objs.addTail(obj);
         this.objsCount++;
         obj.isRevealed = true;

--- a/src/server/friend/FriendServer.ts
+++ b/src/server/friend/FriendServer.ts
@@ -1,17 +1,12 @@
-import fs from 'fs';
-import fsp from 'fs/promises';
-
 import { WebSocket, WebSocketServer } from 'ws';
 
 import { db, toDbDate } from '#/db/query.js';
-import { PlayerLoading } from '#/engine/entity/PlayerLoading.js';
-import Packet from '#/io/Packet.js';
 import { FriendServerRepository } from '#/server/friend/FriendServerRepository.js';
 import InternalClient from '#/server/InternalClient.js';
 import { ChatModePrivate } from '#/util/ChatModes.js';
 import Environment from '#/util/Environment.js';
 import { fromBase37, toBase37 } from '#/util/JString.js';
-import { printError, printInfo } from '#/util/Logger.js';
+import { printInfo } from '#/util/Logger.js';
 
 /**
  * client -> server opcodes for friends server
@@ -425,8 +420,7 @@ export class FriendServer {
         });
     }
 
-    async start() {
-    }
+    async start() {}
 
     private async sendFriendsListToPlayer(username37: bigint, socket: WebSocket) {
         const playerFriends = await this.repository.getFriends(username37);


### PR DESCRIPTION
Hey, I saw some lint warnings on pull requests and noticed this TODO in the `eslint.config.js`.

In a handful of places, we have caught errors with the variable name `_`, but the config wasn't set to ignore those. It will ignore them now.

The most interesting change is in `src/db/query.ts`. `dialect` was getting defined but going unused. Meanwhile a separate, inline `dialect` was getting defined. Their definitions appeared identical, so I removed the duplication to satisfy eslint.

I set `no-case-declarations` and `@typescript-eslint/no-namespace` to `error` as well. No code changes were needed.

--

I have prettier configured to format files on save in my editor, but in that same `src/db/query.ts`, there's some formatting that prettier was modifying. I didn't check those changes in because prettier's formatting conflicts with [these eslint rules](https://github.com/2004Scape/Server/blob/4751c99d5e6f06f29995a5348d4e3348d4b4f8cc/eslint.config.js#L33-L35). imo it's best to turn off those kinds of rules and leave formatting to prettier, but I didn't want to make that kind of change before bringing it up. I could put those changes in a separate PR -- Let me know what you think!