### PR TITLE
fix(engine): input tracking bugfix

### DIFF
--- a/src/engine/World.ts
+++ b/src/engine/World.ts
@@ -94,7 +94,7 @@ import { printDebug, printError, printInfo } from '#/util/Logger.js';
 import WalkTriggerSetting from '#/util/WalkTriggerSetting.js';
 import { createWorker } from '#/util/WorkerFactory.js';
 
-import InputTrackingEvent from './entity/tracking/InputEvent.js';
+import InputTrackingBlob from './entity/tracking/InputEvent.js';
 
 const priv = forge.pki.privateKeyFromPem(Environment.STANDALONE_BUNDLE ? await (await fetch('data/config/private.pem')).text() : fs.readFileSync('data/config/private.pem', 'ascii'));
 
@@ -2188,13 +2188,13 @@ class World {
         });
     }
 
-    submitInputTracking(username: string, session_uuid: string, events: InputTrackingEvent[]) {
+    submitInputTracking(username: string, session_uuid: string, blobs: InputTrackingBlob[]) {
         this.loggerThread.postMessage({
             type: 'input_track',
             username,
             session_uuid,
             timestamp: Date.now(),
-            events
+            blobs
         });
     }
 

--- a/src/engine/entity/Player.ts
+++ b/src/engine/entity/Player.ts
@@ -1201,7 +1201,7 @@ export default class Player extends PathingEntity {
     }
 
     processInputTracking(): void {
-        this.input.process();
+        this.input.onCycle();
     }
 
     // ----

--- a/src/engine/entity/tracking/InputEvent.ts
+++ b/src/engine/entity/tracking/InputEvent.ts
@@ -1,4 +1,4 @@
-export default class InputTrackingEvent {
+export default class InputTrackingBlob {
     readonly seq: number;
     readonly data: string;
     readonly coord?: number;

--- a/src/network/rs225/client/handler/EventTrackingHandler.ts
+++ b/src/network/rs225/client/handler/EventTrackingHandler.ts
@@ -18,7 +18,7 @@ export default class EventTrackingHandler extends MessageHandler<EventTracking> 
         if (!player.input.shouldSubmitTrackingDetails()) {
             return true;
         }
-        if (player.input.recordedEventsSizeTotal > Environment.NODE_LIMIT_BYTES_PER_TRACKING_SESSION) {
+        if (player.input.recordedBlobsSizeTotal > Environment.NODE_LIMIT_BYTES_PER_TRACKING_SESSION) {
             // An upper limit for the quantity of data used for a tracking session.
             // Prevents further parsing/storing of events.
             return false;

--- a/src/server/logger/LoggerClient.ts
+++ b/src/server/logger/LoggerClient.ts
@@ -1,4 +1,4 @@
-import InputTrackingEvent from '#/engine/entity/tracking/InputEvent.js';
+import InputTrackingBlob from '#/engine/entity/tracking/InputEvent.js';
 import InternalClient from '#/server/InternalClient.js';
 import Environment from '#/util/Environment.js';
 
@@ -49,7 +49,7 @@ export default class LoggerClient extends InternalClient {
         );
     }
 
-    public async inputTrack(username: string, session_uuid: string, timestamp: number, events: InputTrackingEvent[]) {
+    public async inputTrack(username: string, session_uuid: string, timestamp: number, blobs: InputTrackingBlob[]) {
         await this.connect();
 
         if (!this.ws || !this.wsr || !this.wsr.checkIfWsLive()) {
@@ -64,7 +64,7 @@ export default class LoggerClient extends InternalClient {
                 username,
                 session_uuid,
                 timestamp,
-                events
+                blobs
             })
         );
     }

--- a/src/server/logger/LoggerServer.ts
+++ b/src/server/logger/LoggerServer.ts
@@ -1,7 +1,7 @@
 import { WebSocketServer } from 'ws';
 
 import { db, loggerDb, toDbDate } from '#/db/query.js';
-import InputTrackingEvent from '#/engine/entity/tracking/InputEvent.js';
+import InputTrackingBlob from '#/engine/entity/tracking/InputEvent.js';
 import { SessionLog } from '#/engine/entity/tracking/SessionLog.js';
 import Environment from '#/util/Environment.js';
 import { printInfo } from '#/util/Logger.js';
@@ -61,8 +61,8 @@ export default class LoggerServer {
                             break;
                         }
                         case 'input_track': {
-                            const { username, session_uuid, timestamp, events } = msg;
-                            if (!events.length) {
+                            const { username, session_uuid, timestamp, blobs } = msg;
+                            if (!blobs.length) {
                                 break;
                             }
 
@@ -78,12 +78,12 @@ export default class LoggerServer {
                                         timestamp: toDbDate(timestamp)
                                     })
                                     .executeTakeFirst();
-                                const values = events.map((e: InputTrackingEvent) => {
+                                const values = blobs.map((blob: InputTrackingBlob) => {
                                     return {
                                         input_report_id: report.insertId,
-                                        seq: e.seq,
-                                        coord: e.coord,
-                                        data: Buffer.from(e.data, 'base64')
+                                        seq: blob.seq,
+                                        coord: blob.coord,
+                                        data: Buffer.from(blob.data, 'base64')
                                     };
                                 });
                                 await loggerDb.insertInto('input_report_event_raw').values(values).execute();

--- a/src/server/logger/LoggerThread.ts
+++ b/src/server/logger/LoggerThread.ts
@@ -58,8 +58,8 @@ async function handleRequests(_parentPort: ParentPort, msg: any) {
         }
         case 'input_track': {
             if (Environment.LOGGER_SERVER) {
-                const { username, session_uuid, timestamp, events } = msg;
-                await client.inputTrack(username, session_uuid, timestamp, events);
+                const { username, session_uuid, timestamp, blobs } = msg;
+                await client.inputTrack(username, session_uuid, timestamp, blobs);
             }
             break;
         }


### PR DESCRIPTION
Current code has a bug where it does not properly wait for the client data to be sent after tracking ends. It was supposed to wait a number of ticks for the client to send this. As a result, we are often discarding some input tracking data from the client.

```
if (this.waitingForLastReport) {
    if (this.endTrackingAt + InputTracking.FINAL_REPORT_TIME_LEEWAY >
World.currentTick) {
        // Finalize tracking
    }
}
```

This will not wait the intended duration before finalizing the tracking session as the logic is wrong. `endTrackingAt+16` will always be greater than `World.currentTick`. So if a client took more than 1 tick to send its input tracking bundle it would be discarded.

Issue can be reproduced by delaying the FinishTracking ClientProt by a tick, or modifying client to wait an extra tick before sending its input data.

In fixing this I have also reworked the class for better readability.