### PR TITLE
fix(engine): Truncate statsub percentage calculations

### DIFF
--- a/src/engine/script/handlers/NpcOps.ts
+++ b/src/engine/script/handlers/NpcOps.ts
@@ -436,7 +436,7 @@ const NpcOps: CommandHandlers = {
 
         const npc = state.activeNpc;
         const current = npc.levels[stat];
-        const subbed = current - Math.trunc(constant + (current * percent) / 100);
+        const subbed = current - ((constant + (current * percent) / 100) | 0);
         npc.levels[stat] = Math.max(subbed, 0);
     }),
 

--- a/src/engine/script/handlers/NpcOps.ts
+++ b/src/engine/script/handlers/NpcOps.ts
@@ -244,7 +244,7 @@ const NpcOps: CommandHandlers = {
         const npc = state.activeNpc;
         const base = npc.baseLevels[stat];
         const current = npc.levels[stat];
-        const healed = current + (constant + (current * percent) / 100);
+        const healed = current + ((constant + (current * percent) / 100) | 0);
         npc.levels[stat] = Math.min(healed, base);
 
         // reset hero points if hp current == base

--- a/src/engine/script/handlers/NpcOps.ts
+++ b/src/engine/script/handlers/NpcOps.ts
@@ -436,7 +436,7 @@ const NpcOps: CommandHandlers = {
 
         const npc = state.activeNpc;
         const current = npc.levels[stat];
-        const subbed = current - (constant + (current * percent) / 100);
+        const subbed = current - Math.trunc(constant + (current * percent) / 100);
         npc.levels[stat] = Math.max(subbed, 0);
     }),
 

--- a/src/engine/script/handlers/NpcOps.ts
+++ b/src/engine/script/handlers/NpcOps.ts
@@ -419,7 +419,7 @@ const NpcOps: CommandHandlers = {
 
         const npc = state.activeNpc;
         const current = npc.levels[stat];
-        const added = current + (constant + (current * percent) / 100);
+        const added = current + ((constant + (current * percent) / 100) | 0);
         npc.levels[stat] = Math.min(added, 255);
 
         if (stat === 0 && npc.levels[stat] >= npc.baseLevels[stat]) {

--- a/src/engine/script/handlers/PlayerOps.ts
+++ b/src/engine/script/handlers/PlayerOps.ts
@@ -453,7 +453,7 @@ const PlayerOps: CommandHandlers = {
 
         const player = state.activePlayer;
         const current = player.levels[stat];
-        const added = current + (constant + (current * percent) / 100);
+        const added = current + ((constant + (current * percent) / 100) | 0);
         player.levels[stat] = Math.min(added, 255);
         if (stat === 3 && player.levels[3] >= player.baseLevels[3]) {
             player.heroPoints.clear();

--- a/src/engine/script/handlers/PlayerOps.ts
+++ b/src/engine/script/handlers/PlayerOps.ts
@@ -472,7 +472,7 @@ const PlayerOps: CommandHandlers = {
 
         const player = state.activePlayer;
         const current = player.levels[stat];
-        const subbed = current - Math.trunc(constant + (current * percent) / 100);
+        const subbed = current - ((constant + (current * percent) / 100) | 0);
         player.levels[stat] = Math.max(subbed, 0);
         if (subbed !== current) {
             player.changeStat(stat);

--- a/src/engine/script/handlers/PlayerOps.ts
+++ b/src/engine/script/handlers/PlayerOps.ts
@@ -472,7 +472,7 @@ const PlayerOps: CommandHandlers = {
 
         const player = state.activePlayer;
         const current = player.levels[stat];
-        const subbed = current - (constant + (current * percent) / 100);
+        const subbed = current - Math.trunc(constant + (current * percent) / 100);
         player.levels[stat] = Math.max(subbed, 0);
         if (subbed !== current) {
             player.changeStat(stat);

--- a/src/engine/script/handlers/PlayerOps.ts
+++ b/src/engine/script/handlers/PlayerOps.ts
@@ -497,7 +497,7 @@ const PlayerOps: CommandHandlers = {
         const player = state.activePlayer;
         const base = player.baseLevels[stat];
         const current = player.levels[stat];
-        const healed = current + (constant + (current * percent) / 100);
+        const healed = current + ((constant + (current * percent) / 100) | 0);
         player.levels[stat] = Math.max(Math.min(healed, base), current);
 
         if (stat === 3 && player.levels[3] >= player.baseLevels[3]) {


### PR DESCRIPTION
Implementation for stat drains seems to be incorrect.

Zammy flames drains one more point than expected

osrs: https://imgur.com/a/ci5dbP0
pre-fix: https://imgur.com/a/zFv737U

npc reduction: https://imgur.com/a/QbuS8x4
