### PR TITLE
fix(content): biohazard vials

### DIFF
--- a/data/src/scripts/quests/quest_biohazard/scripts/chancy.rs2
+++ b/data/src/scripts/quests/quest_biohazard/scripts/chancy.rs2
@@ -66,7 +66,7 @@ if(testbit(%bioerrand, ^chancy_correct) = true) {
     mes("He gives you the vial of liquid honey.");
     inv_add(inv, liquid_honey, 1);
     %bioerrand = clearbit(%bioerrand, ^chancy_given);
-    %bioerrand = clearbit(%bioerrand, 2);
+    %bioerrand = clearbit(%bioerrand, ^chancy_correct);
     p_delay(2);
     ~chatnpc("<p,sad>Next time give me something more valuable... I couldn't get anything for this on the blackmarket.");
     ~chatplayer("<p,neutral>That was the idea.");
@@ -76,8 +76,8 @@ if(testbit(%bioerrand, ^chancy_correct) = true) {
     ~chatplayer("<p,confused>What do you mean?");
     ~chatnpc("<p,shifty>Well, it turns out that potion you gave me, was quite valuable...");
     ~chatplayer("<p,shock>What?");
-    %bioerrand = setbit(%bioerrand, ^chancy_given);
-    %bioerrand = setbit(%bioerrand, ^chancy_wrong);
+    %bioerrand = clearbit(%bioerrand, ^chancy_given);
+    %bioerrand = clearbit(%bioerrand, ^chancy_wrong);
     ~chatnpc("<p,shifty>I know that I probably shouldn't have sold it... but some friends and I were having a little wager, the odds were just too good!");
     ~chatplayer("<p,angry>You sold my vial and gambled with the money?!");
     ~chatnpc("<p,shifty>Actually yes... but praise be to Saradoming because I won! So all's well that ends well right?");

--- a/data/src/scripts/quests/quest_biohazard/scripts/hops.rs2
+++ b/data/src/scripts/quests/quest_biohazard/scripts/hops.rs2
@@ -74,8 +74,8 @@ if(testbit(%bioerrand, ^hops_correct) = true) {
     ~chatplayer("<p,happy>Hello, how was your journey?");
     ~chatnpc("<p,neutral>Pretty thirst-inducing actually...");
     ~chatplayer("<p,confused>Please tell me that you haven't drunk the contents...");
-    %bioerrand = setbit(%bioerrand, ^hops_given);
-    %bioerrand = setbit(%bioerrand, ^hops_wrong);
+    %bioerrand = clearbit(%bioerrand, ^hops_given);
+    %bioerrand = clearbit(%bioerrand, ^hops_wrong);
     ~chatnpc("<p,shifty>Of course I can tell you that I haven't drunk the contents...");
     ~chatnpc("<p,shifty>But I'd be lying. Sorry about that me old mucker, can I get you a drink?");
     ~chatplayer("<p,angry>No, I think you've done enough for now.");

--- a/data/src/scripts/skill_magic/scripts/spells/telegrab.rs2
+++ b/data/src/scripts/skill_magic/scripts/spells/telegrab.rs2
@@ -31,7 +31,7 @@ if((oc_category(obj_type) = trail_clue_easy | oc_category(obj_type) = trail_clue
     return;
 }
 // These use a different mes compared to obj's with the telegrab_disabled param (maybe make a 2nd param)
-if(obj_type = holy_grail | obj_type = ghost_skull | obj_type = ice_arrow | obj_type = boy_ball | obj_type = Ethenea | obj_type = liquid_honey | obj_type = sulphuric_broline | obj_type = plague_sample | (oc_category(obj_type) = cog)
+if(obj_type = holy_grail | obj_type = ghost_skull | obj_type = ice_arrow | obj_type = boy_ball | (oc_category(obj_type) = cog)
     | obj_type = orb_of_light1 | obj_type = orb_of_light2 | obj_type = orb_of_light3 | obj_type = orb_of_light4 | obj_type = fire_feather | obj_type = grips_keyring | obj_type = bunny_ears | obj_type = scythe) {
     mes("I can't use Telekinetic Grab on this object.");
     return;


### PR DESCRIPTION
- clear bits instead of setting them when talking to chancy/hops in varrock with the wrong vials given
- remove telegrab restriction on the plague items