### PR TITLE
fix(content): more partyroom changes

### DIFF
--- a/data/src/scripts/general/scripts/invs.rs2
+++ b/data/src/scripts/general/scripts/invs.rs2
@@ -24,6 +24,46 @@ while ($i < enum_getoutputcount($slots)) {
 }
 return(true);
 
+// reorganize all of the slots towards the left of the inv.
+[proc,reorganize_inv](inv $inv)
+def_int $size = inv_size($inv);
+def_int $count = 0;
+
+while ($count < $size) {
+    def_int $slot_count = inv_getnum($inv, $count);
+
+    if ($slot_count = 0) {
+        def_int $peek_slot = ~inv_peek_next_available_obj_slot($inv, $count);
+
+        if ($peek_slot = -1) {
+            $count = add($size, 1);
+        } else {
+            inv_movetoslot($inv, $inv, $peek_slot, $count);
+            $count = add($count, 1);
+        }
+    } else {
+        $count = add($count, 1);
+    }
+}
+
+// used to check for any obj slots that are ahead of the input slot.
+// returns the slot or -1 if none available.
+[proc,inv_peek_next_available_obj_slot](inv $inv, int $from_slot)(int)
+def_int $size = inv_size($inv);
+def_int $count = $from_slot;
+def_int $slot = -1;
+
+while ($count < $size) {
+    def_int $slot_count = inv_getnum($inv, $count);
+    if ($slot_count = 0) {
+        $count = add($count, 1);
+    } else {
+        $slot = $count;
+        $count = add($size, 1);
+    }
+}
+return($slot);
+
 [proc,del_all_if_exists](inv $inv, namedobj $obj)
 def_int $total = inv_total($inv, $obj);
 if ($total > 0) {

--- a/data/src/scripts/interface_bank/scripts/bank.rs2
+++ b/data/src/scripts/interface_bank/scripts/bank.rs2
@@ -10,7 +10,7 @@
 
 [label,openbank]
 %bank_noted = 0;
-~reorganize_bank;
+~reorganize_inv(bank);
 inv_transmit(inv, bank_side:inv);
 inv_transmit(bank, bank_main:inv);
 if_openmain_side(bank_main, bank_side);
@@ -20,8 +20,12 @@ inv_stoptransmit(bank_side:inv);
 inv_stoptransmit(bank_main:inv);
 queue(reorganize_bank, 0); // confirmed queued
 
+// reorganize the bank like when you open the bank.
+// this is because a player can move objs around in the bank
+// to any slot that is available. so when they open the bank
+// we reorganize all of the slots towards the left of the bank.
 [queue,reorganize_bank]
-~reorganize_bank;
+~reorganize_inv(bank);
 
 [label,bank_withdraw](int $slot, int $requested_number)
 // Check if the slot was empty.
@@ -106,49 +110,6 @@ if (map_members = false) {
     }
 }
 return(false);
-
-// reorganize the bank like when you open the bank.
-// this is because a player can move objs around in the bank
-// to any slot that is available. so when they open the bank
-// we reorganize all of the slots towards the left of the bank.
-[proc,reorganize_bank]
-def_int $size = inv_size(bank);
-def_int $count = 0;
-
-while ($count < $size) {
-    def_int $slot_count = inv_getnum(bank, $count);
-
-    if ($slot_count = 0) {
-        def_int $peek_slot = ~bank_peek_next_available_obj_slot($count);
-
-        if ($peek_slot = -1) {
-            $count = add($size, 1);
-        } else {
-            inv_movetoslot(bank, bank, $peek_slot, $count);
-            $count = add($count, 1);
-        }
-    } else {
-        $count = add($count, 1);
-    }
-}
-
-// used to check for any obj slots that are ahead of the input slot.
-// returns the slot or -1 if none available.
-[proc,bank_peek_next_available_obj_slot](int $from_slot)(int)
-def_int $size = inv_size(bank);
-def_int $count = $from_slot;
-def_int $slot = -1;
-
-while ($count < $size) {
-    def_int $slot_count = inv_getnum(bank, $count);
-    if ($slot_count = 0) {
-        $count = add($count, 1);
-    } else {
-        $slot = $count;
-        $count = add($size, 1);
-    }
-}
-return($slot);
 
 // returns if an obj is considered to be unbankable.
 // experience lamps, quest items, etc.

--- a/data/src/scripts/minigames/game_partyroom/scripts/partyroom.rs2
+++ b/data/src/scripts/minigames/game_partyroom/scripts/partyroom.rs2
@@ -137,16 +137,27 @@ p_delay(0);
 loc_change(loc_param(next_loc_stage), 6);
 // todo: chance was fixed before Jul 2004, was changed to scale off of chest freespace afterwards (this chance is just a guess unfortunately)
 if (~inzone_coord_pair_table(party_room_zones, loc_coord) = true & random(4) = 0) {
-    def_int $rand_slot = random(calc(inv_size(partyroominv) - inv_freespace(partyroominv)));
+    def_int $partyroom_size = inv_size(partyroominv);
+    def_int $rand_slot = random(calc($partyroom_size - inv_freespace(partyroominv)));
     def_obj $obj = inv_getobj(partyroominv, $rand_slot);
     def_int $count = 1;
+    def_int $obj_total = inv_getnum(partyroominv, $rand_slot);
     if($obj = null) {
         return;
     }
     if(oc_stackable($obj) = true | oc_uncert($obj) ! $obj) {
-        $count = ~random_range(1, inv_getnum(partyroominv, $rand_slot));
+        $count = ~random_range(1, $obj_total);
     }
     inv_dropitem(partyroominv, loc_coord, $obj, $count, 100);
+    if($count = $obj_total) {
+        while($rand_slot < $partyroom_size) {
+            $rand_slot = add($rand_slot, 1);
+            if(inv_getobj(partyroominv, $rand_slot) = null) { // break loop is cur slot is empty
+                return;
+            }
+            inv_movetoslot(partyroominv, partyroominv, $rand_slot, calc($rand_slot - 1));
+        }
+    }
     return;
 }
 p_delay(0);

--- a/data/src/scripts/minigames/game_partyroom/scripts/partyroom.rs2
+++ b/data/src/scripts/minigames/game_partyroom/scripts/partyroom.rs2
@@ -138,7 +138,8 @@ loc_change(loc_param(next_loc_stage), 6);
 // todo: chance was fixed before Jul 2004, was changed to scale off of chest freespace afterwards (this chance is just a guess unfortunately)
 if (~inzone_coord_pair_table(party_room_zones, loc_coord) = true & random(4) = 0) {
     def_int $partyroom_size = inv_size(partyroominv);
-    def_int $rand_slot = random(calc($partyroom_size - inv_freespace(partyroominv)));
+    def_int $free_slots = calc($partyroom_size - inv_freespace(partyroominv));
+    def_int $rand_slot = random(calc($free_slots + ~partyroom_empty_slots($free_slots)));
     def_obj $obj = inv_getobj(partyroominv, $rand_slot);
     def_int $count = 1;
     def_int $obj_total = inv_getnum(partyroominv, $rand_slot);
@@ -149,16 +150,23 @@ if (~inzone_coord_pair_table(party_room_zones, loc_coord) = true & random(4) = 0
         $count = ~random_range(1, $obj_total);
     }
     inv_dropitem(partyroominv, loc_coord, $obj, $count, 100);
-    if($count = $obj_total) {
-        while($rand_slot < $partyroom_size) {
-            $rand_slot = add($rand_slot, 1);
-            if(inv_getobj(partyroominv, $rand_slot) = null) { // break loop is cur slot is empty
-                return;
-            }
-            inv_movetoslot(partyroominv, partyroominv, $rand_slot, calc($rand_slot - 1));
-        }
+    // for w/e reason, in old videos the inv doesn't reorg sometimes, there doesn't seem to be any specific condition for it
+    // https://youtu.be/Ve5UF8B3BMw?si=NKO9H7bd6rJGY_LF&t=251
+    if($count = $obj_total & random(3) < 2) {
+        ~reorganize_inv(partyroominv);
     }
     return;
 }
 p_delay(0);
 loc_del(1);
+
+[proc,partyroom_empty_slots](int $free_slots)(int)
+def_int $slot = 0;
+def_int $count = 0;
+while($slot < $free_slots) {
+    if(inv_getobj(partyroominv, $slot) = null) {
+        $count = add($count,1);
+    }
+    $slot = add($slot,1);
+}
+return ($count);

--- a/data/src/scripts/minigames/game_partyroom/scripts/partyroom_chest.rs2
+++ b/data/src/scripts/minigames/game_partyroom/scripts/partyroom_chest.rs2
@@ -62,8 +62,22 @@ if($total = 0 | inv_itemspace(partyroomoffer, $obj, $total, inv_size(partyroomof
 inv_moveitem(inv, partyroomoffer, $obj, $total);
 
 [if_button,party_drop_chest:com_94]
-if(inv_freespace(partyroominv) < calc(inv_size(partyroomoffer) - inv_freespace(partyroomoffer))) {
-    mes("The chest cannot hold your offer at the moment.");
+def_int $i = 0;
+def_boolean $moveditem = false;
+if(inv_freespace(partyroomoffer) = inv_size(partyroomoffer)) {
     return;
 }
-~moveallinv(partyroomoffer, partyroominv);
+while($i < inv_size(partyroomoffer)) {
+    def_obj $obj = inv_getobj(partyroomoffer, $i);
+    def_int $count = inv_getnum(partyroomoffer, $i);
+    if ($obj ! null) {
+        if(inv_itemspace(partyroominv, $obj, $count, inv_size(partyroominv)) = true) {
+            inv_moveitem(partyroomoffer, partyroominv, $obj, $count);
+            $moveditem = true;
+        }
+    }
+    $i = add($i, 1);
+}
+if($moveditem = false) {
+    mes("The chest cannot hold your offer at the moment.");
+}


### PR DESCRIPTION
- change main inv space checks to match OSRS (check itemspace per obj being added rather than using inv_freespace)
- account for empty slots when getting a random slot (this way, items near the end of the chest won't get stuck there if there are empty slots)
- reorganize partyroom inv as items are removed (most of the time), matches https://youtu.be/Ve5UF8B3BMw?si=NKO9H7bd6rJGY_LF&t=251