### PR TITLE
fix(engine): Truncate stat_subs percentage calculation

### DIFF
--- a/src/engine/script/handlers/NpcOps.ts
+++ b/src/engine/script/handlers/NpcOps.ts
@@ -436,7 +436,7 @@ const NpcOps: CommandHandlers = {
 
         const npc = state.activeNpc;
         const current = npc.levels[stat];
-        const subbed = current - (constant + (current * percent) / 100);
+        const subbed = current - Math.trunc(constant + (current * percent) / 100);
         npc.levels[stat] = Math.max(subbed, 0);
     }),
 

--- a/src/engine/script/handlers/PlayerOps.ts
+++ b/src/engine/script/handlers/PlayerOps.ts
@@ -472,7 +472,7 @@ const PlayerOps: CommandHandlers = {
 
         const player = state.activePlayer;
         const current = player.levels[stat];
-        const subbed = current - (constant + (current * percent) / 100);
+        const subbed = current - Math.trunc(constant + (current * percent) / 100);
         player.levels[stat] = Math.max(subbed, 0);
         if (subbed !== current) {
             player.changeStat(stat);


### PR DESCRIPTION
Implementation for stat drains seems to be incorrect.

Zammy flames drains one more point than expected

osrs: https://imgur.com/a/ci5dbP0
pre-fix: https://imgur.com/a/zFv737U

npc reduction: https://imgur.com/a/QbuS8x4