### PR TITLE
fix(engine): The engine now more directly checks if an entity is active, rather than inferring it indirectly

### DIFF
--- a/src/engine/World.ts
+++ b/src/engine/World.ts
@@ -673,7 +673,7 @@ class World {
         const start: number = Date.now();
         for (const npc of this.npcs) {
             try {
-                if (npc.checkLifeCycle(this.currentTick)) {
+                if (npc.isActive) {
                     if (npc.delayed && this.currentTick >= npc.delayedUntil) npc.delayed = false;
 
                     // - resume suspended script
@@ -1113,7 +1113,7 @@ class World {
         // - reset npcs
         this.npcRenderer.removeTemporary();
         for (const npc of this.npcs) {
-            if (!npc.checkLifeCycle(tick)) {
+            if (!npc.isActive) {
                 continue;
             }
 

--- a/src/engine/entity/BuildArea.ts
+++ b/src/engine/entity/BuildArea.ts
@@ -105,7 +105,6 @@ export default class BuildArea {
         const min = -radius >> 1;
         const max = radius >> 1;
         const length = radius ** 2;
-        const tick: number = World.currentTick;
 
         let dx = 0;
         let dz = 0;
@@ -120,7 +119,7 @@ export default class BuildArea {
                         if (this.players.size >= BuildArea.PREFERRED_PLAYERS) {
                             return;
                         }
-                        if (this.filterPlayer(player, pid, level, x, z, tick)) {
+                        if (this.filterPlayer(player, pid, level, x, z)) {
                             yield player;
                         }
                     }
@@ -144,7 +143,6 @@ export default class BuildArea {
         const startZ: number = CoordGrid.zone(z - distance);
         const endX: number = CoordGrid.zone(x + distance);
         const endZ: number = CoordGrid.zone(z + distance);
-        const tick: number = World.currentTick;
 
         for (let zx = startX; zx <= endX; zx++) {
             const zoneX: number = zx << 3;
@@ -154,7 +152,7 @@ export default class BuildArea {
                     if (this.players.size >= BuildArea.PREFERRED_PLAYERS) {
                         return;
                     }
-                    if (!this.filterPlayer(player, pid, level, x, z, tick)) {
+                    if (!this.filterPlayer(player, pid, level, x, z)) {
                         continue;
                     }
                     yield player;
@@ -169,7 +167,6 @@ export default class BuildArea {
         const startZ: number = CoordGrid.zone(z - distance);
         const endX: number = CoordGrid.zone(x + distance);
         const endZ: number = CoordGrid.zone(z + distance);
-        const tick: number = World.currentTick;
 
         for (let zx = startX; zx <= endX; zx++) {
             const zoneX: number = zx << 3;
@@ -179,7 +176,7 @@ export default class BuildArea {
                     if (this.npcs.size >= BuildArea.PREFERRED_NPCS) {
                         return;
                     }
-                    if (!this.filterNpc(npc, level, x, z, tick)) {
+                    if (!this.filterNpc(npc, level, x, z)) {
                         continue;
                     }
                     yield npc;
@@ -188,11 +185,11 @@ export default class BuildArea {
         }
     }
 
-    private filterPlayer(player: Player, pid: number, level: number, x: number, z: number, tick: number): boolean {
-        return !(this.players.has(player) || !CoordGrid.isWithinDistanceSW({ x, z }, player, this.viewDistance) || player.pid === -1 || player.pid === pid || player.level !== level || !player.checkLifeCycle(tick));
+    private filterPlayer(player: Player, pid: number, level: number, x: number, z: number): boolean {
+        return !(this.players.has(player) || !CoordGrid.isWithinDistanceSW({ x, z }, player, this.viewDistance) || player.pid === -1 || player.pid === pid || player.level !== level || !player.isActive);
     }
 
-    private filterNpc(npc: Npc, level: number, x: number, z: number, tick: number): boolean {
-        return !(this.npcs.has(npc) || !CoordGrid.isWithinDistanceSW({ x, z }, npc, BuildArea.PREFERRED_VIEW_DISTANCE) || npc.nid === -1 || npc.level !== level || !npc.checkLifeCycle(tick));
+    private filterNpc(npc: Npc, level: number, x: number, z: number): boolean {
+        return !(this.npcs.has(npc) || !CoordGrid.isWithinDistanceSW({ x, z }, npc, BuildArea.PREFERRED_VIEW_DISTANCE) || npc.nid === -1 || npc.level !== level || !npc.isActive);
     }
 }

--- a/src/engine/entity/Entity.ts
+++ b/src/engine/entity/Entity.ts
@@ -37,19 +37,6 @@ export default abstract class Entity extends Linkable {
         return this.lifecycleTick === tick && this.lifecycle !== EntityLifeCycle.FOREVER;
     }
 
-    checkLifeCycle(tick: number): boolean {
-        if (this.lifecycle === EntityLifeCycle.FOREVER) {
-            return true;
-        }
-        if (this.lifecycle === EntityLifeCycle.RESPAWN) {
-            return this.lifecycleTick < tick;
-        }
-        if (this.lifecycle === EntityLifeCycle.DESPAWN) {
-            return this.lifecycleTick > tick;
-        }
-        return false;
-    }
-
     setLifeCycle(tick: number): void {
         this.lifecycleTick = tick;
         this.lastLifecycleTick = World.currentTick;

--- a/src/engine/script/handlers/ServerOps.ts
+++ b/src/engine/script/handlers/ServerOps.ts
@@ -347,7 +347,7 @@ const ServerOps: CommandHandlers = {
 
             const layer = layerForLocShape(loc.shape);
 
-            if (!loc.checkLifeCycle(World.currentTick) && layer === LocLayer.WALL) {
+            if (!loc.isActive && layer === LocLayer.WALL) {
                 continue;
             }
 

--- a/src/engine/zone/Zone.ts
+++ b/src/engine/zone/Zone.ts
@@ -168,9 +168,9 @@ export default class Zone {
                 continue;
             }
             player.write(new UpdateZonePartialFollows(this.x, this.z, player.originX, player.originZ));
-            if (obj.lifecycle === EntityLifeCycle.DESPAWN && obj.checkLifeCycle(currentTick)) {
+            if (obj.lifecycle === EntityLifeCycle.DESPAWN && obj.isActive) {
                 player.write(new ObjAdd(CoordGrid.packZoneCoord(obj.x, obj.z), obj.type, obj.count));
-            } else if (obj.lifecycle === EntityLifeCycle.RESPAWN && obj.checkLifeCycle(currentTick)) {
+            } else if (obj.lifecycle === EntityLifeCycle.RESPAWN && obj.isActive) {
                 player.write(new ObjAdd(CoordGrid.packZoneCoord(obj.x, obj.z), obj.type, obj.count));
             }
         }

--- a/src/network/rs225/server/codec/NpcInfoEncoder.ts
+++ b/src/network/rs225/server/codec/NpcInfoEncoder.ts
@@ -46,13 +46,13 @@ export default class NpcInfoEncoder extends MessageEncoder<NpcInfo> {
     }
 
     private writeNpcs(buf: Packet, updates: Packet, message: NpcInfo, bytes: number): number {
-        const { currentTick, renderer, player } = message;
+        const { renderer, player } = message;
         const buildArea: BuildArea = player.buildArea;
         // update existing npcs (255 max - 8 bits)
         buf.pBit(8, buildArea.npcs.size);
         for (const npc of buildArea.npcs) {
             const nid: number = npc.nid;
-            if (nid === -1 || npc.tele || npc.level !== player.level || !CoordGrid.isWithinDistanceSW(player, npc, 15) || !npc.checkLifeCycle(currentTick)) {
+            if (nid === -1 || npc.tele || npc.level !== player.level || !CoordGrid.isWithinDistanceSW(player, npc, 15) || !npc.isActive) {
                 // if the npc was teleported, it needs to be removed and re-added
                 this.remove(buf, buildArea, npc);
                 continue;

--- a/src/network/rs225/server/codec/PlayerInfoEncoder.ts
+++ b/src/network/rs225/server/codec/PlayerInfoEncoder.ts
@@ -70,13 +70,13 @@ export default class PlayerInfoEncoder extends MessageEncoder<PlayerInfo> {
     }
 
     private writePlayers(buf: Packet, updates: Packet, message: PlayerInfo, bytes: number): number {
-        const { currentTick, renderer, player } = message;
+        const { renderer, player } = message;
         const buildArea: BuildArea = player.buildArea;
         // update other players (255 max - 8 bits)
         buf.pBit(8, buildArea.players.size);
         for (const other of buildArea.players) {
             const pid: number = other.pid;
-            if (pid === -1 || other.tele || other.level !== player.level || !CoordGrid.isWithinDistanceSW(player, other, buildArea.viewDistance) || !other.checkLifeCycle(currentTick) || other.visibility === Visibility.HARD) {
+            if (pid === -1 || other.tele || other.level !== player.level || !CoordGrid.isWithinDistanceSW(player, other, buildArea.viewDistance) || !other.isActive || other.visibility === Visibility.HARD) {
                 // if the player was teleported, they need to be removed and re-added
                 this.remove(buf, player, other);
                 continue;


### PR DESCRIPTION
Basically I removed `Entity.checkLifecycle` because it's supposed to do exactly what the `isActive` variable does except it does it less directly

I need this to be done because I am going to completely rewrite how entity lifecycles work in a way that we can no longer use it to check stuff like this

@ultraviolet-jordan These changes need to be reflected in rsbuf at some point. Instead of passing in the lifecycle variable we should just pass in `isActive` and check against that, like we are doing in this PR

I went through and tested killing npcs, changing npcs, picking up static objs, dropping dynamic ones, spawning dynamic locs, and relogging while doing all of this. Behavior should be entirely unchanged, since `isActive` and `checkLifecycle` aim to measure the same thing about an Entity