### PR TITLE
fix(engine): Sped up Loc and Obj events by 1 tick to match OSRS, this will make resources respawn slightly faster

### DIFF
--- a/data/src/scripts/areas/area_alkharid/scripts/border_gate.rs2
+++ b/data/src/scripts/areas/area_alkharid/scripts/border_gate.rs2
@@ -126,17 +126,19 @@ p_delay(0);
 def_coord $other = movecoord(loc_coord, 0, 0, 1);
 
 def_coord $coord = ~movecoord_loc_return(~door_open(loc_angle, loc_shape));
-.loc_add($coord, loc_83, loc_angle, wall_straight, 2);
-.loc_add($coord, loc_param(next_loc_stage), calc(loc_angle + 3), loc_shape, 2);
-loc_add(loc_coord, loc_83, loc_angle, loc_shape, 2);
+// Temp note: dur updated
+.loc_add($coord, loc_83, loc_angle, wall_straight, 3);
+.loc_add($coord, loc_param(next_loc_stage), calc(loc_angle + 3), loc_shape, 3);
+loc_add(loc_coord, loc_83, loc_angle, loc_shape, 3);
 
 loc_findallzone($coord);
 while (loc_findnext = true) {
     if (loc_coord = $other & loc_category = border_gate_toll_right) {
         def_coord $coord2 = ~movecoord_loc_return(~door_open(loc_angle, loc_shape));
-        .loc_add($coord2, loc_83, loc_angle, wall_straight, 2);
-        .loc_add($coord2, loc_param(next_loc_stage), calc(loc_angle + 1), loc_shape, 2);
-        loc_add(loc_coord, loc_83, loc_angle, wall_straight, 2);
+        // Temp note: dur updated
+        .loc_add($coord2, loc_83, loc_angle, wall_straight, 3);
+        .loc_add($coord2, loc_param(next_loc_stage), calc(loc_angle + 1), loc_shape, 3);
+        loc_add(loc_coord, loc_83, loc_angle, wall_straight, 3);
     }
 }
 
@@ -146,17 +148,19 @@ def_coord $other = movecoord(loc_coord, 0, 0, -1);
 
 
 def_coord $coord = ~movecoord_loc_return(~door_open(loc_angle, loc_shape));
-.loc_add($coord, loc_83, loc_angle, wall_straight, 2);
-.loc_add($coord, loc_param(next_loc_stage), modulo(add(loc_angle, 1), 4), loc_shape, 2);
-loc_add(loc_coord, loc_83, loc_angle, loc_shape, 2);
+// Temp note: dur updated
+.loc_add($coord, loc_83, loc_angle, wall_straight, 3);
+.loc_add($coord, loc_param(next_loc_stage), modulo(add(loc_angle, 1), 4), loc_shape, 3);
+loc_add(loc_coord, loc_83, loc_angle, loc_shape, 3);
 
 loc_findallzone($coord);
 while (loc_findnext = true) {
     if (loc_coord = $other & loc_category = border_gate_toll_left) {
         $coord = ~movecoord_loc_return(~door_open(loc_angle, loc_shape));
-        .loc_add($coord, loc_83, loc_angle, wall_straight, 2);
-        .loc_add($coord, loc_param(next_loc_stage), modulo(add(loc_angle, 3), 4), loc_shape, 2);
-        loc_add(loc_coord, loc_83, loc_angle, wall_straight, 2);
+        // Temp note: dur updated
+        .loc_add($coord, loc_83, loc_angle, wall_straight, 3);
+        .loc_add($coord, loc_param(next_loc_stage), modulo(add(loc_angle, 3), 4), loc_shape, 3);
+        loc_add(loc_coord, loc_83, loc_angle, wall_straight, 3);
     }
 }
 

--- a/data/src/scripts/areas/area_alkharid/scripts/misc_locs.rs2
+++ b/data/src/scripts/areas/area_alkharid/scripts/misc_locs.rs2
@@ -1,6 +1,8 @@
 // Curtains
 [oploc1,loc_1529]
+// Temp note: dur does not need updated
 loc_change(loc_1528, 200);
 
 [oploc1,loc_1528]
+// Temp note: dur does not need updated
 loc_change(loc_1529, 200);

--- a/data/src/scripts/areas/area_ardougne_east/scripts/wilderness_lever.rs2
+++ b/data/src/scripts/areas/area_ardougne_east/scripts/wilderness_lever.rs2
@@ -18,7 +18,8 @@ if (%warning_wilderness_teleport_lever = ^false) {
 // teleport to wilderness
 anim(human_leverdown, 0); // OSRS uses seq's not in 225, going to assume here
 sound_synth(lever, 0, 0);
-loc_change(loc_161, 6);
+// Temp note: dur updated
+loc_change(loc_161, 7);
 if_close;
 p_delay(1);
 mes("You pull the lever...");
@@ -33,7 +34,8 @@ p_arrivedelay;
 // teleport to wilderness
 anim(human_leverdown, 0); // OSRS uses seq's not in 225, going to assume here
 sound_synth(lever, 0, 0);
-loc_change(loc_161, 6);
+// Temp note: dur updated
+loc_change(loc_161, 7);
 if_close;
 p_delay(0);
 mes("You pull the lever...");

--- a/data/src/scripts/areas/area_ardougne_west/scripts/doors.rs2
+++ b/data/src/scripts/areas/area_ardougne_west/scripts/doors.rs2
@@ -27,20 +27,20 @@ if(%biohazard_progress = ^biohazard_complete) {
     def_coord $loc_coord = loc_coord;
     mes("...You open them and walk through.");
     if(loc_find(0_39_51_62_36, loc_2049) = true) {
-        loc_del(4);
-        loc_add(loc_coord, loc_2048, 2, loc_shape, 4);
+        // Temp note: dur updated
+        loc_add(loc_coord, loc_2048, 2, loc_shape, 5);
     }
     if(loc_find(0_39_51_61_36, loc_2048) = true) {
-        loc_del(4);
-        loc_add(loc_coord, loc_2049, 0, loc_shape, 4);
+        // Temp note: dur updated
+        loc_add(loc_coord, loc_2049, 0, loc_shape, 5);
     }
     if(loc_find(0_39_51_62_35, loc_2048) = true) {
-        loc_del(4);
-        loc_add(loc_coord, loc_2049, 2, loc_shape, 4);
+        // Temp note: dur updated
+        loc_add(loc_coord, loc_2049, 2, loc_shape, 5);
     }
     if(loc_find(0_39_51_61_35, loc_2049) = true) {
-        loc_del(4);
-        loc_add(loc_coord, loc_2048, 0, loc_shape, 4);
+        // Temp note: dur updated
+        loc_add(loc_coord, loc_2048, 0, loc_shape, 5);
     }
     sound_synth(coffin_open, 0, 0);
     if(coordx(coord) < coordx(loc_coord)) {

--- a/data/src/scripts/areas/area_ardougne_west/scripts/manhole.rs2
+++ b/data/src/scripts/areas/area_ardougne_west/scripts/manhole.rs2
@@ -7,6 +7,7 @@ loc_findallzone(^quest_elena_west_ardy_manhole_coord); // the manhole is not in 
 while (loc_findnext = true) {
     // if the manhole is closed we open it when getting out basically.
     if (loc_type = loc_2543) {
+        // Temp note: dur does not need updated
         loc_change(loc_param(next_loc_stage), 500);
         loc_add(movecoord(loc_coord, 0, 0, -1), loc_2545, loc_angle, centrepiece_straight, 500);
     }
@@ -25,6 +26,7 @@ loc_del(500);
 while (loc_findnext = true) {
     // if the manhole is closed we open it when getting out basically.
     if (loc_type = loc_2544) {
+        // Temp note: dur does not need updated
         loc_change(loc_param(next_loc_stage), 500);
     }
 }

--- a/data/src/scripts/areas/area_barbarian_outpost/scripts/outpost_gate.rs2
+++ b/data/src/scripts/areas/area_barbarian_outpost/scripts/outpost_gate.rs2
@@ -17,9 +17,11 @@ while(loc_findnext = true) {
             def_int $orig_angle = loc_angle;
             loc_del(2);
             if(loc_type = loc_2116) {
-                loc_add(movecoord($central_coord, 1, 0, 0), loc_1562, 3, loc_shape, 2);
-                loc_add(movecoord($central_coord, 1, 0, 1), loc_1563, 1, loc_shape, 2); 
+                // Temp note: dur updated
+                loc_add(movecoord($central_coord, 1, 0, 0), loc_1562, 3, loc_shape, 3);
+                loc_add(movecoord($central_coord, 1, 0, 1), loc_1563, 1, loc_shape, 3); 
             }
-            loc_add($central_coord, loc_83, $orig_angle, loc_shape, 2);
+            // Temp note: dur updated
+            loc_add($central_coord, loc_83, $orig_angle, loc_shape, 3);
      }
 }

--- a/data/src/scripts/areas/area_barbarian_outpost/scripts/outpost_gate.rs2
+++ b/data/src/scripts/areas/area_barbarian_outpost/scripts/outpost_gate.rs2
@@ -15,7 +15,8 @@ while(loc_findnext = true) {
      if(loc_category = outpost_gate) {
             def_coord $central_coord = loc_coord;
             def_int $orig_angle = loc_angle;
-            loc_del(2);
+            // Temp note: dur updated
+            loc_del(3);
             if(loc_type = loc_2116) {
                 // Temp note: dur updated
                 loc_add(movecoord($central_coord, 1, 0, 0), loc_1562, 3, loc_shape, 3);

--- a/data/src/scripts/areas/area_brimhaven/scripts/pineapple_plants.rs2
+++ b/data/src/scripts/areas/area_brimhaven/scripts/pineapple_plants.rs2
@@ -4,6 +4,7 @@ if (inv_freespace(inv) = 0) {
     return;
 }
 
+// Temp note: dur does not need updated
 loc_change(loc_param(next_loc_stage), 500);
 inv_add(inv, pineapple, 1);
 

--- a/data/src/scripts/areas/area_desert/scripts/kharidian_cactus.rs2
+++ b/data/src/scripts/areas/area_desert/scripts/kharidian_cactus.rs2
@@ -70,4 +70,5 @@ if (stat_random(stat(woodcutting), 30, 252) = true) {
     stat_advance(woodcutting, 4);
 }
 
+// Temp note: dur does not need updated
 loc_change(loc_param(next_loc_stage), 100);

--- a/data/src/scripts/areas/area_edgeville/scripts/edgeville_dungeon.rs2
+++ b/data/src/scripts/areas/area_edgeville/scripts/edgeville_dungeon.rs2
@@ -41,9 +41,9 @@ if (inv_total(inv, brass_key) > 0) {
 
     p_teleport($dest);
 
-    loc_del(2);
-    loc_add($loc_coord, loc_83, $angle, $shape, 2);
-    loc_add(movecoord($loc_coord, $x, 0, $z), $replacement, modulo(add($angle, 1), 4), $shape, 2);
+    // Temp note: dur updated
+    loc_add($loc_coord, loc_83, $angle, $shape, 3);
+    loc_add(movecoord($loc_coord, $x, 0, $z), $replacement, modulo(add($angle, 1), 4), $shape, 3);
 } else {
     mes("The door is locked.");
 }

--- a/data/src/scripts/areas/area_gnome/scripts/gnome_gate.rs2
+++ b/data/src/scripts/areas/area_gnome/scripts/gnome_gate.rs2
@@ -34,10 +34,11 @@ if(coordz(coord) > coordz($loc_coord) & coord ! $north_entrance) {
 }
 p_delay(0);
 // replace gate
-loc_change(loc_191, 4);
-loc_add(movecoord($loc_coord, 3, 0, 0), loc_192, 0, loc_shape, 4); // opened right side
-loc_add(movecoord($loc_coord, 2, 0, 0), loc_83, 3, loc_shape, 4); // blocks whole path
-loc_add(movecoord($loc_coord, 2, 0, 1), loc_83, 1, loc_shape, 4);
+// Temp note: dur updated
+loc_change(loc_191, 5);
+loc_add(movecoord($loc_coord, 3, 0, 0), loc_192, 0, loc_shape, 5); // opened right side
+loc_add(movecoord($loc_coord, 2, 0, 0), loc_83, 3, loc_shape, 5); // blocks whole path
+loc_add(movecoord($loc_coord, 2, 0, 1), loc_83, 1, loc_shape, 5);
 p_delay(0);
 // walk to dest
 if(coordz(coord) > coordz($loc_coord)) {
@@ -53,7 +54,8 @@ if(coordz(coord) > coordz($loc_coord)) {
 // pass start x because these door locs are also on the sides (maybe to increase the hitbox)
 [label,open_tree_door](loc $open_door, int $start_x)
 sound_synth(door_open, 0, 0);
-loc_change($open_door, 4);
+// Temp note: dur updated
+loc_change($open_door, 5);
 p_teleport(movecoord(coord, calc($start_x - coordx(coord)), 0, 0));
 p_delay(0);
 def_coord $end_pos = movecoord(coord, 0, 0, -2);

--- a/data/src/scripts/areas/area_karamja/scripts/banana_tree.rs2
+++ b/data/src/scripts/areas/area_karamja/scripts/banana_tree.rs2
@@ -4,6 +4,7 @@ if (inv_freespace(inv) = 0) {
     return;
 }
 
+// Temp note: dur does not need updated
 loc_change(loc_param(next_loc_stage), 500);
 inv_add(inv, banana, 1);
 

--- a/data/src/scripts/areas/area_shilo/scripts/shilo_sandpit.rs2
+++ b/data/src/scripts/areas/area_shilo/scripts/shilo_sandpit.rs2
@@ -8,6 +8,7 @@ if (last_useitem = bucket_empty) {
         return;
     }
     ~shilo_sandscoop;
+    // Temp note: dur does not need updated
     loc_change(loc_2978, 100);
     return;
 }
@@ -23,6 +24,7 @@ if (last_useitem = bucket_empty) {
         return;
     }
     ~shilo_sandscoop;
+    // Temp note: dur does not need updated
     loc_change(loc_2979, 100);
     return;
 }

--- a/data/src/scripts/areas/area_shilo/scripts/yohnus.rs2
+++ b/data/src/scripts/areas/area_shilo/scripts/yohnus.rs2
@@ -24,8 +24,9 @@ switch_int(~p_choice2("Use Furnace - 20 Gold", 1, "No thanks!", 2)) {
             def_int $angle = loc_angle;
             def_locshape $shape = loc_shape;
             $x, $z = ~door_open($angle, loc_shape);
-            loc_change(loc_83, 2);
-            loc_add(movecoord($loc_coord, $x, 0, $z), loc_1532, modulo(add($angle, 1), 4), $shape, 2);
+            // Temp note: dur updated
+            loc_change(loc_83, 3);
+            loc_add(movecoord($loc_coord, $x, 0, $z), loc_1532, modulo(add($angle, 1), 4), $shape, 3);
             sound_synth(door_open, 0, 0);
         }
         p_teleport(movecoord(coord, 0, 0, 1));

--- a/data/src/scripts/areas/area_taverly/scripts/crystal_chest.rs2
+++ b/data/src/scripts/areas/area_taverly/scripts/crystal_chest.rs2
@@ -14,7 +14,8 @@ if (inv_total(inv, crystal_key) > 0) {
     mes("You unlock the chest with your key.");
     anim(human_openchest, 0);
     sound_synth(chest_open, 0, 0);
-    loc_change(opened_crystal_chest, 2);
+    // Temp note: dur updated
+    loc_change(opened_crystal_chest, 3);
     p_delay(0);
     inv_del(inv, crystal_key, 1);
     mes("You find some treasure in the chest!");

--- a/data/src/scripts/areas/area_varrock/scripts/champions_guild.rs2
+++ b/data/src/scripts/areas/area_varrock/scripts/champions_guild.rs2
@@ -33,10 +33,9 @@ if ($entering = true) {
 
 p_teleport($dest);
 
-
-loc_del(2);
-loc_add($loc_coord, loc_83, $angle, $shape, 2);
-loc_add(movecoord($loc_coord, $x, 0, $z), $replacement, modulo(add($angle, 1), 4), $shape, 2);
+// Temp note: dur updated
+loc_add($loc_coord, loc_83, $angle, $shape, 3);
+loc_add(movecoord($loc_coord, $x, 0, $z), $replacement, modulo(add($angle, 1), 4), $shape, 3);
 
 if ($entering = true) {
     ~chatnpc_specific("Guild master", guild_master, "<p,happy>Greetings bold adventurer. Welcome to the guild of Champions.");

--- a/data/src/scripts/areas/area_varrock/scripts/east_gate.rs2
+++ b/data/src/scripts/areas/area_varrock/scripts/east_gate.rs2
@@ -53,10 +53,11 @@ while(loc_findnext = true) {
             def_coord $central_coord = loc_coord;
             def_int $orig_angle = loc_angle;
             def_loc $type = loc_type;
-            loc_change(loc_83, 2);
+            // Temp note: dur updated
+            loc_change(loc_83, 3);
             if($type = loc_2050) {
-                loc_add(movecoord($central_coord, -1, 0, 0), loc_2052, 3, loc_shape, 2);
-                loc_add(movecoord($central_coord, -2, 0, 0), loc_2053, 3, loc_shape, 2); 
+                loc_add(movecoord($central_coord, -1, 0, 0), loc_2052, 3, loc_shape, 3);
+                loc_add(movecoord($central_coord, -2, 0, 0), loc_2053, 3, loc_shape, 3); 
             }
      }
 }

--- a/data/src/scripts/areas/area_white_wolf_mountain/scripts/white_wolf_mountain.rs2
+++ b/data/src/scripts/areas/area_white_wolf_mountain/scripts/white_wolf_mountain.rs2
@@ -24,15 +24,17 @@ if(stat(mining) < 50) {
 anim(oc_param($pickaxe, mining_animation), 0);
 sound_synth(mine_quick, 0, 0);
 def_coord $loc_coord = loc_coord;
-loc_change(loc_472, 2);
+// Temp note: dur updated
+loc_change(loc_472, 3);
 p_delay(1);
-loc_change(loc_474, 2);
+// Temp note: dur updated
+loc_change(loc_474, 3);
 p_delay(1);
-loc_del(3);
-loc_add($loc_coord, loc_475, loc_angle, loc_shape, 3); // replace rockslide with 2x2 invisible barrier
-loc_add(movecoord($loc_coord, 0, 0, 1), loc_475, loc_angle, loc_shape, 3);
-loc_add(movecoord($loc_coord, 1, 0, 1), loc_475, loc_angle, loc_shape, 3);
-loc_add(movecoord($loc_coord, 1, 0, 0), loc_475, loc_angle, loc_shape, 3);
+// Temp note: dur updated
+loc_add($loc_coord, loc_475, loc_angle, loc_shape, 4); // replace rockslide with 2x2 invisible barrier
+loc_add(movecoord($loc_coord, 0, 0, 1), loc_475, loc_angle, loc_shape, 4);
+loc_add(movecoord($loc_coord, 1, 0, 1), loc_475, loc_angle, loc_shape, 4);
+loc_add(movecoord($loc_coord, 1, 0, 0), loc_475, loc_angle, loc_shape, 4);
 if (coordx(coord) > coordx($loc_coord)) {
   ~forcemove(movecoord(coord, -2, 0, 0));
   ~forcemove(movecoord(coord, -1, 0, 1));

--- a/data/src/scripts/areas/area_wilderness/scripts/king_black_dragon.rs2
+++ b/data/src/scripts/areas/area_wilderness/scripts/king_black_dragon.rs2
@@ -354,7 +354,8 @@ return($maxhit);
 p_delay(0); // delay in osrs? isntead of arrivedelay
 anim(human_leverdown, 0); // OSRS uses seq's not in 225, going to assume here
 sound_synth(lever, 0, 0);
-loc_change(loc_161, 6);
+// Temp note: dur updated
+loc_change(loc_161, 7);
 if_close;
 p_delay(0);
 mes("You pull the lever...");
@@ -368,7 +369,8 @@ mes("...And teleport into the Dragon's lair."); // changed to "Lair" (uppercase)
 p_arrivedelay;
 anim(human_leverdown, 0); // OSRS uses seq's not in 225, going to assume here
 sound_synth(lever, 0, 0);
-loc_change(loc_161, 6);
+// Temp note: dur updated
+loc_change(loc_161, 7);
 if_close;
 p_delay(0);
 mes("You pull the lever...");

--- a/data/src/scripts/areas/area_wilderness/scripts/lava_maze.rs2
+++ b/data/src/scripts/areas/area_wilderness/scripts/lava_maze.rs2
@@ -11,8 +11,8 @@ anim(human_openchest, 0);
 sound_synth(chest_open, 0, 0);
 mes("You unlock the chest with your key.");
 p_delay(0);
-loc_del(1);
-loc_add(loc_coord, muddy_chest_opened, loc_angle, loc_shape, 1);
+// Temp note: dur updated
+loc_add(loc_coord, muddy_chest_opened, loc_angle, loc_shape, 2);
 inv_del(inv, muddy_key, 1);
 inv_add(inv, mithril_bar, 1);
 inv_add(inv, lawrune, 2);

--- a/data/src/scripts/areas/area_yanille/scripts/agility_dungeon.rs2
+++ b/data/src/scripts/areas/area_yanille/scripts/agility_dungeon.rs2
@@ -106,7 +106,8 @@ if(last_useitem = sinister_key) {
     inv_add(inv, unidentified_avantoe, 1);
     inv_add(inv, unidentified_kwuarm, 1);
     inv_add(inv, unidentified_torstol, 1);
-    loc_change(loc_3368, 4);
+    // Temp note: dur updated
+    loc_change(loc_3368, 5);
     return;
 }
 ~displaymessage(^dm_default);

--- a/data/src/scripts/areas/area_yanille/scripts/ogre_trader.rs2
+++ b/data/src/scripts/areas/area_yanille/scripts/ogre_trader.rs2
@@ -34,7 +34,8 @@ if(inv_freespace(inv) = 0) {
 }
 mes("You cautiously grab a cake from the stall.");
 inv_add(inv, rock_cake, 1);
-loc_change(loc_2792, 11); // 11t osrs
+// Temp note: dur updated
+loc_change(loc_2792, 12); // 11t osrs
 stat_advance(thieving, 65);
 
 [opnpc1,ogre_trader_3]

--- a/data/src/scripts/doors/scripts/doors.rs2
+++ b/data/src/scripts/doors/scripts/doors.rs2
@@ -9,6 +9,7 @@ if (coord = $new_loc_coord & loc_shape = wall_diagonal) {
     p_delay(1);
 };
 sound_synth(door_open, 0, 0);
+// Temp note: dur does not need updated
 loc_del(500);
 loc_add($new_loc_coord, loc_param(next_loc_stage), modulo(add(loc_angle, 1), 4), loc_shape, 500);
 // mes("Loc coord: <~coord_tostring(loc_coord)>");
@@ -24,6 +25,7 @@ if (coord = $new_loc_coord & loc_shape = wall_diagonal) {
     p_delay(1);
 }
 sound_synth(door_close, 0, 0);
+// Temp note: dur does not need updated
 loc_del(500);
 loc_add($new_loc_coord, loc_param(next_loc_stage), modulo(add(loc_angle, 3), 4), loc_shape, 500);
 // mes("Loc coord: <~coord_tostring(loc_coord)>");

--- a/data/src/scripts/doors/scripts/open_and_close_doors.rs2
+++ b/data/src/scripts/doors/scripts/open_and_close_doors.rs2
@@ -33,9 +33,9 @@ if ($entering = true) {
     $dest = movecoord($loc_coord, $x, 0, $z);
 }
 p_teleport($dest);
-
-loc_change(loc_83, 2);
-loc_add(movecoord($loc_coord, $x, 0, $z), $replacement, modulo(add($angle, 1), 4), $shape, 2);
+// Temp note: dur updated
+loc_change(loc_83, 3);
+loc_add(movecoord($loc_coord, $x, 0, $z), $replacement, modulo(add($angle, 1), 4), $shape, 3);
 
 sound_synth(door_open, 0, 0);
 
@@ -57,8 +57,9 @@ if ($entering = true) {
     $dest = movecoord(loc_coord, $x, 0, $z);
 }
 p_teleport($dest);
-loc_change(loc_83, 2);
-loc_add(movecoord($loc_coord, $x, 0, $z), $replacement, modulo(add($angle, 1), 4), $shape, 2);
+// Temp note: dur updated
+loc_change(loc_83, 3);
+loc_add(movecoord($loc_coord, $x, 0, $z), $replacement, modulo(add($angle, 1), 4), $shape, 3);
 
 // Same as other proc but uses delay of 0 for outside doors, example: https://youtu.be/n_ip_vEDbCA?si=6WmhtFdrgVyPhvNQ&t=1219
 [proc,open_and_close_door3](loc $replacement, boolean $entering, synth $sound)
@@ -78,8 +79,9 @@ if ($entering = true) {
     $dest = movecoord(loc_coord, $x, 0, $z);
 }
 p_teleport($dest);
-loc_change(loc_83, 2);
-loc_add(movecoord($loc_coord, $x, 0, $z), $replacement, modulo(add($angle, 1), 4), $shape, 2);
+// Temp note: dur updated
+loc_change(loc_83, 3);
+loc_add(movecoord($loc_coord, $x, 0, $z), $replacement, modulo(add($angle, 1), 4), $shape, 3);
 
 [proc,open_and_close_metal_gate](loc $replacement, boolean $entering, boolean $mirrored)
 // ~loc_shape_debug(loc_shape);
@@ -114,8 +116,9 @@ if ($entering = true) {
 }
 p_teleport($dest);
 
-loc_change(loc_83, 2);
-loc_add(movecoord($loc_coord, $x, 0, $z), $replacement, modulo(add($angle, 1), 4), $shape, 2);
+// Temp note: dur updated
+loc_change(loc_83, 3);
+loc_add(movecoord($loc_coord, $x, 0, $z), $replacement, modulo(add($angle, 1), 4), $shape, 3);
 
 sound_synth(grate_open, 0, 0);
 
@@ -153,5 +156,6 @@ if ($entering = true) {
 }
 p_teleport($dest);
 
-loc_change(loc_83, 2);
-loc_add(movecoord($loc_coord, $x, 0, $z), $replacement, modulo(add($angle, 1), 4), $shape, 2);
+// Temp note: dur updated
+loc_change(loc_83, 3);
+loc_add(movecoord($loc_coord, $x, 0, $z), $replacement, modulo(add($angle, 1), 4), $shape, 3);

--- a/data/src/scripts/doors/scripts/open_and_close_double_doors.rs2
+++ b/data/src/scripts/doors/scripts/open_and_close_double_doors.rs2
@@ -38,13 +38,16 @@ if ($entering = true) {
 p_teleport($dest);
 
 if ($side = ^left) {
-    ~open_double_doors_left(2, double_door_open_and_close_right, loc_param(open_sound));
+    // Temp note: dur updated
+    ~open_double_doors_left(3, double_door_open_and_close_right, loc_param(open_sound));
 } else if ($side = ^right) {
-    ~open_double_doors_right(2, double_door_open_and_close_left, loc_param(open_sound));
+    // Temp note: dur updated
+    ~open_double_doors_right(3, double_door_open_and_close_left, loc_param(open_sound));
 }
 
-loc_add($opposite_coord, loc_83, $angle, $shape, 2);
-loc_add($loc_coord, loc_83, $angle, $shape, 2);
+// Temp note: dur updated
+loc_add($opposite_coord, loc_83, $angle, $shape, 3);
+loc_add($loc_coord, loc_83, $angle, $shape, 3);
 // mes(~coord_tostring($opposite_coord));
 
 // variation that plays sound instantly
@@ -83,10 +86,13 @@ if ($entering = true) {
 p_teleport($dest);
 
 if ($side = ^left) {
-    ~open_double_doors_left(2, double_door_open_and_close_right, null);
+    // Temp note: dur updated
+    ~open_double_doors_left(3, double_door_open_and_close_right, null);
 } else if ($side = ^right) {
-    ~open_double_doors_right(2, double_door_open_and_close_left, null);
+    // Temp note: dur updated
+    ~open_double_doors_right(3, double_door_open_and_close_left, null);
 }
 
-loc_add($opposite_coord, loc_83, $angle, $shape, 2);
-loc_add($loc_coord, loc_83, $angle, $shape, 2);
+// Temp note: dur updated
+loc_add($opposite_coord, loc_83, $angle, $shape, 3);
+loc_add($loc_coord, loc_83, $angle, $shape, 3);

--- a/data/src/scripts/general_use/scripts/chests.rs2
+++ b/data/src/scripts/general_use/scripts/chests.rs2
@@ -47,6 +47,7 @@ p_arrivedelay;
 anim(human_openchest, 0);
 sound_synth(chest_open, 0, 0);
 p_delay(0);
+// Temp note: dur does not need updated
 loc_change($other_chest, 300);
 
 [proc,close_chest](loc $other_chest)
@@ -54,4 +55,5 @@ p_arrivedelay;
 anim(human_closechest, 0);
 sound_synth(chest_close, 0, 0);
 p_delay(0);
+// Temp note: dur does not need updated
 loc_change($other_chest, 300);

--- a/data/src/scripts/general_use/scripts/coffins.rs2
+++ b/data/src/scripts/general_use/scripts/coffins.rs2
@@ -1,9 +1,11 @@
 [oploc1,loc_398]
 mes("The coffin creaks open...");
 sound_synth(coffin_open, 0, 0);
+// Temp note: dur does not need updated ? @indio
 loc_change(loc_399, 485);
 
 [oploc1,loc_399]
 mes("You close the coffin.");
 sound_synth(coffin_close, 0, 0);
+// Temp note: dur does not need updated ? @indio
 loc_change(loc_398, 485);

--- a/data/src/scripts/general_use/scripts/coffins.rs2
+++ b/data/src/scripts/general_use/scripts/coffins.rs2
@@ -2,10 +2,10 @@
 mes("The coffin creaks open...");
 sound_synth(coffin_open, 0, 0);
 // Temp note: dur does not need updated ? @indio
-loc_change(loc_399, 485);
+loc_change(loc_399, 500);
 
 [oploc1,loc_399]
 mes("You close the coffin.");
 sound_synth(coffin_close, 0, 0);
 // Temp note: dur does not need updated ? @indio
-loc_change(loc_398, 485);
+loc_change(loc_398, 500);

--- a/data/src/scripts/general_use/scripts/cupboards.rs2
+++ b/data/src/scripts/general_use/scripts/cupboards.rs2
@@ -43,6 +43,7 @@ p_arrivedelay;
 anim(human_openchest,0);
 sound_synth(cupboard_open, 0, 0);
 p_delay(0);
+// Temp note: dur does not need updated
 loc_change(loc_param(cupboard_other), 300);
 if ($message = true) {
     mes("You open the cupboard.");
@@ -53,6 +54,7 @@ p_arrivedelay;
 anim(human_closechest, 0);
 sound_synth(cupboard_close, 0, 0);
 p_delay(0);
+// Temp note: dur does not need updated
 loc_change(loc_param(cupboard_other), 300);
 if ($message = true) {
     mes("You close the cupboard.");

--- a/data/src/scripts/general_use/scripts/drawers.rs2
+++ b/data/src/scripts/general_use/scripts/drawers.rs2
@@ -19,6 +19,7 @@ p_arrivedelay;
 anim(human_openchest,0);
 p_delay(0);
 // todo - Sound
+// Temp note: dur does not need updated
 loc_change(loc_param(drawer_other), 300);
 
 [oplocu,_drawer]
@@ -70,4 +71,5 @@ p_arrivedelay;
 anim(human_closechest,0);
 p_delay(0);
 // todo - Sound
+// Temp note: dur does not need updated
 loc_change(loc_param(drawer_other), 300);

--- a/data/src/scripts/general_use/scripts/gates.rs2
+++ b/data/src/scripts/general_use/scripts/gates.rs2
@@ -49,11 +49,13 @@ def_coord $main_open = ~movecoord_loc_return(~gate_set_close($orig_angle, 1));
 def_coord $outer_open = ~movecoord_loc_return(~gate_set_close($orig_angle, 2));
 //todo: Figure out if these use door_open/close, the gate sounds werent added until ~2005?
 sound_synth(door_open, 0, 0); 
+// Temp note: dur does not need updated
 loc_del(500);
 loc_add($main_open, loc_param(next_loc_stage), modulo(add(loc_angle, 3), 4), wall_straight, 500);
 loc_findallzone(~get_pair_coord($orig_coord, $orig_angle, false));
 while (loc_findnext = true) {
     if (distance($orig_coord, loc_coord) <= 1 & loc_category = gate_outer_closed) {
+        // Temp note: dur does not need updated
         loc_del(500);
         loc_add($outer_open, loc_param(next_loc_stage), modulo(add($orig_angle, 3), 4), wall_straight, 500);
         return;
@@ -66,11 +68,13 @@ def_coord $orig_coord = loc_coord;
 def_coord $main_closed = ~movecoord_loc_return(~gate_set_open($orig_angle, false));
 def_coord $outer_closed = ~movecoord_loc_return(~gate_set_open($orig_angle, true));
 sound_synth(door_close, 0, 0); 
+// Temp note: dur does not need updated
 loc_del(500);
 loc_add($main_closed, loc_param(next_loc_stage), modulo(add(loc_angle, 1), 4), wall_straight, 500);
 loc_findallzone(~get_pair_coord($orig_coord, $orig_angle, false));
 while (loc_findnext = true) {
     if (distance($orig_coord, loc_coord) <= 1 & loc_category = gate_outer_open) {
+        // Temp note: dur does not need updated
         loc_del(500);
         loc_add($outer_closed, loc_param(next_loc_stage), modulo(add($orig_angle, 1), 4), wall_straight, 500);
         return;

--- a/data/src/scripts/general_use/scripts/manholes.rs2
+++ b/data/src/scripts/general_use/scripts/manholes.rs2
@@ -1,6 +1,7 @@
 [oploc1,loc_881]
 mes("You pull back the cover from over the manhole.");
 sound_synth(coffin_open, 0, 0);
+// Temp note: dur does not need updated
 loc_change(loc_882, 400);
 loc_add(movecoord(loc_coord, 0, 0, -1), loc_883, loc_angle, loc_shape, 400);
 
@@ -10,7 +11,9 @@ p_telejump(movecoord(coord(), 0, 0, 6400));
 
 [oploc1,loc_883]
 mes("You place the cover back over the manhole.");
+// Temp note: dur does not need updated
 loc_del(400);
 if (.loc_find(movecoord(loc_coord, 0, 0, 1), loc_882) = true) {
+    // Temp note: dur does not need updated
     .loc_change(loc_881, 400);
 }

--- a/data/src/scripts/general_use/scripts/mithril_seeds.rs2
+++ b/data/src/scripts/general_use/scripts/mithril_seeds.rs2
@@ -12,6 +12,7 @@ if (~inzone_coord_pair_table(party_room_zones, coord) = true) {
 mes("You open the small mithril case.");
 mes("You drop a seed by your feet.");
 inv_del(inv, mithril_seeds, 1);
+// Temp note: dur does not need updated
 loc_add(coord, ~random_flowers, 0, centrepiece_straight, 500);
 ~push_player(coord);
 facesquare(loc_coord);

--- a/data/src/scripts/general_use/scripts/trapdoors.rs2
+++ b/data/src/scripts/general_use/scripts/trapdoors.rs2
@@ -2,7 +2,7 @@
 mes("The trapdoor opens...");
 sound_synth(door_open, 0, 0);
 // Temp note: dur does not need updated ? @indio
-loc_change(loc_1570, 485);
+loc_change(loc_1570, 500);
 
 [oploc1,loc_1570]
 mes("You climb down through the trapdoor...");
@@ -14,4 +14,4 @@ p_telejump(movecoord(coord(), 0, 0, 6400));
 mes("You close the trapdoor.");
 sound_synth(door_close, 0,0 );
 // Temp note: dur does not need updated ? @indio
-loc_change(loc_1568, 485);
+loc_change(loc_1568, 500);

--- a/data/src/scripts/general_use/scripts/trapdoors.rs2
+++ b/data/src/scripts/general_use/scripts/trapdoors.rs2
@@ -1,6 +1,7 @@
 [oploc1,loc_1568]
 mes("The trapdoor opens...");
 sound_synth(door_open, 0, 0);
+// Temp note: dur does not need updated ? @indio
 loc_change(loc_1570, 485);
 
 [oploc1,loc_1570]
@@ -12,4 +13,5 @@ p_telejump(movecoord(coord(), 0, 0, 6400));
 [oploc2,loc_1570]
 mes("You close the trapdoor.");
 sound_synth(door_close, 0,0 );
+// Temp note: dur does not need updated ? @indio
 loc_change(loc_1568, 485);

--- a/data/src/scripts/general_use/scripts/wardrobes.rs2
+++ b/data/src/scripts/general_use/scripts/wardrobes.rs2
@@ -6,8 +6,10 @@ p_delay(0);
 
 // 1/21 of spooky wardrobe, https://archive.is/FPJBA
 if (random(21) = 0) {
+    // Temp note: dur does not need updated
     loc_change(loc_390, 500);
 } else {
+    // Temp note: dur does not need updated
     loc_change(loc_389, 500);
 }
 
@@ -26,6 +28,7 @@ p_arrivedelay;
 anim(human_closechest, 0);
 p_delay(0);
 // todo - Sound
+// Temp note: dur does not need updated
 loc_change(loc_388, 500);
 
 [oploc2,loc_390]
@@ -37,4 +40,5 @@ p_arrivedelay;
 anim(human_closechest, 0);
 p_delay(0);
 // todo - Sound
+// Temp note: dur does not need updated
 loc_change(loc_388, 500);

--- a/data/src/scripts/general_use/scripts/web.rs2
+++ b/data/src/scripts/general_use/scripts/web.rs2
@@ -29,6 +29,7 @@ sound_synth(hacksword_slash, 0, 15);
 if (random($chance) = 1) {
     mes("You slash the web apart.");
     p_delay(1); // osrs
+    // Temp note: dur does not need updated
     loc_change(loc_734, 100);
 } else {
     mes("You fail to cut through it.");

--- a/data/src/scripts/general_use/scripts/windmills.rs2
+++ b/data/src/scripts/general_use/scripts/windmills.rs2
@@ -69,6 +69,7 @@ if (inv_total(inv, pot_empty) < 1) {
         // todo: do we revert visual state? let the loc_change run its course?
         %mill_flour = 0;
         mes("You fill a pot with the last of the flour in the bin.");
+        // Temp note: dur does not need updated
         loc_change(millbase, 500);
     }
 }
@@ -86,6 +87,7 @@ if (last_useitem = grain) {
     // sound?
     mes("You put the grain in the hopper.");
     inv_delslot(inv, last_useslot);
+    // Temp note: dur does not need updated
     loc_change(hopper_full, 500);
 } else {
     ~displaymessage(^dm_default);
@@ -96,7 +98,8 @@ def_coord $hopper_coord = loc_param(hopper_coord);
 def_coord $millbase_coord = loc_param(millbase_coord);
 def_loc $hopper = loc_param(next_loc_stage);
 sound_synth(hopperlever, 0, 0);
-loc_change(hoppercontrol_inuse, 2);
+// Temp note: dur updated
+loc_change(hoppercontrol_inuse, 3);
 anim(human_pickuptable, 0);
 
 if (loc_find($hopper_coord, hopper_full) = true) {
@@ -115,6 +118,8 @@ if (loc_find($hopper_coord, hopper_full) = true) {
 
     // reverting the state means multiple people trying at the same time will have issues
     // but it's necessary to prevent infinite flour!
+    // Temp note: dur does not need updated
+    // Temp note: dur does not need updated
     loc_change($hopper, 500);
 
     if (loc_find($millbase_coord, millbase) = true) {

--- a/data/src/scripts/macro events/scripts/mining/macro_event_gas.rs2
+++ b/data/src/scripts/macro events/scripts/mining/macro_event_gas.rs2
@@ -13,6 +13,7 @@
 // - https://youtu.be/hoIaiSdQZGk?t=25
 // - https://youtu.be/Giyx_JsAWxg?t=114
 def_int $duration = 60;
+// Temp note: dur does not need updated
 loc_change(loc_param(macro_gas), $duration);
 sound_synth(gas_hiss, 0, 0);
 p_oploc(1);

--- a/data/src/scripts/macro events/scripts/thieving/macro_event_poisonous_gas.rs2
+++ b/data/src/scripts/macro events/scripts/thieving/macro_event_poisonous_gas.rs2
@@ -11,6 +11,7 @@ mes("You open the chest.");
 sound_synth(chest_open, 0, 0);
 p_delay(1);
 anim(human_openchest, 0);
+// Temp note: dur does not need updated
 loc_change(chest_macro_gas, 100); // timing is guessed
 %macro_chest_gas_coord = loc_coord; // set the active loc
 p_delay(0);

--- a/data/src/scripts/macro events/scripts/woodcutting/macro_event_ent.rs2
+++ b/data/src/scripts/macro events/scripts/woodcutting/macro_event_ent.rs2
@@ -5,6 +5,7 @@ def_loc $loc = nc_param($ent, (next_loc_stage));
 def_coord $coord = loc_coord;
 // for 3x3 trees
 if ($loc = null) {
+    // Temp note: dur does not need updated
     loc_change(loc_2639, 60);
     loc_add(movecoord($coord, 1, 0, 1), loc_2639, 0, centrepiece_straight, 60);
     loc_add(movecoord($coord, 2, 0, 0), loc_83, 0, centrepiece_straight, 60);

--- a/data/src/scripts/macro events/scripts/woodcutting/macro_event_ent.rs2
+++ b/data/src/scripts/macro events/scripts/woodcutting/macro_event_ent.rs2
@@ -11,6 +11,7 @@ if ($loc = null) {
     loc_add(movecoord($coord, 2, 0, 0), loc_83, 0, centrepiece_straight, 60);
     loc_add(movecoord($coord, 0, 0, 2), loc_84, 0, centrepiece_straight, 60);
 } else {
+    // Temp note: dur does not need updated
     loc_change($loc, 60);
 }
 npc_add($coord, $ent, 60);

--- a/data/src/scripts/minigames/game_partyroom/scripts/partyroom.rs2
+++ b/data/src/scripts/minigames/game_partyroom/scripts/partyroom.rs2
@@ -133,7 +133,8 @@ p_walk(loc_coord);
 p_delay(0);
 anim(seq_794, 0);
 p_delay(0);
-loc_change(loc_param(next_loc_stage), 5);
+// Temp note: dur updated, does it need ? @indio
+loc_change(loc_param(next_loc_stage), 6);
 // todo: chance was fixed before Jul 2004, was changed to scale off of chest freespace afterwards (this chance is just a guess unfortunately)
 if (~inzone_coord_pair_table(party_room_zones, loc_coord) = true & random(4) = 0) {
     def_int $rand_slot = random(calc(inv_size(partyroominv) - inv_freespace(partyroominv)));

--- a/data/src/scripts/minigames/game_partyroom/scripts/partyroom.rs2
+++ b/data/src/scripts/minigames/game_partyroom/scripts/partyroom.rs2
@@ -117,6 +117,7 @@ if($balloons_dropped < 200) {
     while($i < ^balloons_per_drop) {
         def_coord $balloon_coord = ~random_partyroom_balloon_coord;
         if(map_blocked($balloon_coord) = false & map_indoors($balloon_coord) = true & map_locaddunsafe($balloon_coord) = false) {
+            // Temp note: dur does not need updated
             loc_add($balloon_coord, ~random_balloon, random(4), centrepiece_straight, 200);
             $balloons_dropped = calc($balloons_dropped + 1);
         }

--- a/data/src/scripts/minigames/game_ranging/scripts/ranging_guild_door.rs2
+++ b/data/src/scripts/minigames/game_ranging/scripts/ranging_guild_door.rs2
@@ -8,8 +8,9 @@ if(coordx(coord) > coordx(loc_coord) | coordz(coord) < coordz(loc_coord)) {
     def_int $angle = loc_angle;
     def_locshape $shape = loc_shape;
     $x, $z = ~door_open($angle, loc_shape);
-    loc_change(loc_83, 2);
-    loc_add(movecoord($loc_coord, $x, 0, $z), loc_1532, modulo(add($angle, 1), 4), $shape, 2);
+    // Temp note: dur updated
+    loc_change(loc_83, 3);
+    loc_add(movecoord($loc_coord, $x, 0, $z), loc_1532, modulo(add($angle, 1), 4), $shape, 3);
     p_teleport(movecoord(coord, -2, 0, 2));
     return;
 }
@@ -27,8 +28,9 @@ def_coord $loc_coord = loc_coord;
 def_int $angle = loc_angle;
 def_locshape $shape = loc_shape;
 $x, $z = ~door_open($angle, loc_shape);
-loc_change(loc_83, 2);
-loc_add(movecoord($loc_coord, $x, 0, $z), loc_1532, modulo(add($angle, 1), 4), $shape, 2);
+// Temp note: dur updated
+loc_change(loc_83, 3);
+loc_add(movecoord($loc_coord, $x, 0, $z), loc_1532, modulo(add($angle, 1), 4), $shape, 3);
 p_teleport(movecoord(coord, 2, 0, -2));
 
 [opnpc1,ranging_guild_doorman]

--- a/data/src/scripts/minigames/game_trail/scripts/easy/trail_clue_easy.rs2
+++ b/data/src/scripts/minigames/game_trail/scripts/easy/trail_clue_easy.rs2
@@ -42,6 +42,7 @@ p_arrivedelay;
 anim(human_openchest, 0);
 sound_synth(cupboard_open, 0, 0);
 p_delay(0);
-loc_change(loc_3369, 4);
+// Temp note: dur updated
+loc_change(loc_3369, 5);
 p_delay(0);
 ~trail_clue_easy_loc_interact(trail_clue_easy_riddle_exp008);

--- a/data/src/scripts/minigames/game_trail/scripts/medium/trail_clue_medium.rs2
+++ b/data/src/scripts/minigames/game_trail/scripts/medium/trail_clue_medium.rs2
@@ -46,7 +46,8 @@ if(inv_total(inv, trail_clue_medium_riddle_exp001) > 0) {
         anim(human_openchest, 0);
         sound_synth(chest_open, 0, 0);
         p_delay(0);
-        loc_change(loc_3368, 4);
+        // Temp note: dur updated
+        loc_change(loc_3368, 5);
         p_delay(0);
         inv_del(inv, trail_clue_medium_key_exp001, 1);
         ~progress_clue_medium(trail_clue_medium_riddle_exp001, "You've found another clue scroll!");
@@ -64,7 +65,8 @@ if(inv_total(inv, trail_clue_medium_riddle_exp002) > 0) {
         anim(human_openchest, 0);
         sound_synth(cupboard_open, 0, 0);
         p_delay(0);
-        loc_change(loc_3369, 4);
+        // Temp note: dur updated
+        loc_change(loc_3369, 5);
         p_delay(0);
         inv_del(inv, trail_clue_medium_key_exp002, 1);
         ~progress_clue_medium(trail_clue_medium_riddle_exp002, "You've found another clue scroll!");
@@ -82,7 +84,8 @@ if(inv_total(inv, trail_clue_medium_riddle_exp003) > 0) {
         anim(human_openchest, 0);
         sound_synth(cupboard_open, 0, 0);
         p_delay(0);
-        loc_change(loc_3369, 4);
+        // Temp note: dur updated
+        loc_change(loc_3369, 5);
         p_delay(0);
         inv_del(inv, trail_clue_medium_key_exp003, 1);
         ~progress_clue_medium(trail_clue_medium_riddle_exp003, "You've found another clue scroll!");
@@ -100,7 +103,8 @@ if(inv_total(inv, trail_clue_medium_riddle_exp004) > 0) {
         anim(human_openchest, 0);
         sound_synth(cupboard_open, 0, 0);
         p_delay(0);
-        loc_change(loc_3370, 4);
+        // Temp note: dur updated
+        loc_change(loc_3370, 5);
         p_delay(0);
         inv_del(inv, trail_clue_medium_key_exp004, 1);
         ~progress_clue_medium(trail_clue_medium_riddle_exp004, "You've found another clue scroll!");
@@ -118,7 +122,8 @@ if(inv_total(inv, trail_clue_medium_riddle_exp005) > 0) {
         anim(human_openchest, 0);
         sound_synth(chest_open, 0, 0);
         p_delay(0);
-        loc_change(loc_3368, 4);
+        // Temp note: dur updated
+        loc_change(loc_3368, 5);
         p_delay(0);
         inv_del(inv, trail_clue_medium_key_exp005, 1);
         ~progress_clue_medium(trail_clue_medium_riddle_exp005, "You've found another clue scroll!");

--- a/data/src/scripts/minigames/game_trawler/scripts/trawler.rs2
+++ b/data/src/scripts/minigames/game_trawler/scripts/trawler.rs2
@@ -149,10 +149,12 @@ if (npc_find(^trawler_start_center_under, murphy_nonflood, 5, 0) = true) {
 def_int $i = 0;
 while ($i < enum_getoutputcount(trawler_hulls)) {
     if (loc_find(enum(int, coord, trawler_hulls, $i), game_trawler_leak) = true) {
-        loc_change(game_trawler_hull, 1);
+        // Temp note: dur updated
+        loc_change(game_trawler_hull, 2);
     }
     if (loc_find(enum(int, coord, trawler_hulls, $i), game_trawler_repaired_leak) = true) {
-        loc_change(game_trawler_hull, 1);
+        // Temp note: dur updated
+        loc_change(game_trawler_hull, 2);
     }
     $i = add($i, 1);
 }
@@ -160,25 +162,30 @@ while ($i < enum_getoutputcount(trawler_hulls)) {
 $i = 0;
 while ($i < enum_getoutputcount(trawler_hulls_flooded)) {
     if (loc_find(enum(int, coord, trawler_hulls_flooded, $i), game_trawler_leak) = true) {
-        loc_change(game_trawler_hull, 1);
+        // Temp note: dur updated
+        loc_change(game_trawler_hull, 2);
     }
     if (loc_find(enum(int, coord, trawler_hulls_flooded, $i), game_trawler_repaired_leak) = true) {
-        loc_change(game_trawler_hull, 1);
+        loc_change(game_trawler_hull, 2);
     }
     $i = add($i, 1);
 }
 // nets
 if (loc_find(^trawler_start_net1, game_trawler_fish_net_broken1) = true) {
-    loc_change(game_trawler_fish_net1, 1);
+    // Temp note: dur updated
+    loc_change(game_trawler_fish_net1, 2);
 }
 if (loc_find(^trawler_start_net2, game_trawler_fish_net_broken2) = true) {
-    loc_change(game_trawler_fish_net2, 1); 
+    // Temp note: dur updated
+    loc_change(game_trawler_fish_net2, 2); 
 }
 if (loc_find(^trawler_flood_net1, game_trawler_fish_net_broken1) = true) {
-    loc_change(game_trawler_fish_net1, 1);
+    // Temp note: dur updated
+    loc_change(game_trawler_fish_net1, 2);
 }
 if (loc_find(^trawler_flood_net2, game_trawler_fish_net_broken2) = true) {
-    loc_change(game_trawler_fish_net2, 1); 
+    // Temp note: dur updated
+    loc_change(game_trawler_fish_net2, 2); 
 }
 
 [proc,trawler_login]

--- a/data/src/scripts/minigames/game_trawler/scripts/trawler_flood.rs2
+++ b/data/src/scripts/minigames/game_trawler/scripts/trawler_flood.rs2
@@ -23,11 +23,13 @@ while (huntnext = true) {
 }
 
 [proc,trawler_leak] // requires active loc
+// Temp note: dur does not need updated
 loc_change(game_trawler_leak, 1000);
 ~sound_area(leak, 0, loc_coord, 5);
 
 def_coord $flood_coord = movecoord(loc_coord, 128, 0, 0);
 if (loc_find($flood_coord, game_trawler_hull) = true | loc_find($flood_coord, game_trawler_repaired_leak) = true) {
+    // Temp note: dur does not need updated
     loc_change(game_trawler_leak, 1000);
     ~sound_area(leak, 0, $flood_coord, 5);
 }
@@ -74,6 +76,7 @@ if (loc_type = game_trawler_leak) {
     sound_synth(pick, 0, 0);
     p_delay(0);
     if (loc_type = game_trawler_leak) {
+        // Temp note: dur does not need updated
         loc_change(game_trawler_repaired_leak, 1000);
         if (~inzone_coord_pair_table(trawler_flood_zones, loc_coord) = true) {
             if (random(5) = 0) {
@@ -82,6 +85,7 @@ if (loc_type = game_trawler_leak) {
                 }
             }
             if (loc_find(movecoord(loc_coord, -128, 0, 0), game_trawler_leak) = true) {
+                // Temp note: dur does not need updated
                 loc_change(game_trawler_repaired_leak, 1000);
             }
         } else {
@@ -91,6 +95,7 @@ if (loc_type = game_trawler_leak) {
                 }
             }
             if (loc_find(movecoord(loc_coord, 128, 0, 0), game_trawler_leak) = true) {
+                // Temp note: dur does not need updated
                 loc_change(game_trawler_repaired_leak, 1000);
             }
         } 

--- a/data/src/scripts/minigames/game_trawler/scripts/trawler_net.rs2
+++ b/data/src/scripts/minigames/game_trawler/scripts/trawler_net.rs2
@@ -71,16 +71,20 @@ if (stat_random(stat(crafting), 30, 300) = false) { // stat random is mostly gue
     return;
 }
 if (loc_find(^trawler_start_net1, game_trawler_fish_net_broken1) = true) {
-    loc_change(game_trawler_fish_net1, 1);
+    // Temp note: dur updated
+    loc_change(game_trawler_fish_net1, 2);
 }
 if (loc_find(^trawler_start_net2, game_trawler_fish_net_broken2) = true) {
-    loc_change(game_trawler_fish_net2, 1); 
+    // Temp note: dur updated
+    loc_change(game_trawler_fish_net2, 2); 
 }
 if (loc_find(^trawler_flood_net1, game_trawler_fish_net_broken1) = true) {
-    loc_change(game_trawler_fish_net1, 1);
+    // Temp note: dur updated
+    loc_change(game_trawler_fish_net1, 2);
 }
 if (loc_find(^trawler_flood_net2, game_trawler_fish_net_broken2) = true) {
-    loc_change(game_trawler_fish_net2, 1); 
+    // Temp note: dur updated
+    loc_change(game_trawler_fish_net2, 2); 
 }
 anim(human_pickupfloor, 0);
 p_delay(0);

--- a/data/src/scripts/quests/quest_arena/scripts/general_khazard.rs2
+++ b/data/src/scripts/quests/quest_arena/scripts/general_khazard.rs2
@@ -64,8 +64,9 @@ if(loc_find(0_40_49_40_6, loc_79) = true) {
     def_int $angle = loc_angle;
     def_locshape $shape = loc_shape;
     $x, $z = ~door_open($angle, loc_shape);
-    loc_change(loc_83, 2);
-    loc_add(movecoord($loc_coord, $x, 0, $z), loc_37, modulo(add($angle, 1), 4), $shape, 2);
+    // Temp note: dur updated
+    loc_change(loc_83, 3);
+    loc_add(movecoord($loc_coord, $x, 0, $z), loc_37, modulo(add($angle, 1), 4), $shape, 3);
     sound_synth(grate_open, 0, 0);
 }
 ~forcemove(movecoord(coord, 0, 0, 1));

--- a/data/src/scripts/quests/quest_arena/scripts/hengrad.rs2
+++ b/data/src/scripts/quests/quest_arena/scripts/hengrad.rs2
@@ -36,8 +36,9 @@ if(%arena_progress = ^arena_sent_jail) {
         def_int $angle = loc_angle;
         def_locshape $shape = loc_shape;
         $x, $z = ~door_open($angle, loc_shape);
-        loc_change(loc_83, 2);
-        loc_add(movecoord($loc_coord, $x, 0, $z), loc_37, modulo(add($angle, 1), 4), $shape, 2);
+        // Temp note: dur updated
+        loc_change(loc_83, 3);
+        loc_add(movecoord($loc_coord, $x, 0, $z), loc_37, modulo(add($angle, 1), 4), $shape, 3);
         sound_synth(grate_open, 0, 0);
     }
     p_teleport(movecoord(coord, 0, 0, -1));
@@ -57,8 +58,9 @@ if(%arena_progress = ^arena_sent_jail) {
         def_int $angle = loc_angle;
         def_locshape $shape = loc_shape;
         $x, $z = ~door_open($angle, loc_shape);
-        loc_change(loc_83, 2);
-        loc_add(movecoord($loc_coord, $x, 0, $z), loc_1532, modulo(add($angle, 1), 4), $shape, 2);
+        // Temp note: dur updated
+        loc_change(loc_83, 3);
+        loc_add(movecoord($loc_coord, $x, 0, $z), loc_1532, modulo(add($angle, 1), 4), $shape, 3);
         sound_synth(door_open, 0, 0);
     }
     ~forcemove(movecoord(coord, -4, 0, 4));

--- a/data/src/scripts/quests/quest_arena/scripts/jeremy_servil.rs2
+++ b/data/src/scripts/quests/quest_arena/scripts/jeremy_servil.rs2
@@ -83,8 +83,9 @@ def_coord $loc_coord = loc_coord;
 def_int $angle = loc_angle;
 def_locshape $shape = loc_shape;
 $x, $z = ~door_open($angle, loc_shape);
-loc_change(loc_83, 2);
-loc_add(movecoord($loc_coord, $x, 0, $z), loc_37, modulo(add($angle, 1), 4), $shape, 2);
+// Temp note: dur updated
+loc_change(loc_83, 3);
+loc_add(movecoord($loc_coord, $x, 0, $z), loc_37, modulo(add($angle, 1), 4), $shape, 3);
 sound_synth(grate_open, 0, 0);
 p_delay(6);
 npc_del;
@@ -118,10 +119,11 @@ npc_setmode(none);
 npc_walk(movecoord($ogre_to, 1, 0, 0));
 p_delay($delay);
 if(loc_find(0_40_49_46_29, loc_78) = true & .loc_find(0_40_49_46_30, loc_77) = true) {
-    loc_del(5);
-    loc_add(movecoord(loc_coord, 1, 0, 0), loc_type, 3, loc_shape, 5);
-    .loc_del(5);
-    .loc_add(movecoord(.loc_coord, 1, 0, 0), .loc_type, 1, .loc_shape, 5);
+    // Temp note: dur updated
+    loc_del(6);
+    loc_add(movecoord(loc_coord, 1, 0, 0), loc_type, 3, loc_shape, 6);
+    .loc_del(6);
+    .loc_add(movecoord(.loc_coord, 1, 0, 0), .loc_type, 1, .loc_shape, 6);
 }
 npc_tele($ogre_to);
 npc_queue(10, 0, 1);

--- a/data/src/scripts/quests/quest_arena/scripts/quest_arena.rs2
+++ b/data/src/scripts/quests/quest_arena/scripts/quest_arena.rs2
@@ -130,8 +130,9 @@ if(coordx(coord) > coordx(loc_coord) | coordz(coord) < coordz(loc_coord)) {
             def_int $angle = loc_angle;
             def_locshape $shape = loc_shape;
             $x, $z = ~door_open($angle, loc_shape);
-            loc_change(loc_83, 2);
-            loc_add(movecoord($loc_coord, $x, 0, $z), loc_1532, modulo(add($angle, 1), 4), $shape, 2);
+            // Temp note: dur updated
+            loc_change(loc_83, 3);
+            loc_add(movecoord($loc_coord, $x, 0, $z), loc_1532, modulo(add($angle, 1), 4), $shape, 3);
             ~forcemove(movecoord(coord, 2, 0, -2));
     }
 }
@@ -149,8 +150,9 @@ if(loc_find(0_40_49_46_16, loc_82) = true) {
     def_int $angle = loc_angle;
     def_locshape $shape = loc_shape;
     $x, $z = ~door_open($angle, loc_shape);
-    loc_change(loc_83, 2);
-    loc_add(movecoord($loc_coord, $x, 0, $z), loc_1532, modulo(add($angle, 1), 4), $shape, 2);
+    // Temp note: dur updated
+    loc_change(loc_83, 3);
+    loc_add(movecoord($loc_coord, $x, 0, $z), loc_1532, modulo(add($angle, 1), 4), $shape, 3);
     sound_synth(door_open, 0, 0);
 }
 cam_moveto(0_40_49_43_26, 270, 1, 1);
@@ -180,8 +182,9 @@ def_coord $loc_coord = loc_coord;
 def_int $angle = loc_angle;
 def_locshape $shape = loc_shape;
 $x, $z = ~door_open($angle, loc_shape);
-loc_change(loc_83, 2);
-loc_add(movecoord($loc_coord, $x, 0, $z), loc_1532, modulo(add($angle, 1), 4), $shape, 2);
+// Temp note: dur updated
+loc_change(loc_83, 3);
+loc_add(movecoord($loc_coord, $x, 0, $z), loc_1532, modulo(add($angle, 1), 4), $shape, 3);
 ~forcemove(movecoord(coord, -2, 0, 2));
 if (%arena_progress = ^arena_defeated_ogre & npc_find(coord, general_khazard, 8, 0) = true) {
     @khazard_welldone;
@@ -209,10 +212,11 @@ cam_moveto(0_40_49_41_23, 450, 4, 2);
 npc_walk(0_40_49_47_23);
 p_delay(2);
 if(loc_find(0_40_49_46_23, loc_78) = true & .loc_find(0_40_49_46_24, loc_77) = true) {
-    loc_del(5);
-    loc_add(movecoord(loc_coord, 1, 0, 0), loc_type, 3, loc_shape, 5);
-    .loc_del(5);
-    .loc_add(movecoord(.loc_coord, 1, 0, 0), .loc_type, 1, .loc_shape, 5);
+    // Temp note: dur updated
+    loc_del(6);
+    loc_add(movecoord(loc_coord, 1, 0, 0), loc_type, 3, loc_shape, 6);
+    .loc_del(6);
+    .loc_add(movecoord(.loc_coord, 1, 0, 0), .loc_type, 1, .loc_shape, 6);
 }
 npc_tele(movecoord(npc_coord, -1, 0, 0));
 ~npc_retaliate(0);
@@ -241,10 +245,11 @@ cam_moveto(0_40_49_41_26, 450, 4, 2);
 npc_walk(0_40_49_47_26);
 p_delay(2);
 if(loc_find(0_40_49_46_26, loc_78) = true & .loc_find(0_40_49_46_27, loc_77) = true) {
-    loc_del(5);
-    loc_add(movecoord(loc_coord, 1, 0, 0), loc_type, 3, loc_shape, 5);
-    .loc_del(5);
-    .loc_add(movecoord(.loc_coord, 1, 0, 0), .loc_type, 1, .loc_shape, 5);
+    // Temp note: dur updated
+    loc_del(6);
+    loc_add(movecoord(loc_coord, 1, 0, 0), loc_type, 3, loc_shape, 6);
+    .loc_del(6);
+    .loc_add(movecoord(.loc_coord, 1, 0, 0), .loc_type, 1, .loc_shape, 6);
 }
 npc_tele(movecoord(npc_coord, -1, 0, 0));
 ~npc_retaliate(0);

--- a/data/src/scripts/quests/quest_arthur/scripts/quest_arthur.rs2
+++ b/data/src/scripts/quests/quest_arthur/scripts/quest_arthur.rs2
@@ -91,12 +91,15 @@ while(loc_findnext = true) {
      if(loc_category = keep_lefaye_door) {
             def_coord $central_coord = loc_coord;
             def_int $orig_angle = loc_angle;
-            loc_del(2);
+            // Temp note: dur updated
+            loc_del(3);
             if(loc_type = loc_71) {
-                loc_add(movecoord($central_coord, 1, 0, 0), blackknight_double_door_left, 1, loc_shape, 2);
-                loc_add(movecoord($central_coord, 1, 0, -1), blackknight_double_door_right, 3, loc_shape, 2); 
+                // Temp note: dur updated
+                loc_add(movecoord($central_coord, 1, 0, 0), blackknight_double_door_left, 1, loc_shape, 3);
+                loc_add(movecoord($central_coord, 1, 0, -1), blackknight_double_door_right, 3, loc_shape, 3); 
             }
-            loc_add($central_coord, loc_83, $orig_angle, loc_shape, 2);
+            // Temp note: dur updated
+            loc_add($central_coord, loc_83, $orig_angle, loc_shape, 3);
      }
 }
 p_teleport(movecoord(coord, -1, 0, 0));

--- a/data/src/scripts/quests/quest_ball/scripts/quest_ball.rs2
+++ b/data/src/scripts/quests/quest_ball/scripts/quest_ball.rs2
@@ -53,11 +53,13 @@ if($next_loc = loc_1563) {
     $next_angle = calc(loc_angle + 1);
 }
 p_teleport($dest);
-loc_change(loc_83, 2);
-loc_add(movecoord($loc_coord, 1, 0, 0), $next_loc, $next_angle, $shape, 2);
+// Temp note: dur updated
+loc_change(loc_83, 3);
+loc_add(movecoord($loc_coord, 1, 0, 0), $next_loc, $next_angle, $shape, 3);
 
 // this cupboard just opens/closes with loc_add/del
 [oploc1,loc_2868]
+// Temp note: dur does not need updated
 loc_change(loc_2869, 500);
 
 [oploc1,loc_2869]

--- a/data/src/scripts/quests/quest_biohazard/scripts/quest_biohazard.rs2
+++ b/data/src/scripts/quests/quest_biohazard/scripts/quest_biohazard.rs2
@@ -80,10 +80,12 @@ mes("The pigeons don't want to leave");
 if_close;
 mes("You climb up the rope ladder...");
 if (loc_find(0_39_51_61_3, loc_2066) = true) {
-    loc_change(loc_2065, 4);
+    // Temp note: dur updated
+    loc_change(loc_2065, 5);
 }
 if (loc_find(0_39_51_62_3, loc_2066) = true) {
-    loc_change(loc_2065, 4);
+    // Temp note: dur updated
+    loc_change(loc_2065, 5);
 }
 if(%biohazard_progress = ^biohazard_released_pigeons) %biohazard_progress = ^biohazard_climbed_ladder;
 p_delay(3); // 4t

--- a/data/src/scripts/quests/quest_blackarmgang/scripts/quest_blackarmgang.rs2
+++ b/data/src/scripts/quests/quest_blackarmgang/scripts/quest_blackarmgang.rs2
@@ -84,8 +84,9 @@ if ($leaving = true) {
     $dest = movecoord(loc_coord, $x, 0, $z);
 }
 p_teleport($dest);
-loc_change(loc_83, 2);
-loc_add(movecoord($loc_coord, $x, 0, $z), loc_1535, modulo(add($angle, 1), 4), $shape, 2);
+// Temp note: dur updated
+loc_change(loc_83, 3);
+loc_add(movecoord($loc_coord, $x, 0, $z), loc_1535, modulo(add($angle, 1), 4), $shape, 3);
 
 [opobj3,phoenix_crossbow]
 // not a zone specific check, you can drop a crossbow in the nearby building to trigger this dialogue 

--- a/data/src/scripts/quests/quest_chompybird/scripts/ogre_chest.rs2
+++ b/data/src/scripts/quests/quest_chompybird/scripts/ogre_chest.rs2
@@ -27,7 +27,8 @@ if (%chompybird_progress = ^chompybird_kids_play_with_toad) {
     %chompybird_progress = ^chompybird_removed_rock_from_chest;
 }
 // duration from OSRS
-loc_change(chompybird_ogre_chest_open, 48);
+// Temp note: dur updated ? Assuming this is an even number so I added 2 instead of 1
+loc_change(chompybird_ogre_chest_open, 50);
 
 [oploc1,chompybird_ogre_chest_open]
 anim(human_pickuptable, 0);

--- a/data/src/scripts/quests/quest_chompybird/scripts/raw_chompy.rs2
+++ b/data/src/scripts/quests/quest_chompybird/scripts/raw_chompy.rs2
@@ -59,7 +59,8 @@ if(%chompybird_progress = ^chompybird_complete) {
 [label,cook_chompy_offquest]
 mes("You carefully place the chompy bird on the spit-roast.");
 inv_del(inv, raw_chompy, 1);
-loc_change(ogre_spitroast_raw_chompy, 4);
+// Temp note: dur updated
+loc_change(ogre_spitroast_raw_chompy, 5);
 loc_anim(spit_anim);
 anim(human_cooking, 0);
 sound_synth(spit_roast, 0, 0);
@@ -68,7 +69,8 @@ p_delay(2);
 def_boolean $passes_roll = stat_random(stat(cooking), 200, 255);
 if ($passes_roll = true) {
     mes("You start to cook the chompy... it takes some time.");
-    loc_change(ogre_spitroast_cooked_chompy, 4);
+    // Temp note: dur updated
+    loc_change(ogre_spitroast_cooked_chompy, 5);
     loc_anim(spit_anim);
     anim(human_cooking, 0);
     p_delay(2);
@@ -78,7 +80,8 @@ if ($passes_roll = true) {
     stat_advance(cooking, 140);
 } else {
     mes("You accidentally burn the chompy.");
-    loc_change(ogre_spitroast_burnt_chompy, 4);
+    // Temp note: dur updated
+    loc_change(ogre_spitroast_burnt_chompy, 5);
     loc_anim(spit_anim);
     anim(human_cooking, 0);
     p_delay(2);
@@ -179,7 +182,8 @@ if ($has_rantz_ingredient = false | $has_bugs_ingredient = false | $has_fycie_in
 
 mes("You carefully place the chompy bird on the spit-roast.");
 inv_del(inv, raw_chompy, 1);
-loc_change(ogre_spitroast_raw_chompy, 4);
+// Temp note: dur updated
+loc_change(ogre_spitroast_raw_chompy, 5);
 loc_anim(spit_anim);
 anim(human_cooking, 0);
 sound_synth(spit_roast, 0, 0);
@@ -190,7 +194,8 @@ if ($passes_roll = true) {
     mes("You add the other ingredients and cook the food.");
     %chompybird_progress = ^chompybird_chompy_cooked;
     ~delete_chompy_ingredients($rantz_ingredient, $bugs_ingredient, $fycie_ingredient);
-    loc_change(ogre_spitroast_cooked_chompy, 4);
+    // Temp note: dur updated
+    loc_change(ogre_spitroast_cooked_chompy, 5);
     loc_anim(spit_anim);
     anim(human_cooking, 0);
     p_delay(2);
@@ -203,7 +208,8 @@ if ($passes_roll = true) {
 } else {
     mes("You accidentally burn the chompy.");
     ~delete_chompy_ingredients($rantz_ingredient, $bugs_ingredient, $fycie_ingredient);
-    loc_change(ogre_spitroast_burnt_chompy, 4);
+    // Temp note: dur updated
+    loc_change(ogre_spitroast_burnt_chompy, 5);
     loc_anim(spit_anim);
     anim(human_cooking, 0);
     p_delay(2);

--- a/data/src/scripts/quests/quest_cog/scripts/locs/quest_cog_gates_and_levers.rs2
+++ b/data/src/scripts/quests/quest_cog/scripts/locs/quest_cog_gates_and_levers.rs2
@@ -9,11 +9,13 @@ if (testbit(%cog_progress, ^quest_cog_rat_door_bit) = true) {
 [label,clock_tower_first_door_for_rat_cage]
 def_boolean $is_inside = ~check_axis(coord, loc_coord, loc_angle);
 if ($is_inside = true) {
+    // Temp note: dur does not need updated
     loc_del(500);
     loc_add(movecoord(loc_coord, 1, 0, 0), loc_1541, 3, loc_shape, 500);
     sound_synth(grate_open, 0, 0);
 
     if(loc_find(0_40_150_31_61, loc_33) = true) {
+        // Temp note: dur does not need updated
         loc_del(500);
         loc_add(loc_coord, loc_35, loc_angle, loc_shape, 500);
     }
@@ -28,10 +30,12 @@ facesquare(movecoord(loc_coord,0, 0, -1));
 //anim 2141 on OSRS and RS3
 anim(human_leverdown, 0);
 sound_synth(lever, 0, 0);
+// Temp note: dur does not need updated
 loc_del(500);
 loc_add(loc_coord, loc_35, loc_angle, loc_shape, 500);
 
 if(loc_find(0_40_150_35_57, loc_37) = true) {
+    // Temp note: dur does not need updated
     loc_del(500);
     loc_add(movecoord(loc_coord, 1, 0, 0), loc_1541, 3, loc_shape, 500);
 }
@@ -42,10 +46,12 @@ facesquare(movecoord(loc_coord,0, 0, -1));
 //anim 2141 on OSRS and RS3
 anim(human_leverdown, 0);
 sound_synth(lever, 0, 0);
+// Temp note: dur does not need updated
 loc_del(500);
 loc_add(loc_coord, loc_33, loc_angle, loc_shape, 500);
 
 if(loc_find(0_40_150_36_57, loc_1541) = true) {
+    // Temp note: dur does not need updated
     loc_del(500);
     loc_add(movecoord(loc_coord, -1, 0, 0), loc_37, 2, loc_shape, 2);
 }
@@ -62,6 +68,7 @@ facesquare(movecoord(loc_coord,0, 0, -1));
 //anim 2141 on OSRS and RS3
 anim(human_leverdown, 0);
 sound_synth(lever, 0, 0);
+// Temp note: dur does not need updated
 loc_del(500);
 loc_add(loc_coord, $replacement_loc, loc_angle, loc_shape, 500);
 

--- a/data/src/scripts/quests/quest_crest/scripts/quest_crest.rs2
+++ b/data/src/scripts/quests/quest_crest/scripts/quest_crest.rs2
@@ -33,6 +33,7 @@ session_log(^log_adventure, "Quest complete: Family Crest");
     anim(human_leverdown, 0);
     sound_synth(lever, 0, 0);
     // Tested on OSRS, levers revert to original state after 5 mins
+    // Temp note: dur does not need updated
     loc_change($new_loc, 500);
     if ($up = true) {
         %crest_spells_levers_gauntlets = setbit(%crest_spells_levers_gauntlets, $lever);

--- a/data/src/scripts/quests/quest_desertrescue/scripts/bedabin_nomad_guard.rs2
+++ b/data/src/scripts/quests/quest_desertrescue/scripts/bedabin_nomad_guard.rs2
@@ -9,7 +9,8 @@ if(%desertrescue_progress >= ^desertrescue_given_pineapple) {
         ~forcewalk(0_49_47_33_37);
         p_delay(max(0, calc(3 - $dist)));
     }
-    if(loc_find(0_49_47_33_38, loc_2700) = true) loc_change(loc_2701, 2);
+    // Temp note: dur updated
+    if(loc_find(0_49_47_33_38, loc_2700) = true) loc_change(loc_2701, 3);
     p_teleport(0_49_47_33_38);
     p_delay(3);
     return;
@@ -31,7 +32,8 @@ if(%desertrescue_progress >= ^desertrescue_given_pineapple) {
             ~forcewalk(0_49_47_33_37);
             p_delay(max(0, calc(3 - $dist)));
         }
-        if(loc_find(0_49_47_33_38, loc_2700) = true) loc_change(loc_2701, 2);
+        // Temp note: dur updated
+        if(loc_find(0_49_47_33_38, loc_2700) = true) loc_change(loc_2701, 3);
         p_teleport(0_49_47_33_38);
         p_delay(3);
     }
@@ -39,7 +41,8 @@ if(%desertrescue_progress >= ^desertrescue_given_pineapple) {
 
 [oploc1,loc_2700]
 if(testbit(%desertrescue_map_mechanisms, ^desertrescue_gained_tent_access) = true & %desertrescue_progress < ^desertrescue_learned_darts) {
-    loc_change(loc_2701, 2);
+    // Temp note: dur updated
+    loc_change(loc_2701, 3);
     if(coordz(coord) >= coordz(loc_coord)) {
         mes("You walk out of the tent.");
         p_teleport(0_49_47_33_37);
@@ -59,7 +62,8 @@ if(testbit(%desertrescue_map_mechanisms, ^desertrescue_gained_tent_access) = tru
             if_close;
             %desertrescue_map_mechanisms = setbit(%desertrescue_map_mechanisms, ^desertrescue_gained_tent_access);
             p_teleport(movecoord(coord, 0, 0, 1));
-            loc_change(loc_2701, 2); // curtain_open
+            // Temp note: dur updated
+            loc_change(loc_2701, 3); // curtain_open
             p_delay(3);
         } else { // todo - confirm mesanims
             ~chatnpc("<p,neutral>Sorry, no one is allowed to enter.");
@@ -83,7 +87,8 @@ if(last_useitem = technical_plans) {
             if_close;
             %desertrescue_map_mechanisms = setbit(%desertrescue_map_mechanisms, ^desertrescue_gained_tent_access);
             p_teleport(movecoord(coord, 0, 0, 1));
-            if(loc_find(0_49_47_33_38, loc_2700) = true) loc_change(loc_2701, 2);
+            // Temp note: dur updated
+            if(loc_find(0_49_47_33_38, loc_2700) = true) loc_change(loc_2701, 3);
         case ^desertrescue_retrieved_plans :
             ~chatnpc("<p,neutral>Hmm, those plans look interesting. Go and show them to Al Shabim... I'm sure he'll be pleased to see them.");
     }

--- a/data/src/scripts/quests/quest_dragon/scripts/magic_door.rs2
+++ b/data/src/scripts/quests/quest_dragon/scripts/magic_door.rs2
@@ -34,6 +34,7 @@ mes("You open the chest.");
 anim(human_openchest, 0);
 sound_synth(chest_open, 0, 0);
 p_delay(0);
+// Temp note: dur does not need updated
 loc_change(dragon_slayer_magic_chest_opened, 300);
 
 [oploc2,dragon_slayer_magic_chest_opened]
@@ -42,6 +43,7 @@ mes("You close the chest.");
 anim(human_closechest, 0);
 sound_synth(chest_close, 0, 0);
 p_delay(0);
+// Temp note: dur does not need updated
 loc_change(dragon_slayer_magic_chest_closed, 300);
 
 [oploc1,dragon_slayer_magic_chest_opened]
@@ -55,4 +57,5 @@ if (~quest_dragon_getting_map_parts = false | ~obj_gettotal(crandor_map_part3) >
     inv_add(inv, crandor_map_part3, 1);
 }
 // auto closes, yes. https://youtu.be/tmPf68hogzw?t=471
+// Temp note: dur does not need updated
 loc_change(dragon_slayer_magic_chest_closed, 300);

--- a/data/src/scripts/quests/quest_dragon/scripts/melzars_maze.rs2
+++ b/data/src/scripts/quests/quest_dragon/scripts/melzars_maze.rs2
@@ -142,6 +142,7 @@ mes("You open the chest.");
 anim(human_openchest, 0);
 sound_synth(chest_open, 0, 0);
 p_delay(0);
+// Temp note: dur does not need updated
 loc_change(melzar_maze_chest_opened, 300);
 
 
@@ -151,6 +152,7 @@ mes("You close the chest.");
 anim(human_closechest, 0);
 sound_synth(chest_close, 0, 0);
 p_delay(0);
+// Temp note: dur does not need updated
 loc_change(melzar_maze_chest_closed, 300);
 
 [oploc1,melzar_maze_chest_opened]
@@ -163,4 +165,5 @@ if (~quest_dragon_getting_map_parts = false | ~obj_gettotal(crandor_map_part1) >
     ~mesbox("You find a map piece in the chest.");
     inv_add(inv, crandor_map_part1, 1);
 }
+// Temp note: dur does not need updated
 loc_change(melzar_maze_chest_closed, 300);

--- a/data/src/scripts/quests/quest_drunkmonk/scripts/quest_drunkmonk.rs2
+++ b/data/src/scripts/quests/quest_drunkmonk/scripts/quest_drunkmonk.rs2
@@ -1,6 +1,7 @@
 [timer,blanket_ladder]
 if(distance(^blanket_ladder_coord, coord) <= 2 & ~drunkmonk_ladder_active = false) {
     mes("A ladder mysteriously appears.");
+    // Temp note: dur does not need updated
     loc_add(^blanket_ladder_coord, loc_1765, 1, centrepiece_straight, 200);
 }
 
@@ -69,6 +70,7 @@ def_int $count = 0;
 while($count < ^balloons_per_drop) {
     def_coord $balloon_coord = ~drunkmonk_balloon_coord;
     if(map_blocked($balloon_coord) = false & map_indoors($balloon_coord) = true & map_locaddunsafe($balloon_coord) = false) {
+        // Temp note: dur does not need updated
         loc_add($balloon_coord, ~random_balloon, random(4), centrepiece_straight, 200);
     }
     $count = calc($count + 1);

--- a/data/src/scripts/quests/quest_elena/scripts/sewerpipe.rs2
+++ b/data/src/scripts/quests/quest_elena/scripts/sewerpipe.rs2
@@ -38,6 +38,7 @@ loc_findallzone(^quest_elena_west_ardy_manhole_coord); // the manhole is not in 
 while (loc_findnext = true) {
     // if the manhole is closed we open it when getting out basically.
     if (loc_type = loc_2543) {
+        // Temp note: dur does not need updated
         loc_change(loc_2544, 500);
         loc_add(movecoord(loc_coord, 0, 0, -1), loc_2545, loc_angle, centrepiece_straight, 500);
     }

--- a/data/src/scripts/quests/quest_fishingcompo/scripts/quest_fishingcompo.rs2
+++ b/data/src/scripts/quests/quest_fishingcompo/scripts/quest_fishingcompo.rs2
@@ -57,10 +57,12 @@ while(loc_findnext = true) {
             def_coord $central_coord = loc_coord;
             def_int $orig_angle = loc_angle;
             def_loc $type = loc_type;
-            loc_change(loc_83, 2);
+            // Temp note: dur updated
+            loc_change(loc_83, 3);
             if($type = loc_47) {
-                loc_add(movecoord($central_coord, 1, 0, 0), loc_49, 1, loc_shape, 2);
-                loc_add(movecoord($central_coord, 2, 0, 0), loc_50, 1, loc_shape, 2); 
+                // Temp note: dur updated
+                loc_add(movecoord($central_coord, 1, 0, 0), loc_49, 1, loc_shape, 3);
+                loc_add(movecoord($central_coord, 2, 0, 0), loc_50, 1, loc_shape, 3); 
             }
      }
 }

--- a/data/src/scripts/quests/quest_grandtree/scripts/charlie.rs2
+++ b/data/src/scripts/quests/quest_grandtree/scripts/charlie.rs2
@@ -74,8 +74,8 @@ p_delay(2); // 3t
 if_close;
 // can't use door proc here since it opens incorrectly (notice the lock side)
 if(loc_find(movecoord(coord, 1, 0, 0), loc_3367) = true) {
-    loc_del(6);
-    loc_add(loc_coord, loc_1546, 1, loc_shape, 6);
+    // Temp note: dur updated
+    loc_add(loc_coord, loc_1546, 1, loc_shape, 7);
     sound_synth(locked, 0, 0);
 } 
 p_teleport(movecoord(coord, 1, 0, 0));

--- a/data/src/scripts/quests/quest_grandtree/scripts/femi.rs2
+++ b/data/src/scripts/quests/quest_grandtree/scripts/femi.rs2
@@ -56,7 +56,8 @@ p_delay(0);
 p_telejump(0_38_53_27_17);
 ~update_bas;
 if(loc_find(movecoord(coord, -1, 0, 1), loc_308) = false) {
-    loc_add(movecoord(coord, -1, 0, 1), loc_308, 0, centrepiece_straight, 199);
+    // Temp note: dur updated
+    loc_add(movecoord(coord, -1, 0, 1), loc_308, 0, centrepiece_straight, 200);
 }
 if(npc_find(coord, femi, 5, 0) = false) {
     npc_add(movecoord(coord, -1, 0, 0), femi, 200);
@@ -67,6 +68,7 @@ if(npc_find(coord, femi, 5, 0) = false) {
 
 [label,femi_boxes]
 if(loc_find(0_38_52_28_52, loc_83) = true) {
+    // Temp note: dur does not need updated
     loc_change(loc_361, 200);
 }
 ~chatnpc("<p,happy>Hello there.");

--- a/data/src/scripts/quests/quest_grandtree/scripts/femi.rs2
+++ b/data/src/scripts/quests/quest_grandtree/scripts/femi.rs2
@@ -90,6 +90,7 @@ switch_int(~p_choice2("Sorry, I'm a bit busy.", 1, "OK then.", 2)) {
         anim(human_pickupfloor, 0);
         p_delay(0);
         if(loc_find(movecoord(coord, -1, 0, 0), loc_361) = true) {
+            // Temp note: dur does not need updated
             loc_change(loc_83, 200); // rs3 removes loc here instead, this can get you stuck, not sure which is correct cause the cart doesn't change on RS3 as well
         }
         facesquare(0_38_52_26_50);
@@ -97,6 +98,7 @@ switch_int(~p_choice2("Sorry, I'm a bit busy.", 1, "OK then.", 2)) {
         anim(human_pickupfloor, 0);
         p_delay(0);
         if(loc_find(0_38_52_26_50, loc_307) = true) {
+            // Temp note: dur does not need updated
             loc_change(loc_308, 200);
         }
         p_delay(0);

--- a/data/src/scripts/quests/quest_grandtree/scripts/king_narnode.rs2
+++ b/data/src/scripts/quests/quest_grandtree/scripts/king_narnode.rs2
@@ -215,6 +215,7 @@ switch_int(%grandtree_progress) {
                 }
                 npc_facesquare(movecoord(^narnode_trapdoor_coord, -1, 0, -1));
                 if(loc_find(movecoord(^narnode_trapdoor_coord, -1, 0, -1), loc_2446) = true) {
+                    // Temp note: dur does not need updated ? @indio
                     loc_change(loc_2445, 10);
                 }
                 npc_say("Down here.");

--- a/data/src/scripts/quests/quest_grandtree/scripts/quest_grandtree.rs2
+++ b/data/src/scripts/quests/quest_grandtree/scripts/quest_grandtree.rs2
@@ -128,10 +128,12 @@ while(loc_findnext = true) {
             def_coord $central_coord = loc_coord;
             def_int $orig_angle = loc_angle;
             def_loc $type = loc_type;
-            loc_change(loc_83, 2);
+            // Temp note: dur updated
+            loc_change(loc_83, 3);
             if($type = loc_2438) {
-                loc_add(movecoord($central_coord, -1, 0, 0), loc_49, 3, loc_shape, 2);
-                loc_add(movecoord($central_coord, -2, 0, 0), loc_50, 3, loc_shape, 2); 
+                // Temp note: dur updated
+                loc_add(movecoord($central_coord, -1, 0, 0), loc_49, 3, loc_shape, 3);
+                loc_add(movecoord($central_coord, -2, 0, 0), loc_50, 3, loc_shape, 3); 
             }
      }
 }

--- a/data/src/scripts/quests/quest_grandtree/scripts/quest_grandtree.rs2
+++ b/data/src/scripts/quests/quest_grandtree/scripts/quest_grandtree.rs2
@@ -2,7 +2,8 @@
 if(%grandtree_progress = ^grandtree_complete) {
     anim(human_pickupfloor, 0);
     sound_synth(door_open, 0, 0);
-    loc_change(loc_2445, 5); 
+    // Temp note: dur updated
+    loc_change(loc_2445, 6); 
     p_delay(1);
     p_teleport(movecoord(coord, 0, 0, 6400));
     return;
@@ -53,6 +54,7 @@ if(%grandtree_progress = ^grandtree_given_twigs &
 if(%grandtree_progress >= ^grandtree_unlocked_trapdoor) {
     anim(human_pickupfloor, 0);
     sound_synth(door_open, 0, 0);
+    // Temp note: dur updated
     loc_change(loc_2445, 5); // idk cause this is varbit now, will assume same as the other trapdoor
     p_delay(1);
     p_teleport(0_38_154_59_8);
@@ -72,7 +74,8 @@ if(last_useitem = gloughs_key) {
     anim(human_openchest, 0);
     sound_synth(chest_open, 0, 0);
     p_delay(0);
-    loc_change(loc_3368, 4);
+    // Temp note: dur updated
+    loc_change(loc_3368, 5);
     if((%grandtree_progress = ^grandtree_found_invasion_plans | %grandtree_progress = ^grandtree_clue_charlie) & ~obj_gettotal(invasion_plans) = 0) {
         ~objbox(invasion_plans, "You have found a scroll!", 250, 0, 0);
         if(inv_freespace(inv) = 0) { 

--- a/data/src/scripts/quests/quest_haunted/scripts/quest_haunted.rs2
+++ b/data/src/scripts/quests/quest_haunted/scripts/quest_haunted.rs2
@@ -123,7 +123,8 @@ facesquare(movecoord(coord, 1, 0, 0));
 mes("The lever opens the secret door!");
 anim(human_leverdown, 0);
 sound_synth(lever, 0, 0);
-loc_change(loc_161, 3);
+// Temp note: dur updated
+loc_change(loc_161, 4);
 p_teleport(movecoord(coord, 0, 0, 1));
 p_delay(1);
 @manor_bookcase_door(movecoord(coord, 2, 0, 0));

--- a/data/src/scripts/quests/quest_haunted/scripts/quest_haunted.rs2
+++ b/data/src/scripts/quests/quest_haunted/scripts/quest_haunted.rs2
@@ -15,12 +15,15 @@ while(loc_findnext = true) {
      if(loc_category = manor_entrance) {
             def_coord $central_coord = loc_coord;
             def_int $orig_angle = loc_angle;
-            loc_del(3);
+            // Temp note: dur updated
+            loc_del(4);
             if(loc_type = loc_134) {
-                loc_add(movecoord($central_coord, 0, 0, 1), loc_1522, 0, loc_shape, 3);
-                loc_add(movecoord($central_coord, 1, 0, 1), loc_1523, 2, loc_shape, 3); 
+                // Temp note: dur updated
+                loc_add(movecoord($central_coord, 0, 0, 1), loc_1522, 0, loc_shape, 4);
+                loc_add(movecoord($central_coord, 1, 0, 1), loc_1523, 2, loc_shape, 4); 
             }
-            loc_add($central_coord, loc_83, $orig_angle, loc_shape, 3);
+            // Temp note: dur updated
+            loc_add($central_coord, loc_83, $orig_angle, loc_shape, 4);
      }
 }
 sound_synth(door_open, 0, 0);
@@ -135,11 +138,13 @@ p_delay(0);
 loc_findallzone(movecoord(coord, 0, 0, -1));
 while (loc_findnext = true) {
     if(loc_type = loc_155) {
-        loc_change(loc_83, 2);
-        loc_add(movecoord(loc_coord, 0, 0, -1), loc_157, loc_angle, loc_shape, 2);
+        // Temp note: dur updated
+        loc_change(loc_83, 3);
+        loc_add(movecoord(loc_coord, 0, 0, -1), loc_157, loc_angle, loc_shape, 3);
     } else if(loc_type = loc_156) {
-        loc_change(loc_83, 2);
-        loc_add(movecoord(loc_coord, 0, 0, 1), loc_157, loc_angle, loc_shape, 2);
+        // Temp note: dur updated
+        loc_change(loc_83, 3);
+        loc_add(movecoord(loc_coord, 0, 0, 1), loc_157, loc_angle, loc_shape, 3);
         sound_synth(coffin_open, 0, 0);
     }
 }

--- a/data/src/scripts/quests/quest_hero/scripts/locs/brimhaven_scarface_mansion.rs2
+++ b/data/src/scripts/quests/quest_hero/scripts/locs/brimhaven_scarface_mansion.rs2
@@ -7,6 +7,7 @@ if (%hero_progress >= ^hero_blackarm_mansion_unlocked & %blackarmgang_progress >
 @attempt_open_brimhaven_mansion_door;
 
 [oploc1,grips_cupboard_closed]
+// Temp note: dur does not need updated
 loc_change(grips_cupboard_opened, 500); // todo - how long to keep open?
 @summon_grip;
 
@@ -72,6 +73,7 @@ if (last_useitem = grips_keyring) {
 
 [oploc1,scarface_pete_candlestick_chest]
 mes("You open the chest.");
+// Temp note: dur does not need updated
 loc_change(scarface_pete_candlestick_chest_open, 500); // todo - how long to keep open?
 
 [oploc1,scarface_pete_candlestick_chest_open]
@@ -87,4 +89,5 @@ if (~obj_gettotal(petes_candlestick) > 0) {
     %hero_progress = ^hero_blackarm_looted_chest;
   }
 }
+// Temp note: dur does not need updated
 loc_change(scarface_pete_candlestick_chest, 500);

--- a/data/src/scripts/quests/quest_hunt/scripts/pirate_message.rs2
+++ b/data/src/scripts/quests/quest_hunt/scripts/pirate_message.rs2
@@ -9,8 +9,8 @@ if (last_useitem ! hunt_chest_key) {
 }
 
 p_delay(1);
-
-loc_change(hunt_chest_open, 8);
+// Temp note: dur updated ? Rounded up from 9 to 10 lol
+loc_change(hunt_chest_open, 10);
 sound_synth(chest_open, 0, 0);
 
 mes("All that's in the chest is a message...");

--- a/data/src/scripts/quests/quest_ikov/scripts/ikov_dungeon.rs2
+++ b/data/src/scripts/quests/quest_ikov/scripts/ikov_dungeon.rs2
@@ -88,6 +88,7 @@ p_teleport(0_41_153_30_17); // OSRS area here is a bit different, changed in lat
 if(last_useitem = ikov_lever) {
     ~mesbox("You fit the lever into the bracket.");
     inv_del(inv, ikov_lever, 1);
+    // Temp note: dur does not need updated
     loc_change(loc_87, 200); // 200t OSRS
 }
 ~displaymessage(^dm_default);
@@ -96,6 +97,7 @@ if(last_useitem = ikov_lever) {
 p_arrivedelay;
 anim(human_leverdown, 0); 
 sound_synth(lever, 0, 0);
+// Temp note: dur does not need updated ? @indio
 loc_change(loc_88, 20);
 p_delay(0);
 sound_synth(locked, 0, 0);
@@ -133,7 +135,8 @@ if(%ikov_progress = ^ikov_disabled_trap) %ikov_progress = ^ikov_pulled_lever;
 p_arrivedelay;
 anim(human_leverdown, 0);
 p_delay(0);
-loc_change(loc_88, 5);
+// Temp note: dur updated ? does it need ??
+loc_change(loc_88, 6);
 sound_synth(lever, 0, 0);
 if(%ikov_progress >= ^ikov_disabled_trap) {
     return;

--- a/data/src/scripts/quests/quest_itexam/scripts/area_digsite.rs2
+++ b/data/src/scripts/quests/quest_itexam/scripts/area_digsite.rs2
@@ -780,6 +780,7 @@ if (last_useitem = digsite_chest_key) {
     anim(human_openchest, 0);
     inv_del(inv, digsite_chest_key, 1);
     p_delay(0);
+    // Temp note: dur does not need updated
     loc_change(digsite_chest_open, 300);
 } else {
     ~displaymessage(^dm_default);

--- a/data/src/scripts/quests/quest_itexam/scripts/area_exam_centre.rs2
+++ b/data/src/scripts/quests/quest_itexam/scripts/area_exam_centre.rs2
@@ -2,6 +2,7 @@
 anim(human_openchest, 0);
 mes("You open the cupboard.");
 p_delay(0);
+// Temp note: dur does not need updated
 loc_change(exam_centre_cupboard_rock_pick_open, 300);
 
 [oploc1,exam_centre_cupboard_rock_pick_open]
@@ -15,6 +16,7 @@ if (inv_total(inv, rock_pick) = 0) {
 [oploc2,exam_centre_cupboard_rock_pick_open]
 anim(human_openchest, 0);
 p_delay(0);
+// Temp note: dur does not need updated
 loc_change(exam_centre_cupboard_rock_pick, 300);
 
 [label,exam_centre_cupboard_jar]

--- a/data/src/scripts/quests/quest_itgronigen/scripts/quest_itgronigen.rs2
+++ b/data/src/scripts/quests/quest_itgronigen/scripts/quest_itgronigen.rs2
@@ -64,11 +64,13 @@ npc_add(map_findsquare(coord, 0, 1, ^map_findsquare_lineofwalk), poison_spider_o
 npc_setmode(opplayer2);
 ~npc_retaliate(0);
 queue(poison_player, 0, 15);
+// Temp note: dur does not need updated
 loc_change(loc_2191, 300);
 
 [oploc2,loc_2195]
 mes("You search the chest.");
 mes("The chest contains some antipoison.");
+// Temp note: dur does not need updated
 loc_change(loc_2192, 300);
 if(inv_freespace(inv) = 0) {
     mes("But you don't have space to carry it.");
@@ -91,6 +93,7 @@ if(inv_freespace(inv) = 0) {
     return;
 }
 ~objbox(keep_key, "You find a keep key.", 250, 0, 0);
+// Temp note: dur does not need updated
 loc_change(loc_2197, 300);
 inv_add(inv, keep_key, 1);
 

--- a/data/src/scripts/quests/quest_itgronigen/scripts/quest_itgronigen.rs2
+++ b/data/src/scripts/quests/quest_itgronigen/scripts/quest_itgronigen.rs2
@@ -124,12 +124,15 @@ while(loc_findnext = true) {
      if(loc_category = observatory_dungeon_gate) {
             def_coord $central_coord = loc_coord;
             def_int $orig_angle = loc_angle;
-            loc_del(2);
+            // Temp note: dur updated
+            loc_del(3);
             if(loc_type = loc_2199) {
-                loc_add(movecoord($central_coord, -1, 0, 1), loc_1562, 0, loc_shape, 2);
-                loc_add(movecoord($central_coord, 0, 0, 1), loc_1563, 2, loc_shape, 2);
+                // Temp note: dur updated
+                loc_add(movecoord($central_coord, -1, 0, 1), loc_1562, 0, loc_shape, 3);
+                loc_add(movecoord($central_coord, 0, 0, 1), loc_1563, 2, loc_shape, 3);
             }
-            loc_add($central_coord, loc_83, $orig_angle, loc_shape, 2);
+            // Temp note: dur updated
+            loc_add($central_coord, loc_83, $orig_angle, loc_shape, 3);
      }
 }
 sound_synth(grate_open, 0, 0); //iron_door_open

--- a/data/src/scripts/quests/quest_itwatchtower/scripts/quest_itwatchtower.rs2
+++ b/data/src/scripts/quests/quest_itwatchtower/scripts/quest_itwatchtower.rs2
@@ -425,9 +425,11 @@ $opposite_coord = ~movecoord_loc_return(~multiply2(~door_close(loc_angle, loc_sh
 p_teleport($dest);
 sound_synth(grate_open, 0, 0);
 if (loc_type = loc_2788) {
-    ~open_double_doors_left(2, double_door_open_and_close_right, null);
+    // Temp note: dur updated
+    ~open_double_doors_left(3, double_door_open_and_close_right, null);
 } else {
-    ~open_double_doors_right(2, double_door_open_and_close_left, null);
+    // Temp note: dur updated
+    ~open_double_doors_right(3, double_door_open_and_close_left, null);
 }
 
 loc_add($opposite_coord, loc_83, $angle, $shape, 2);

--- a/data/src/scripts/quests/quest_itwatchtower/scripts/quest_itwatchtower.rs2
+++ b/data/src/scripts/quests/quest_itwatchtower/scripts/quest_itwatchtower.rs2
@@ -432,8 +432,9 @@ if (loc_type = loc_2788) {
     ~open_double_doors_right(3, double_door_open_and_close_left, null);
 }
 
-loc_add($opposite_coord, loc_83, $angle, $shape, 2);
-loc_add($loc_coord, loc_83, $angle, $shape, 2);
+// Temp note: dur updated
+loc_add($opposite_coord, loc_83, $angle, $shape, 3);
+loc_add($loc_coord, loc_83, $angle, $shape, 3);
 
 [oploc1,loc_2823]
 mes("You enter the tunnel.");

--- a/data/src/scripts/quests/quest_itwatchtower/scripts/quest_itwatchtower.rs2
+++ b/data/src/scripts/quests/quest_itwatchtower/scripts/quest_itwatchtower.rs2
@@ -207,6 +207,7 @@ mes("The chest is locked.");
 [oplocu,loc_2790]
 if(last_useitem = toban_key) {
     if(inv_freespace(inv) = 0) {
+        // Temp note: dur does not need updated ??
         loc_change(loc_3273, 20);
         sound_synth(chest_open, 0, 0);
         ~mesbox("There is something in there.|But you don't have the free space to hold it.");
@@ -217,6 +218,7 @@ if(last_useitem = toban_key) {
 ~displaymessage(^dm_default);
 
 [label,open_toban_chest]
+// Temp note: dur does not need updated ?? @indio
 loc_change(loc_3273, 20);
 sound_synth(chest_open, 0, 0);
 if(inv_total(inv, tobans_gold) > 0) {
@@ -294,7 +296,8 @@ if(last_useitem = rope) {
     anim(seq_775, 0);
     p_delay(0);
     inv_del(inv, rope, 1);
-    loc_change(loc_2324, 4);
+    // Temp note: dur updated
+    loc_change(loc_2324, 5);
     p_delay(0);
     loc_anim(rope_swing);
     ~agility_exactmove(human_ropeswing, 20, 0, coord, movecoord(loc_coord, 6, 0, 0), 45, 70, ^exact_east, false);
@@ -336,6 +339,7 @@ p_arrivedelay;
 anim(human_openchest, 0);
 sound_synth(chest_open, 0, 0);
 p_delay(0);
+// Temp note: dur does not need updated
 loc_change(loc_3273, 300);
 mes("Ahh! There is a spider inside.");
 mes("Someone's idea of a joke...");
@@ -347,6 +351,7 @@ p_arrivedelay;
 anim(human_openchest, 0);
 sound_synth(chest_open, 0, 0);
 p_delay(0);
+// Temp note: dur does not need updated
 loc_change(loc_3273, 300);
 switch_int(random(8)) {
     case 0 :

--- a/data/src/scripts/quests/quest_junglepotion/scripts/quest_junglepotion.rs2
+++ b/data/src/scripts/quests/quest_junglepotion/scripts/quest_junglepotion.rs2
@@ -64,6 +64,7 @@ switch_namedobj($unid) {
 }
 inv_add(inv, $unid, 1);
 if ($loc ! null) {
+	// Temp note: dur does not need updated
 	loc_change($loc, 100);
 }
 ~objbox($unid, "You find a herb.", 250, 0, divide(^objbox_height, 2));

--- a/data/src/scripts/quests/quest_priest/scripts/quest_priest.rs2
+++ b/data/src/scripts/quests/quest_priest/scripts/quest_priest.rs2
@@ -10,6 +10,7 @@ anim(human_openchest, 0);
 sound_synth(coffin_open, 0, 0);
 ~check_restlessghost_spawn; // probably before delay like closing
 p_delay(0);
+// Temp note: dur does not need updated
 loc_change(loc_2146, 300);
 
 [oploc2,loc_2145]
@@ -21,6 +22,7 @@ anim(human_closechest, 0);
 sound_synth(coffin_close, 0, 0);
 ~check_restlessghost_spawn; // https://youtu.be/QX-ieoyDXh4?si=mJjuZG052xLGiVWq&t=950
 p_delay(0);
+// Temp note: dur does not need updated
 loc_change(loc_2145, 300);
 
 [proc,check_restlessghost_spawn]

--- a/data/src/scripts/quests/quest_sheepherder/scripts/locs/sheepherder_gate.rs2
+++ b/data/src/scripts/quests/quest_sheepherder/scripts/locs/sheepherder_gate.rs2
@@ -24,10 +24,12 @@ while(loc_findnext = true) {
             def_coord $central_coord = loc_coord;
             def_int $orig_angle = loc_angle;
             def_loc $type = loc_type;
-            loc_change(loc_83, 2);
+            // Temp note: dur updated
+            loc_change(loc_83, 3);
             if($type = sheepherder_gate_left) {
-                loc_add(movecoord($central_coord, 1, 0, 0), loc_49, 1, loc_shape, 2);
-                loc_add(movecoord($central_coord, 2, 0, 0), loc_50, 1, loc_shape, 2); 
+                // Temp note: dur updated
+                loc_add(movecoord($central_coord, 1, 0, 0), loc_49, 1, loc_shape, 3);
+                loc_add(movecoord($central_coord, 2, 0, 0), loc_50, 1, loc_shape, 3); 
             }
      }
 }

--- a/data/src/scripts/quests/quest_totem/scripts/quest_totem.rs2
+++ b/data/src/scripts/quests/quest_totem/scripts/quest_totem.rs2
@@ -142,6 +142,7 @@ if(inv_total(inv, totem) = 0 & inv_total(bank, totem) = 0) {
 } else {
     mes("The chest is empty.");
 }
+// Temp note: dur does not need updated
 loc_change(loc_2709, 300);
 
 [oploc2,loc_2710]

--- a/data/src/scripts/quests/quest_upass/scripts/kardia.rs2
+++ b/data/src/scripts/quests/quest_upass/scripts/kardia.rs2
@@ -86,6 +86,7 @@ p_arrivedelay;
 anim(human_openchest, 0);
 sound_synth(chest_open, 0, 0);
 p_delay(0);
+// Temp note: dur does not need updated ?? @indio I assume
 loc_change(loc_3273, 20);
 @search_kardia_chest;
 

--- a/data/src/scripts/quests/quest_upass/scripts/quest_upass.rs2
+++ b/data/src/scripts/quests/quest_upass/scripts/quest_upass.rs2
@@ -214,7 +214,8 @@ if(last_useitem = spade) {
     mes("You dig into the pile of mud...");
     mes("...and find it's a filled in tunnel!");
     p_delay(1);
-    loc_change(loc_3218, 2); // todo: check this timing
+    // Temp note: dur updated
+    loc_change(loc_3218, 3); // todo: check this timing
     mes("You push your way through the tunnel.");
     p_delay(0);
     p_teleport(0_37_150_24_46);
@@ -527,6 +528,7 @@ if(inv_total(inv, amulet_of_doomion) > 0 & inv_total(inv, amulet_of_othanian) > 
     p_delay(1);
     mes("...You place them on the chest and it opens.");
     sound_synth(chest_open, 0, 0);
+    // Temp note: dur does not need updated
     loc_change(loc_378, 10); // osrs uses 378, you can kind of break this chest for a few minutes but idk if that was original behaviour
     p_delay(1);
     if(inv_total(inv, ibans_shadow) > 0) { // no doll check
@@ -581,7 +583,8 @@ if(coordx(loc_coord) < coordx(coord)) {
         return;
     }
     mes("You pull open the large doors...");
-    loc_change(loc_param(next_loc_stage), 4);
+    // Temp note: dur updated
+    loc_change(loc_param(next_loc_stage), 5);
     sound_synth(door_open, 0, 0);
     ~forcemove(movecoord(loc_coord, -1, 0, 0));
     if(getbit_range(%upass_map_mechanisms, ^upass_blood_on_doll, ^upass_shadow_on_doll) = calc(pow(2,4) - 1) & inv_total(inv, doll_of_iban) > 0 
@@ -603,7 +606,8 @@ if(coordx(loc_coord) < coordx(coord)) {
     }
 } else {
     mes("You pull open the large doors.");
-    loc_change(loc_param(next_loc_stage), 4);
+    // Temp note: dur updated
+    loc_change(loc_param(next_loc_stage), 5);
     p_teleport(loc_coord);
     p_delay(0);
     mes("...And walk out of the temple.");

--- a/data/src/scripts/quests/quest_upass/scripts/quest_upass.rs2
+++ b/data/src/scripts/quests/quest_upass/scripts/quest_upass.rs2
@@ -460,6 +460,7 @@ if(last_useitem = dwarf_brew) {
     }
     sound_synth(fire_lit, 0, 0);
     mes("It bursts into flames.");
+    // Temp note: dur does not need updated
     loc_add(0_36_153_52_8, loc_3357, 3, wall_l, 10);
     loc_add(0_36_153_53_8, loc_3357, 3, wall_straight, 10);
     loc_add(0_36_153_54_8, loc_3357, 3, wall_straight, 10);

--- a/data/src/scripts/quests/quest_upass/scripts/upass_bridge.rs2
+++ b/data/src/scripts/quests/quest_upass/scripts/upass_bridge.rs2
@@ -79,7 +79,8 @@ p_delay(0);
 mes("The bridge falls.");
 mes("You rush across the bridge.");
 if(loc_find(0_38_151_11_52, loc_3239) = true) {
-    loc_change(loc_3240, 7);
+    // Temp note: dur updated
+    loc_change(loc_3240, 8);
 }
 p_delay(3);
 p_teleport(0_38_151_10_52);
@@ -89,13 +90,15 @@ if(%upass_progress = ^upass_spoken_koftik) %upass_progress = ^upass_passed_bridg
 mes("You pull the old lever...");
 anim(seq_798, 0);
 sound_synth(lever, 0, 0);
-loc_change(loc_3242, 3);
+// Temp note: dur updated
+loc_change(loc_3242, 4);
 ~forcemove(0_38_151_7_51);
 p_delay(2);
 ~forcemove(movecoord(coord, 1, 0, 1));
 p_delay(1);
 if(loc_find(0_38_151_11_52, loc_3239) = true) {
-    loc_change(loc_3240, 4);
+    // Temp note: dur updated
+    loc_change(loc_3240, 5);
 }
 ~forcemove(movecoord(coord, 2, 0, 0));
 p_delay(1);

--- a/data/src/scripts/quests/quest_upass/scripts/upass_grid.rs2
+++ b/data/src/scripts/quests/quest_upass/scripts/upass_grid.rs2
@@ -1,7 +1,8 @@
 [oploc1,loc_3337]
 mes("You pull the lever...");
 sound_synth(lever, 0, 0);
-loc_change(loc_3242, 14);
+// Temp note: dur updated !! nice even number :)
+loc_change(loc_3242, 15);
 p_delay(1);
 mes("The portcullis opens.");
 if(loc_find(0_38_151_33_10, loc_3303) = true) {

--- a/data/src/scripts/quests/quest_upass/scripts/upass_obstacles.rs2
+++ b/data/src/scripts/quests/quest_upass/scripts/upass_obstacles.rs2
@@ -58,7 +58,8 @@ mes("You cannot open the grill from this side.");
 [oploc1,loc_3235]
 p_arrivedelay;
 mes("You open the grating.");
-loc_change(loc_3236, 9);
+// Temp note: dur updated!!! nice even number :)
+loc_change(loc_3236, 10);
 ~agility_exactmove(human_pipesqueeze, 30, 3, coord, movecoord(coord, 0, 0, 3), 30, 126, ^exact_north, true);
 sound_synth(squeeze_in, 0, 0);
 mes("You crawl through the pipe.");
@@ -97,7 +98,8 @@ mes("You tie the rope to the rock...");
 anim(seq_775, 0);
 p_delay(0);
 inv_del(inv, rope, 1);
-loc_change(loc_2273, 4);
+// Temp note: dur updated
+loc_change(loc_2273, 5);
 p_delay(0);
 // https://youtu.be/zGVrFETj96E?si=-LiJOUm_2GMCx7VU&t=144, might need more data
 if(stat_random(stat(agility), 100, 410) = false) {

--- a/data/src/scripts/quests/quest_upass/scripts/upass_obstacles.rs2
+++ b/data/src/scripts/quests/quest_upass/scripts/upass_obstacles.rs2
@@ -187,18 +187,23 @@ if(last_useitem = plank) {
     sound_synth(put_down, 0, 0);
     p_delay(1);
     mes("...and quickly walk over.");
-    loc_del(4);
+    // Temp note: dur updated
+    loc_del(5);
     if(coordz(coord) > coordz(loc_coord)) {
-        loc_add(loc_coord, loc_3231, 0, grounddecor, 4);
+        // Temp note: dur updated
+        loc_add(loc_coord, loc_3231, 0, grounddecor, 5);
         ~forcemove(movecoord(loc_coord, 0, 0, -1));
     } else if(coordz(coord) < coordz(loc_coord)) {
-        loc_add(loc_coord, loc_3231, 0, grounddecor, 4);
+        // Temp note: dur updated
+        loc_add(loc_coord, loc_3231, 0, grounddecor, 5);
         ~forcemove(movecoord(loc_coord, 0, 0, 1));
     } else if(coordx(coord) > coordx(loc_coord)) {
-        loc_add(loc_coord, loc_3231, 1, grounddecor, 4);
+        // Temp note: dur updated
+        loc_add(loc_coord, loc_3231, 1, grounddecor, 5);
         ~forcemove(movecoord(loc_coord, -1, 0, 0));
     } else {
-        loc_add(loc_coord, loc_3231, 1, grounddecor, 4);
+        // Temp note: dur updated
+        loc_add(loc_coord, loc_3231, 1, grounddecor, 5);
         ~forcemove(movecoord(loc_coord, 1, 0, 0));
     }
 }

--- a/data/src/scripts/quests/quest_vampire/scripts/quest_vampire.rs2
+++ b/data/src/scripts/quests/quest_vampire/scripts/quest_vampire.rs2
@@ -7,6 +7,7 @@
 ~send_quest_progress(questlist:vampire, %vampire_progress, ^vampire_complete);
 
 [label,quest_vampire_coffin_open]
+// Temp note: dur does not need updated ?? nice even number
 loc_change(loc_2615, 10);
 if (%vampire_progress = ^vampire_complete | %vampire_progress = ^quest_vampire_not_started) {
     return;
@@ -30,6 +31,7 @@ npc_sethuntmode(aggressive_melee_extra);
 npc_sethunt(5);
 
 [label,quest_vampire_coffin_close]
+// Temp note: dur does not need updated ??? bc it's a good number
 loc_change(loc_2614, 10);
 
 [label,quest_vampire_coffin_search]

--- a/data/src/scripts/quests/quest_waterfall/scripts/quest_waterfall.rs2
+++ b/data/src/scripts/quests/quest_waterfall/scripts/quest_waterfall.rs2
@@ -208,10 +208,12 @@ p_arrivedelay;
 anim(seq_774, 0);
 spotanim_map(spotanim_67, movecoord($rock_coord, 0, 0, 6), 0, 20);
 p_delay(1);
-loc_change(loc_1997, 7);
+// Temp note: dur updated
+loc_change(loc_1997, 8);
 def_int $i = 1;
 while($i < 8) {
-    loc_add(movecoord($rock_coord, 0, 0, $i), loc_1998, loc_angle, loc_shape, calc(8 - $i));
+    // Temp note: dur updated
+    loc_add(movecoord($rock_coord, 0, 0, $i), loc_1998, loc_angle, loc_shape, calc(9 - $i));
     $i = calc($i + 1);
 }
 ~agility_force_move(0, seq_776, movecoord(coord, 0, 0, -7));

--- a/data/src/scripts/quests/quest_zombiequeen/scripts/quest_zombiequeen.rs2
+++ b/data/src/scripts/quests/quest_zombiequeen/scripts/quest_zombiequeen.rs2
@@ -85,12 +85,15 @@ while(loc_findnext = true) {
     if(loc_category = shilo_metalgate) {
             def_coord $central_coord = loc_coord;
             def_int $orig_angle = loc_angle;
-            loc_del(2);
+            // Temp note: dur updated
+            loc_del(3);
             if(loc_type = loc_2259) {
-                loc_add(movecoord($central_coord, -1, 0, 0), loc_1562, 3, loc_shape, 2);
-                loc_add(movecoord($central_coord, -1, 0, 1), loc_1563, 1, loc_shape, 2);
+                // Temp note: dur updated
+                loc_add(movecoord($central_coord, -1, 0, 0), loc_1562, 3, loc_shape, 3);
+                loc_add(movecoord($central_coord, -1, 0, 1), loc_1563, 1, loc_shape, 3);
             }
-            loc_add($central_coord, loc_83, $orig_angle, loc_shape, 2);
+            // Temp note: dur updated
+            loc_add($central_coord, loc_83, $orig_angle, loc_shape, 3);
             sound_synth(grate_open, 0, 0);
     }
 }
@@ -104,10 +107,12 @@ if(%zombiequeen_progress >= ^zombiequeen_complete) {
             def_coord $central_coord = loc_coord;
             def_int $orig_angle = loc_angle;
             def_loc $type = loc_type;
-            loc_change(loc_83, 2);
+            // Temp note: dur updated
+            loc_change(loc_83, 3);
             if($type = loc_2261) {
-                loc_add(movecoord($central_coord, 1, 0, 0), loc_2263, 1, loc_shape, 2);
-                loc_add(movecoord($central_coord, 2, 0, 0), loc_2264, 1, loc_shape, 2); 
+                // Temp note: dur updated
+                loc_add(movecoord($central_coord, 1, 0, 0), loc_2263, 1, loc_shape, 3);
+                loc_add(movecoord($central_coord, 2, 0, 0), loc_2264, 1, loc_shape, 3); 
             }
         }
     }
@@ -268,12 +273,15 @@ while(loc_findnext = true) {
      if(loc_type = loc_2255 | loc_type = loc_2256) {
             def_coord $central_coord = loc_coord;
             def_int $orig_angle = loc_angle;
-            loc_del(2);
+            // Temp note: dur updated
+            loc_del(3);
             if(loc_type = loc_2255) {
-                loc_add(movecoord($central_coord, 0, 0, 1), loc_1562, 0, loc_shape, 2);
-                loc_add(movecoord($central_coord, 1, 0, 1), loc_1563, 2, loc_shape, 2); 
+                // Temp note: dur updated
+                loc_add(movecoord($central_coord, 0, 0, 1), loc_1562, 0, loc_shape, 3);
+                loc_add(movecoord($central_coord, 1, 0, 1), loc_1563, 2, loc_shape, 3); 
             }
-            loc_add($central_coord, loc_83, $orig_angle, loc_shape, 2);
+            // Temp note: dur updated
+            loc_add($central_coord, loc_83, $orig_angle, loc_shape, 3);
      }
 }
 sound_synth(grate_open, 0, 0);
@@ -675,7 +683,8 @@ switch_int(~p_choice3("A ladder", 1, "A crude raft", 2, "A pole vault", 3)) {
         ~mesbox("You see that this table already looks very sea worthy it takes virtually no time at all to help fix it into a crude raft.");
         if_close;
         mes("You place it carefully on the water!");
-        loc_add(0_45_146_17_29, loc_2227, 0, centrepiece_straight, 6);
+        // Temp note: dur updated
+        loc_add(0_45_146_17_29, loc_2227, 0, centrepiece_straight, 7);
         cam_shake(4, 0, 20, 5);
         cam_shake(1, 0, 20, 4);
         stat_advance(crafting, 30);
@@ -687,34 +696,40 @@ switch_int(~p_choice3("A ladder", 1, "A crude raft", 2, "A pole vault", 3)) {
         mes("You push off!");
         p_delay(1);
         say("Weeeeeeee!");
-        loc_del(1);
-        loc_add(0_45_146_12_17, loc_2227, 0, centrepiece_straight, 2);
+        // Temp note: dur updated
+        loc_del(2);
+        loc_add(0_45_146_12_17, loc_2227, 0, centrepiece_straight, 3);
         p_telejump(0_45_146_12_17);
         p_delay(1);
-        loc_del(1);
-        loc_add(0_45_146_22_7, loc_2227, 1, centrepiece_straight, 2);
+        // Temp note: dur updated
+        loc_del(2);
+        loc_add(0_45_146_22_7, loc_2227, 1, centrepiece_straight, 3);
         p_telejump(0_45_146_22_7);
         p_delay(1);
         say("Weeeeeeee!");
-        loc_del(1);
-        loc_add(0_45_146_38_6, loc_2227, 1, centrepiece_straight, 2);
+        // Temp note: dur updated
+        loc_del(2);
+        loc_add(0_45_146_38_6, loc_2227, 1, centrepiece_straight, 3);
         p_telejump(0_45_146_38_6);
         p_delay(1);
-        loc_del(1);
-        loc_add(0_45_146_47_7, loc_2227, 1, centrepiece_straight, 2);
+        // Temp note: dur updated
+        loc_del(2);
+        loc_add(0_45_146_47_7, loc_2227, 1, centrepiece_straight, 3);
         p_telejump(0_45_146_47_7);
         p_delay(1);
         mes("You come to a huge waterfall...");
         say("* Uh oh! *");
-        loc_del(1);
-        loc_add(0_45_146_55_7, loc_2227, 1, centrepiece_straight, 2);
+        // Temp note: dur updated
+        loc_del(2);
+        loc_add(0_45_146_55_7, loc_2227, 1, centrepiece_straight, 3);
         p_telejump(0_45_146_55_7);
         cam_moveto(0_45_146_48_7, 550, 100, 100);
         cam_lookat(0_46_146_7_7, 20, 100, 100);
         p_delay(1);
         mes("...And plough through it!");
-        loc_del(1);
-        loc_add(0_45_146_61_7, loc_2227, 1, centrepiece_straight, 2);
+        // Temp note: dur updated
+        loc_del(2);
+        loc_add(0_45_146_61_7, loc_2227, 1, centrepiece_straight, 3);
         p_teleport(0_45_146_61_7);
         p_delay(1);
         cam_reset;
@@ -722,24 +737,31 @@ switch_int(~p_choice3("A ladder", 1, "A crude raft", 2, "A pole vault", 3)) {
         facesquare(movecoord(coord, 8, 0, 0));
         p_delay(0);
         p_telejump(movecoord(coord, 1, 0, 0));
-        loc_add(coord, loc_2227, 1, centrepiece_straight, 2);
+        // Temp note: dur updated
+        loc_add(coord, loc_2227, 1, centrepiece_straight, 3);
         p_delay(1);
         loc_del(1);
         p_telejump(movecoord(coord, 1, 0, 0));
-        loc_add(coord, loc_2227, 1, centrepiece_straight, 7);
+        // Temp note: dur updated
+        loc_add(coord, loc_2227, 1, centrepiece_straight, 8);
         p_delay(0);
         mes("The raft soons breaks up.");
-        loc_change(loc_1988, 5);
+        // Temp note: dur updated
+        loc_change(loc_1988, 6);
         ~agility_exactmove(human_sidestep_fall, 5, 0, coord, movecoord(coord, 0, 0, 1), 6, 30, ^exact_east, false);
-        loc_del(1);
+        // Temp note: dur updated
+        loc_del(2);
         sound_synth(pool_plop, 0, 0);
         spotanim_map(watersplash, coord, 0, 0);
-        loc_add(movecoord(coord, 1, 0, 0), loc_1988, 1, centrepiece_straight, 5);
+        // Temp note: dur updated
+        loc_add(movecoord(coord, 1, 0, 0), loc_1988, 1, centrepiece_straight, 6);
         ~set_readyandwalk_bas(seq_773, seq_773, human_swim);
         p_delay(0);
         ~forcemove(movecoord(coord, 0, 0, 1));
         ~update_bas;
-        loc_del(1);
+        // Temp note: dur updated
+        loc_del(2);
+        // Temp note: dur does not need updated ? @indio
         loc_add(0_45_46_53_7, loc_1988, 1, centrepiece_straight, 10);
         ~forcemove(movecoord(coord, 0, 0, 1));
     case 3 :
@@ -1333,12 +1355,13 @@ if(coordz(coord) <= coordz(loc_coord)) {
     p_teleport(loc_coord);
 }
 if((loc_find(0_45_148_12_8, loc_2246) = true | loc_find(0_45_148_12_8, loc_2248) = true | loc_find(0_45_148_12_8, loc_2249) = true) & (.loc_find(0_45_148_13_8, loc_2247) = true | .loc_find(0_45_148_13_8, loc_2250) = true)) {
-    loc_change(loc_2249, 2);
-    .loc_change(loc_2250, 2);
-    loc_change(loc_83, 2);
-    .loc_change(loc_83, 2);
-    loc_add(movecoord(loc_coord, 0, 0, 1), loc_2251, 0, loc_shape, 2);
-    .loc_add(movecoord(.loc_coord, 0, 0, 1), loc_2252, 2, .loc_shape, 2);
+    // Temp note: dur updated
+    loc_change(loc_2249, 3);
+    .loc_change(loc_2250, 3);
+    loc_change(loc_83, 3);
+    .loc_change(loc_83, 3);
+    loc_add(movecoord(loc_coord, 0, 0, 1), loc_2251, 0, loc_shape, 3);
+    .loc_add(movecoord(.loc_coord, 0, 0, 1), loc_2252, 2, .loc_shape, 3);
     sound_synth(coffin_open, 0, 0);
 }
 

--- a/data/src/scripts/quests/quest_zombiequeen/scripts/quest_zombiequeen.rs2
+++ b/data/src/scripts/quests/quest_zombiequeen/scripts/quest_zombiequeen.rs2
@@ -740,7 +740,8 @@ switch_int(~p_choice3("A ladder", 1, "A crude raft", 2, "A pole vault", 3)) {
         // Temp note: dur updated
         loc_add(coord, loc_2227, 1, centrepiece_straight, 3);
         p_delay(1);
-        loc_del(1);
+        // Temp note: dur updated
+        loc_del(2);
         p_telejump(movecoord(coord, 1, 0, 0));
         // Temp note: dur updated
         loc_add(coord, loc_2227, 1, centrepiece_straight, 8);

--- a/data/src/scripts/skill_agility/scripts/wilderness_course.rs2
+++ b/data/src/scripts/skill_agility/scripts/wilderness_course.rs2
@@ -138,12 +138,15 @@ while(loc_findnext = true) {
      if(loc_category = wilderness_course_main_gate) {
             def_coord $central_coord = loc_coord;
             def_int $orig_angle = loc_angle;
-            loc_del(3);
+            // Temp note: dur updated
+            loc_del(4);
             if(loc_type = loc_2308) {
-                loc_add(movecoord($central_coord, 0, 0, -1), loc_1563, 0, loc_shape, 3);
-                loc_add(movecoord($central_coord, 1, 0, -1), loc_1562, 2, loc_shape, 3); 
+                // Temp note: dur updated
+                loc_add(movecoord($central_coord, 0, 0, -1), loc_1563, 0, loc_shape, 4);
+                loc_add(movecoord($central_coord, 1, 0, -1), loc_1562, 2, loc_shape, 4); 
             }
-            loc_add($central_coord, loc_83, $orig_angle, loc_shape, 3);
+            // Temp note: dur updated
+            loc_add($central_coord, loc_83, $orig_angle, loc_shape, 4);
      }
 }
 sound_synth(door_open, 0, 0);
@@ -152,8 +155,9 @@ sound_synth(door_open, 0, 0);
 loc_findallzone(coord);
 while(loc_findnext = true) {
     if(loc_type = loc_2309) {
-        loc_change(loc_83, 2);
-        loc_add(movecoord(loc_coord, 0, 0, -1), loc_1541, 0, loc_shape, 2);
+        // Temp note: dur updated
+        loc_change(loc_83, 3);
+        loc_add(movecoord(loc_coord, 0, 0, -1), loc_1541, 0, loc_shape, 3);
         sound_synth(door_open, 0, 0);
     }
 }

--- a/data/src/scripts/skill_firemaking/scripts/firemaking.rs2
+++ b/data/src/scripts/skill_firemaking/scripts/firemaking.rs2
@@ -113,6 +113,7 @@ facesquare($fire_coord);
 //mes("<tostring(map_clock)>, <tostring(%action_delay)>: The fire catches and the logs begin to burn.");
 mes("The fire catches and the logs begin to burn.");
 def_int $delay = calc(100 + random(100)); // firemaking length: https://archive.is/zF5hb
+// Temp note: dur does not need updated
 loc_add($fire_coord, loc_2732, 1, centrepiece_straight, $delay);
 
 // -2 to match osrs behavior. Potentially this is an engine problem with world_delay being too slow though

--- a/data/src/scripts/skill_mining/scripts/mining.rs2
+++ b/data/src/scripts/skill_mining/scripts/mining.rs2
@@ -127,6 +127,7 @@ if (random($chance) = ^true) {
     // p_delay(0);
     // deplete
     def_int $respawn = ~scale_by_playercount(db_getfield($data, mining_table:rock_respawnrate, 0));
+    // Temp note: dur does not need updated
     loc_change(loc_param(next_loc_stage_mining), $respawn);
     sound_synth(sound_230, 0, 0); // Sudden says its sound_230
     anim(null, 0);
@@ -169,6 +170,7 @@ if (random($chance) = ^true) {
 } else if (stat_random(stat(mining), db_getfield($data, mining_table:rock_successchance, 0)) = true) {
     // deplete
     def_int $respawn = ~scale_by_playercount(db_getfield($data, mining_table:rock_respawnrate, 0));
+    // Temp note: dur does not need updated
     loc_change(loc_param(next_loc_stage_mining), $respawn);
     sound_synth(sound_230, 0, 0); // Sudden says its sound_230
     anim(null, 0);
@@ -213,6 +215,7 @@ if (stat_random(stat(mining), $low, $high) = true) {
     // p_delay(0);
     // deplete
     def_int $respawn = ~scale_by_playercount(db_getfield($data, mining_table:rock_respawnrate, 0));
+    // Temp note: dur does not need updated
     loc_change(loc_param(next_loc_stage_mining), $respawn);
     // stop mining, give ore and xp.
     sound_synth(found_gem, 0, 0);

--- a/data/src/scripts/skill_thieving/scripts/chest/trapped_chest.rs2
+++ b/data/src/scripts/skill_thieving/scripts/chest/trapped_chest.rs2
@@ -102,8 +102,10 @@ mes("You find treasure inside!");
 anim(human_openchest, 0);
 stat_advance(thieving, $experience);
 ~trapped_chest_check_for_reward($data);
-loc_change(loc_2574, 3); //opened chest
+// Temp note: dur updated
+loc_change(loc_2574, 4); //opened chest
 p_delay(3);
+// Temp note: dur does not need updated ???
 loc_change(loc_2572, $respawn_ticks); //looted chest
 
 [oploc1,loc_2572]

--- a/data/src/scripts/skill_thieving/scripts/thieving.rs2
+++ b/data/src/scripts/skill_thieving/scripts/thieving.rs2
@@ -92,6 +92,7 @@ switch_loc (loc_type) {
 }
 ~stealing_check_for_reward($data);
 stat_advance(thieving, $experience);
+// Temp note: dur does not need updated
 loc_change(market_stall, $respawn_ticks);
 
 [label,activate_trapped_chest]
@@ -129,7 +130,7 @@ anim(human_openchest, 0);
 def_int $experience = db_getfield($data, trapped_chest:experience, 0);
 stat_advance(thieving, $experience);
 def_int $respawn_ticks = db_getfield($data, trapped_chest:respawn_ticks, 0);
-
+// Temp note: dur does not need updated
 loc_change(loc_2574, $respawn_ticks);
 
 if (db_getfieldcount($data, trapped_chest:tele_coord) > 0) {

--- a/data/src/scripts/skill_woodcutting/scripts/old_woodcut.rs2
+++ b/data/src/scripts/skill_woodcutting/scripts/old_woodcut.rs2
@@ -30,7 +30,7 @@ if (%action_delay = map_clock) {
         stat_advance(woodcutting, 250);
         inv_add(inv, logs, 1);
         // Temp note: dur does not need updated
-        loc_change(loc_param(next_loc_stage), ~scale_by_playercount(~random_range(120, 198)));
+        loc_change(loc_param(next_loc_stage), ~scale_by_playercount(add(120, random(80))));
         anim(null, 0);
         return;
     }

--- a/data/src/scripts/skill_woodcutting/scripts/old_woodcut.rs2
+++ b/data/src/scripts/skill_woodcutting/scripts/old_woodcut.rs2
@@ -29,6 +29,7 @@ if (%action_delay = map_clock) {
         mes("You get some logs.");
         stat_advance(woodcutting, 250);
         inv_add(inv, logs, 1);
+        // Temp note: dur does not need updated
         loc_change(loc_param(next_loc_stage), ~scale_by_playercount(~random_range(120, 198)));
         anim(null, 0);
         return;

--- a/data/src/scripts/skill_woodcutting/scripts/woodcut.rs2
+++ b/data/src/scripts/skill_woodcutting/scripts/woodcut.rs2
@@ -120,7 +120,7 @@ def_int $deplete_chance = 8; // 1/8 chance to deplete
 // if normal tree, add some variance
 // scuffed way of doing it but it works
 if ($respawnrate = 0) {
-    $respawnrate = ~random_range(120, 198);
+    $respawnrate = add(120, random(80));
     $deplete_chance = 0;
 }
 if (stat_random(stat(woodcutting), $tree_chance_low, $tree_chance_high) = true) {

--- a/data/src/scripts/tutorial/scripts/skills/tut_firemaking.rs2
+++ b/data/src/scripts/tutorial/scripts/skills/tut_firemaking.rs2
@@ -81,6 +81,7 @@ if (%tutorial_progress = ^survival_guide_build_fire) {
     ~set_tutorial_progress;
 }
 def_int $delay = 150;
+// Temp note: dur does not need updated
 loc_add($fire_coord, loc_2732, 1, centrepiece_straight, $delay);
 world_delay($delay);
 obj_add($fire_coord, ashes, 1, 100);

--- a/data/src/scripts/tutorial/scripts/skills/tut_mining.rs2
+++ b/data/src/scripts/tutorial/scripts/skills/tut_mining.rs2
@@ -71,6 +71,7 @@ sound_synth(mine_quick, 0, 10);
 p_delay(0);
 sound_synth(sound_230, 0, 10);
 p_delay(0);
+// Temp note: dur does not need updated ??
 loc_change(plainrock1, 10);
 anim(null, 0);
 return(true);

--- a/data/src/scripts/tutorial/scripts/skills/tut_woodcut.rs2
+++ b/data/src/scripts/tutorial/scripts/skills/tut_woodcut.rs2
@@ -81,6 +81,7 @@ if (%tutorial_progress = ^survival_guide_cut_tree) {
 [proc,tut_woodcutting_swap_loc]
 // Seem to be a fixed 9.6 seconds https://www.youtube.com/watch?v=Ln_NMq4eQss
 def_int $respawnrate = 16;
+// Temp note: dur does not need updated ??
 loc_change(loc_param(next_loc_stage), $respawnrate);
 // set skill anim so it doesnt continue after depletion
 anim(null, $respawnrate);

--- a/data/src/scripts/tutorial/scripts/tut_doors_and_gates.rs2
+++ b/data/src/scripts/tutorial/scripts/tut_doors_and_gates.rs2
@@ -5,10 +5,12 @@ while(loc_findnext = true) {
         def_coord $central_coord = loc_coord;
         def_int $orig_angle = loc_angle;
         def_loc $type = loc_type;
-        loc_change(loc_83, 2);
+        // Temp note: dur updated
+        loc_change(loc_83, 3);
         if($type = loc_3015) {
-             loc_add(movecoord($central_coord, 1, 0, 0), loc_49, 1, loc_shape, 2);
-             loc_add(movecoord($central_coord, 2, 0, 0), loc_50, 1, loc_shape, 2);
+            // Temp note: dur updated
+             loc_add(movecoord($central_coord, 1, 0, 0), loc_49, 1, loc_shape, 3);
+             loc_add(movecoord($central_coord, 2, 0, 0), loc_50, 1, loc_shape, 3);
         }
     }
 }
@@ -132,13 +134,15 @@ while(loc_findnext = true) {
      if(loc_category = tut_mining_exit) {
             def_coord $central_coord = loc_coord;
             def_int $orig_angle = loc_angle;
-
-            loc_del(2);
+            // Temp note: dur updated
+            loc_del(3);
             if(loc_type = loc_3020) {
-                loc_add(movecoord($central_coord, 1, 0, 0), loc_1562, 1, loc_shape, 2);
-                loc_add(movecoord($central_coord, 1, 0, -1), loc_1563, 3, loc_shape, 2);
+                // Temp note: dur updated
+                loc_add(movecoord($central_coord, 1, 0, 0), loc_1562, 1, loc_shape, 3);
+                loc_add(movecoord($central_coord, 1, 0, -1), loc_1563, 3, loc_shape, 3);
             }
-            loc_add($central_coord, loc_83, $orig_angle, loc_shape, 2);
+            // Temp note: dur updated
+            loc_add($central_coord, loc_83, $orig_angle, loc_shape, 3);
      }
 }
 sound_synth(door_open, 0, 0);
@@ -180,12 +184,15 @@ while(loc_findnext = true) {
     if(loc_category = rat_pit_cage) {
         def_coord $central_coord = loc_coord;
         def_int $orig_angle = loc_angle;
-        loc_del(2);
+        // Temp note: dur updated
+        loc_del(3);
         if(loc_type = loc_3022) {
-            loc_add(movecoord($central_coord, -1, 0, 0), loc_1562, 3, loc_shape, 2);
-            loc_add(movecoord($central_coord, -1, 0, 1), loc_1563, 1, loc_shape, 2);
+            // Temp note: dur updated
+            loc_add(movecoord($central_coord, -1, 0, 0), loc_1562, 3, loc_shape, 3);
+            loc_add(movecoord($central_coord, -1, 0, 1), loc_1563, 1, loc_shape, 3);
         }
-        loc_add($central_coord, loc_83, $orig_angle, loc_shape, 2);
+        // Temp note: dur updated
+        loc_add($central_coord, loc_83, $orig_angle, loc_shape, 3);
     }
 }
 sound_synth(door_open, 0, 0);

--- a/src/engine/World.ts
+++ b/src/engine/World.ts
@@ -323,7 +323,7 @@ class World {
             this.loginThread.postMessage({
                 type: 'world_startup'
             });
-    
+
             this.friendThread.postMessage({
                 type: 'connect'
             });
@@ -1315,8 +1315,8 @@ class World {
         // In OSRS I suspect they use a counter per Loc/Obj to keep track of events rather than scheduling for a tick
         // In 2004scape, we schedule for a tick. Scheduling for a tick ends up naturally 1 tick slower, so we do a -1 to compensate to match OSRS behavior
         // - Bea5
-        entity.setLifeCycle(this.currentTick + duration);
-        this.trackZone(this.currentTick + duration, zone);
+        entity.setLifeCycle(this.currentTick + duration - 1);
+        this.trackZone(this.currentTick + duration - 1, zone);
         this.trackZone(this.currentTick, zone);
     }
 


### PR DESCRIPTION
Our `loc_add`, `loc_change`, `loc_del`, `obj_add`, and `obj_del` commands all processed 1 tick slow compared to OSRS. This made things that took, for example, 500 ticks end up being 1 tick too slow. Also, our resource respawns were likely 1 tick too slow

However, we had a lot of content that was written to match OSRS assuming a 1 tick slow event. Since we sped up every event by 1 tick, we have to manually slow down over 150 examples in content where the behavior matched previously 😬

The majority of this PR is sifting through 90+ files and checking whether or not we need to slow down these commands by 1 tick. For every case of `loc_add`, `loc_change`, and `loc_del` I have added a comment that explains whether I chose to slow it down to match previous behavior, or leave it alone to let it be sped up 1 tick by the engine change

@Indio3 @tannerdino Please scroll through files changed if you can 