### PR TITLE
fix(content): spirit tree plague sample, charcoal tree, update zamorak wizard/black demon vars earlier

### DIFF
--- a/data/src/scripts/areas/area_gnome/scripts/spirit_tree.rs2
+++ b/data/src/scripts/areas/area_gnome/scripts/spirit_tree.rs2
@@ -69,4 +69,12 @@ if(map_members = false) {
 }
 ~mesbox("You place your hands on the dry tough bark of the spirit tree,|and feel a surge of energy run through your veins.");
 if_close;
-@climb_ladder($dest, true);
+anim(human_reachforladdertop, 0);
+p_delay(0);
+p_telejump($dest);
+// RSC, confirm this is the same on RS3
+if(inv_total(inv, plague_sample) > 0) {
+    inv_del(inv, plague_sample, ^max_32bit_int);
+    mes("The plague sample is too delicate...it disintegrates in the crossing.");
+    return;
+}

--- a/data/src/scripts/minigames/game_trail/scripts/hard/zamorak_wizard.rs2
+++ b/data/src/scripts/minigames/game_trail/scripts/hard/zamorak_wizard.rs2
@@ -29,11 +29,13 @@ if(distance(coord, npc_coord) > 17) { // not 100% sure on this, think it's the s
 }
 
 [ai_queue3,zamorak_wizard]
+if (npc_findhero = true) {
+    queue(queue_defeat_zamorak_wizard, 0);
+}
 gosub(npc_death);
 if (npc_findhero = false) {
     return;
 }
-queue(queue_defeat_zamorak_wizard, 0);
 
 obj_add(npc_coord, npc_param(death_drop), 1, ^lootdrop_duration);
 

--- a/data/src/scripts/quests/quest_grandtree/scripts/grandtree_black_demon.rs2
+++ b/data/src/scripts/quests/quest_grandtree/scripts/grandtree_black_demon.rs2
@@ -22,13 +22,13 @@ if(distance(coord, npc_coord) > 17) {
 }
 
 [ai_queue3,grandtree_black_demon]
-gosub(npc_death);
 if(npc_findhero = true) {
     // queued, no if_close
     if(%grandtree_progress = ^grandtree_unlocked_trapdoor) {
         queue(queue_defeat_blackdemon, 0);
     }
 }
+gosub(npc_death);
 // https://youtu.be/BLxnHE5hU7U?si=mnH0oxq2DbwyAy5y&t=116 
 // https://www.youtube.com/watch?v=mYBva3EhdvM&t=368s, https://youtu.be/iIf98JWB9JI?si=jLbFDg_ZrpzTHGB5&t=78
 if(.npc_find(npc_coord, glough, 7, 0) = true) {

--- a/data/src/scripts/skill_woodcutting/configs/trees/burnt.loc
+++ b/data/src/scripts/skill_woodcutting/configs/trees/burnt.loc
@@ -5,6 +5,6 @@ model=model_loc_1384
 mapscene=6
 op1=Chop down
 op3=hidden
-category=burnt_tree
+category=tree
 param=next_loc_stage,loc_1359
 param=ent,macro_event_ent_dead_tree2


### PR DESCRIPTION
- break plague sample when travelling via spirit tree (RSC behavior)
- switch category on charcoal trees
- update clue/grandtree var before death seq (matches OSRS)