### PR TITLE
feat(client): Add auto client sizing

### DIFF
--- a/view/client.ejs
+++ b/view/client.ejs
@@ -143,6 +143,28 @@
             return size;
         }
  
+        function toggleAutoSizing() {
+            let canvas = document.getElementById('canvas');
+            let autoSizing = localStorage.getItem('autoSizing') !== 'true';
+
+            canvasAutoSizing(canvas, autoSizing);
+            
+            localStorage.setItem('autoSizing', autoSizing);
+        }
+
+        function canvasAutoSizing(canvas, autoSizing) {
+            if (autoSizing) {
+                canvas.style.width = '100%';
+                canvas.style.height = 'auto';
+                
+                let maxWidth = ((window.innerHeight - 120) / 532) * 789; 
+                canvas.style.maxWidth = maxWidth + 'px';
+            } else {
+                let canvasSize = localStorage.getItem('canvasSize');
+                setCanvasSize(canvas, canvasSize || 1);
+            }
+        }
+
         function saveScreenshot() {
             document.getElementById('screenshot').download = 'screenshot-' + Math.floor(Date.now() / 1000) + '.png';
             document.getElementById('screenshot').href = document.getElementById('canvas').toDataURL('image/png').replace(/^data:image\/[^;]/, 'data:application/octet-stream');
@@ -212,6 +234,11 @@
                     hideControls();
                 }
             }
+
+            let autoSizing = localStorage.getItem('autoSizing') === 'true';
+            if (autoSizing) {
+                canvasAutoSizing(canvas, autoSizing);
+            }
         }
     </script>
 </head>
@@ -228,6 +255,7 @@
             <a class="green" href="#" id="fullscreen" onclick="toggleFullscreen();">Go fullscreen</a> |
             <a class="green" href="#" id="filtering" onclick="toggleFiltering();">Auto scaling</a> |
             <a class="green" href="#" id="canvasSize" onclick="changeCanvasSize();">1x size</a> |
+            <a class="green" href="#" id="canvasAutoSizing" onclick="toggleAutoSizing();">Toggle auto sizing</a> |
             <a class="green" href="#" id="screenshot" onclick="saveScreenshot();">Take screenshot</a> |
             <a class="green" href="#" id="hide" onclick="hideControls();">Hide controls</a>
         </div>


### PR DESCRIPTION
Added auto sizing because often the 2x or 3x sizing doesn't fit right for me, and the fullscreen means I can't use other tabs when I am playing on a single monitor.

Below is a demo.

https://github.com/user-attachments/assets/43574e09-5e6f-4417-ab1b-d364af447b65

I have added a 120px height margin for the max width of the client, because in the real client there is the top navigation bar. This might need to change slightly for the real thing.

This is easy to change, it's just this line here

`let maxWidth = ((window.innerHeight - 120) / 532) * 789; `

Make that 140 instead of 120 or etc.