### PR TITLE
fix(content): trawler rewrite

### DIFF
--- a/data/src/scripts/_test/scripts/cheats/cheat_trawler.rs2
+++ b/data/src/scripts/_test/scripts/cheats/cheat_trawler.rs2
@@ -1,16 +1,3 @@
-[debugproc,trawler_win](int $rolls)
-if (~inzone_coord_pair_table(trawler_flood_zones, coord) = true) {
-    if (npc_find(^trawler_flood_center_under, murphy_flood, 5, 0) = true) {
-        %npc_trawler_start = sub(map_clock, 1000);
-        %npc_trawler_fish_caught = $rolls;
-    }
-} else {
-    if (npc_find(^trawler_start_center_under, murphy_nonflood, 5, 0) = true) {
-        %npc_trawler_start = sub(map_clock, 1000);
-        %npc_trawler_fish_caught = $rolls;
-    }
-}
-
 [debugproc,trawler_loot](int $rolls)
 if (p_finduid(uid) = true) {
     %trawler = 3;
@@ -21,3 +8,9 @@ if (p_finduid(uid) = true) {
 if (p_finduid(uid) = true) {
     p_telejump(0_41_49_52_34);
 }
+
+[debugproc,givetrawler]
+inv_clear(inv);
+inv_add(inv, swamp_paste, 1000000);
+inv_add(inv, bailing_bucket_empty, 10);
+inv_add(inv, rope, 5);

--- a/data/src/scripts/_unpack/all.varn
+++ b/data/src/scripts/_unpack/all.varn
@@ -14,11 +14,12 @@ type=player_uid
 
 [npc_poison]
 
-[npc_trawler_start]
-
 [npc_trawler_flood_status]
 
 [npc_trawler_fish_caught]
 
 // confirmed
 [npc_int]
+
+// unconfirmed
+[npc_int2]

--- a/data/src/scripts/login_logout/login.rs2
+++ b/data/src/scripts/login_logout/login.rs2
@@ -62,6 +62,7 @@ if (%tutorial_progress < ^tutorial_complete) {
 }
 ~initalltabs;
 ~update_all(inv_getobj(worn, ^wearpos_rhand));
+cam_reset;
 queue(follower_login, 0);
 if (map_production = true) {
     last_login_info;

--- a/data/src/scripts/minigames/game_trawler/configs/trawler.constant
+++ b/data/src/scripts/minigames/game_trawler/configs/trawler.constant
@@ -3,7 +3,7 @@
 ^trawler_finished = 3
 
 ^trawler_lobby_center_under = 0_41_49_47_38
-^trawler_lobby_center = 1_41_49_47_48
+^trawler_lobby_center = 1_41_49_47_38
 ^trawler_lobby_murphy_spawn = 0_41_49_44_26
 ^trawler_start_center_under = 0_29_75_33_25
 ^trawler_start_center = 1_29_75_33_25

--- a/data/src/scripts/minigames/game_trawler/configs/trawler.constant
+++ b/data/src/scripts/minigames/game_trawler/configs/trawler.constant
@@ -25,3 +25,7 @@
 
 ^trawler_flood_patrol1 = 0_31_75_29_25
 ^trawler_flood_patrol2 = 0_31_75_36_25
+
+
+^trawler_control_flooded = 1
+^trawler_control_nonflooded = 0

--- a/data/src/scripts/minigames/game_trawler/configs/trawler.dbrow
+++ b/data/src/scripts/minigames/game_trawler/configs/trawler.dbrow
@@ -3,14 +3,17 @@ table=coord_pair_table
 data=coord_pair,1_41_49_45_30,1_41_49_49_46
 data=coord_pair,0_41_49_45_30,0_41_49_49_46
 
+// do not change these values, map_playercount doesnt allow both coordy's to be different!!!!
 [trawler_game_zones]
 table=coord_pair_table
-data=coord_pair,0_31_75_0_0,1_31_75_63_63
-data=coord_pair,0_29_75_0_0,1_29_75_63_63
+data=coord_pair,0_31_75_0_0,0_31_75_63_63
+data=coord_pair,1_31_75_0_0,1_31_75_63_63
+data=coord_pair,0_29_75_0_0,0_29_75_63_63
+data=coord_pair,1_29_75_0_0,1_29_75_63_63
 
 [trawler_flood_zones]
 table=coord_pair_table
-data=coord_pair,0_31_75_0_0,1_31_75_63_63
+data=coord_pair,0_31_75_0_0,0_31_75_63_63
 data=coord_pair,1_31_75_0_0,1_31_75_63_63
 
 [trawler_nonflood_zones]
@@ -20,8 +23,10 @@ data=coord_pair,1_29_75_0_0,1_29_75_63_63
 
 [trawler_all_zones]
 table=coord_pair_table
-data=coord_pair,0_41_49_45_30,1_41_49_49_46
-data=coord_pair,0_29_75_0_0,1_31_75_63_63
+data=coord_pair,0_41_49_45_30,0_41_49_49_46
+data=coord_pair,1_41_49_45_30,1_41_49_49_46
+data=coord_pair,0_29_75_0_0,0_31_75_63_63
+data=coord_pair,1_29_75_0_0,1_31_75_63_63
 
 [trawler_wreck_zones]
 table=coord_pair_table

--- a/data/src/scripts/minigames/game_trawler/configs/trawler.npc
+++ b/data/src/scripts/minigames/game_trawler/configs/trawler.npc
@@ -68,6 +68,7 @@ wanderrange=7
 defaultmode=patrol
 patrol1=^trawler_start_patrol1
 patrol2=^trawler_start_patrol2
+timer=5
 
 [murphy_flood]
 vislevel=hide
@@ -105,6 +106,7 @@ wanderrange=7
 defaultmode=patrol
 patrol1=^trawler_flood_patrol1
 patrol2=^trawler_flood_patrol2
+timer=5
 
 [murphy_sunk]
 name=Murphy
@@ -139,6 +141,7 @@ head1=model_55_idk_head
 head2=model_81_idk_head
 head3=model_37_npc_head
 wanderrange=1
+timer=1
 
 [game_trawler_shark1]
 name=Shark

--- a/data/src/scripts/minigames/game_trawler/scripts/trawler.rs2
+++ b/data/src/scripts/minigames/game_trawler/scripts/trawler.rs2
@@ -1,158 +1,22 @@
-[ai_timer,murphy_nonflood] @trawler_controller;
-[ai_timer,murphy_flood] @trawler_controller;
-
-
-[label,trawler_controller]
-def_int $player_count = ~playercount_coord_pair_table(trawler_game_zones);
-if ($player_count < 1) {
-    ~trawler_reset;
-    return;
-}
-if (add(%npc_trawler_start, 1030) < map_clock) {
-    ~trawler_win(divide(%npc_trawler_fish_caught, $player_count));
-    ~trawler_reset;
-    return;
-}
-
-npc_settimer(5);
-
-// "Murphy will not be much of a help around the boat, for he will just yell orders at you. 
-// He will say things such as "My mother can bail better than you", "Nooooooo", or "Fix that net". 
-// One useful thing he will say is how much time is left, but don?t pay attention to this but only to your tasks at hand."
-// - https://web.archive.org/web/20041127044153/https://runescapecommunity.com/index.php%3fshowtopic%3d101380
-def_int $minutes = sub(10, divide(sub(map_clock, %npc_trawler_start), 100));
-def_int $ticks_near_minute = modulo(sub(map_clock, %npc_trawler_start), 100);
-if ($minutes > 0 & $ticks_near_minute > -3 & $ticks_near_minute < 3) {
-    npc_say("<~pluralise($minutes, "minute")> left!");
-}
-
-// increase water
-def_int $leak_count = 0;
-def_int $i = 0;
-while ($i < enum_getoutputcount(trawler_hulls)) {
-    if (loc_find(enum(int, coord, trawler_hulls, $i), game_trawler_leak) = true) {
-        $leak_count = add($leak_count, 1);
-        %npc_trawler_flood_status = add(%npc_trawler_flood_status, 1);
-    }
-    $i = add($i, 1);
-}
-// max leaks:
-// 1p = 4
-// 2p = 7
-def_int $max_leaks = min(add(multiply($player_count, 3), 1), 9);
-def_int $leak_chance = max(divide(32, $player_count), 2);
-// add new ship leaks
-$i = 0;
-while ($i < enum_getoutputcount(trawler_hulls) & $leak_count < $max_leaks) {
-    if (loc_find(enum(int, coord, trawler_hulls, $i), game_trawler_hull) = true | loc_find(enum(int, coord, trawler_hulls, $i), game_trawler_repaired_leak) = true) {
-        if (random($leak_chance) = 0) { // complete guess
-            ~trawler_leak;
-            if (random(5) = 0) {
-                npc_queue(6, 0, 0);
-            }
-            $leak_count = add($leak_count, 1);
-        }
-    }
-    $i = add($i, 1);
-}
-// handle ship events
-if (%npc_trawler_flood_status >= 100) {
-    ~trawler_sink;
-    ~trawler_reset;
-    return;
-} else if (%npc_trawler_flood_status = 0 & npc_type = murphy_flood) {
-    ~trawler_unflood;
-    if (.npc_find(^trawler_start_center_under, murphy_nonflood, 5, 0) = true) {
-        .%npc_trawler_fish_caught = %npc_trawler_fish_caught;
-        .%npc_trawler_flood_status = %npc_trawler_flood_status;
-        .%npc_trawler_start = %npc_trawler_start;
-        .npc_settimer(5);
-        npc_settimer(0);
-        return;
-    }
-} else if (%npc_trawler_flood_status >= 30 & npc_type = murphy_nonflood) {
-    ~trawler_flood;
-    if (.npc_find(^trawler_flood_center_under, murphy_flood, 5, 0) = true) {
-        .%npc_trawler_fish_caught = %npc_trawler_fish_caught;
-        .%npc_trawler_flood_status = %npc_trawler_flood_status;
-        .%npc_trawler_start = %npc_trawler_start;
-        .npc_settimer(5);
-        npc_settimer(0);
-        return;
-    }
-}
-
-if (random(5) = 0) { // handle murphy's sayings
-    if (loc_find(^trawler_start_net1, game_trawler_fish_net_broken1) = true | loc_find(^trawler_start_net2, game_trawler_fish_net_broken2) = true) {
-        npc_say("Arrh! Check that net!");
-        return;
-    }
-    if (%npc_trawler_flood_status = 0 & npc_type = murphy_nonflood) {
-        npc_say("Let's get this net full with fishies!"); //https://youtu.be/scKmu6QETRw?t=298
-    } else if (%npc_trawler_flood_status < 20 & npc_type = murphy_nonflood) {
-        switch_int (random(3)) {
-            case 0 : npc_say("Let's get this net full with fishies!");
-            case 1 : npc_say("Blistering barnacles!");
-            case 2 : npc_say("That's the stuff, fill those holes!");
-        }
-    } else if (%npc_trawler_flood_status < 30 & npc_type = murphy_nonflood) {
-        switch_int (random(2)) {
-            case 0 : npc_say("The water is coming in matey!");
-            case 1 : npc_say("You'll need to start bailing soon!");
-        }
-    } else if (%npc_trawler_flood_status < 80) {
-        switch_int (random(4)) {
-            case 0 : npc_say("It's a fierce sea today traveller.");
-            case 1 : npc_say("Land lubbers!");
-            case 2 : npc_say("My mother could bail better than that!");
-            case 3 : npc_say("We'll all end up in a watery grave!");
-        }
-    } else if (%npc_trawler_flood_status < 100) {
-        switch_int (random(4)) {
-            case 0 : npc_say("Noooooo!");
-            case 1 : npc_say("We're all doomed!");
-            case 2 : npc_say("We're going under!");
-            case 3 : npc_say("Mummy!");
-        }
-    }
-}
-if (random(16) = 0) {
-    if (loc_find(^trawler_start_net1, game_trawler_fish_net_broken1) = false & loc_find(^trawler_start_net2, game_trawler_fish_net_broken2) = false) {    
-        ~trawler_rip_net;
-    }
-}
-
-// from 1697 caught, a player got an equal cut of 20 fish. theres 200 rolls in a trawler game on each player
-// https://youtu.be/Yzu2wp2hJOw?list=PLn23LiLYLb1b7Lj_u-lnuUOa40FGWslbp This game, each player got 20 fish
-// with a final caught of 1697. Means a 1/10 chance per roll for each player
-$i = 0;
-while ($i < $player_count) {
-    if (random(10) = 0) {
-        %npc_trawler_fish_caught = add(%npc_trawler_fish_caught, 1);
-    }
-    $i = add($i, 1);
-}
-
 [proc,trawler_reset]
 if (npc_find(^trawler_flood_center_under, murphy_flood, 5, 0) = true) {
-    %npc_trawler_start = null;
+    %npc_int = 0;
+    %npc_int2 = 0;
     %npc_trawler_flood_status = 0;
     %npc_trawler_fish_caught = 0;
     npc_settimer(0);
 }
 if (npc_find(^trawler_start_center_under, murphy_nonflood, 5, 0) = true) {
-    %npc_trawler_start = null;
+    %npc_int = 0;
+    %npc_int2 = 0;
     %npc_trawler_flood_status = 0;
     %npc_trawler_fish_caught = 0;
     npc_settimer(0);
 }
+// only leaks get changed back, repaired leaks stay repaired and naturally fix them selves after 10 min
 def_int $i = 0;
 while ($i < enum_getoutputcount(trawler_hulls)) {
     if (loc_find(enum(int, coord, trawler_hulls, $i), game_trawler_leak) = true) {
-        // Temp note: dur updated
-        loc_change(game_trawler_hull, 2);
-    }
-    if (loc_find(enum(int, coord, trawler_hulls, $i), game_trawler_repaired_leak) = true) {
         // Temp note: dur updated
         loc_change(game_trawler_hull, 2);
     }
@@ -163,9 +27,6 @@ $i = 0;
 while ($i < enum_getoutputcount(trawler_hulls_flooded)) {
     if (loc_find(enum(int, coord, trawler_hulls_flooded, $i), game_trawler_leak) = true) {
         // Temp note: dur updated
-        loc_change(game_trawler_hull, 2);
-    }
-    if (loc_find(enum(int, coord, trawler_hulls_flooded, $i), game_trawler_repaired_leak) = true) {
         loc_change(game_trawler_hull, 2);
     }
     $i = add($i, 1);

--- a/data/src/scripts/minigames/game_trawler/scripts/trawler_control.rs2
+++ b/data/src/scripts/minigames/game_trawler/scripts/trawler_control.rs2
@@ -1,0 +1,153 @@
+[ai_timer,murphy_nonflood] // 5 tick timer
+if (%npc_int2 = ^trawler_control_flooded) {
+    return;
+}
+def_int $player_count = ~playercount_coord_pair_table(trawler_game_zones);
+if ($player_count < 1) {
+    ~trawler_reset;
+    return;
+}
+if (%npc_int = 200) { // 1000 ticks
+    ~trawler_win(divide(%npc_trawler_fish_caught, $player_count));
+    ~trawler_reset;
+    return;
+}
+
+~trawler_murphy_say;
+
+~trawler_increase_flooding($player_count);
+
+if (%npc_trawler_flood_status >= 30) {
+    ~trawler_flood;
+}
+
+if (random(16) = 0) {
+    ~trawler_rip_net;
+}
+
+~trawler_catch_fish($player_count);
+%npc_int = add(%npc_int, 1);
+npc_settimer(5); // this is important
+
+[ai_timer,murphy_flood]
+if (%npc_int2 = ^trawler_control_nonflooded) {
+    return;
+}
+def_int $player_count = ~playercount_coord_pair_table(trawler_game_zones);
+if ($player_count < 1) {
+    ~trawler_reset;
+    return;
+}
+if (%npc_int = 200) { // 1000 ticks
+    ~trawler_win(divide(%npc_trawler_fish_caught, $player_count));
+    ~trawler_reset;
+    return;
+}
+
+~trawler_murphy_say;
+
+~trawler_increase_flooding($player_count);
+
+if (%npc_trawler_flood_status >= 100) {
+    ~trawler_sink;
+    ~trawler_reset;
+    return;
+}
+if (%npc_trawler_flood_status < 1) {
+    ~trawler_unflood;
+}
+if (random(16) = 0) {
+    ~trawler_rip_net;
+}
+
+~trawler_catch_fish($player_count);
+%npc_int = add(%npc_int, 1);
+npc_settimer(5); // this is important
+
+
+[proc,trawler_murphy_say]
+if (modulo(%npc_int, 20) = 0 & %npc_int >= 20) {
+    npc_say("<~pluralise(divide(%npc_int, 20), "minute")> left!");
+    return;
+}
+if (random(5) = 0) { // handle murphy's sayings
+    if (loc_find(^trawler_start_net1, game_trawler_fish_net_broken1) = true | loc_find(^trawler_start_net2, game_trawler_fish_net_broken2) = true) {
+        npc_say("Arrh! Check that net!");
+        return;
+    }
+    if (%npc_trawler_flood_status = 0) {
+        npc_say("Let's get this net full with fishies!"); //https://youtu.be/scKmu6QETRw?t=298
+        return;
+    }
+    if (%npc_trawler_flood_status < 20) {
+        switch_int (random(3)) {
+            case 0 : npc_say("Let's get this net full with fishies!");
+            case 1 : npc_say("Blistering barnacles!");
+            case 2 : npc_say("That's the stuff, fill those holes!");
+        }
+    } else if (%npc_trawler_flood_status < 30) {
+        switch_int (random(2)) {
+            case 0 : npc_say("The water is coming in matey!");
+            case 1 : npc_say("You'll need to start bailing soon!");
+        }
+    } else if (%npc_trawler_flood_status < 80) {
+        switch_int (random(4)) {
+            case 0 : npc_say("It's a fierce sea today traveller.");
+            case 1 : npc_say("Land lubbers!");
+            case 2 : npc_say("My mother could bail better than that!");
+            case 3 : npc_say("We'll all end up in a watery grave!");
+        }
+    } else if (%npc_trawler_flood_status < 100) {
+        switch_int (random(4)) {
+            case 0 : npc_say("Noooooo!");
+            case 1 : npc_say("We're all doomed!");
+            case 2 : npc_say("We're going under!");
+            case 3 : npc_say("Mummy!");
+        }
+    }
+}
+
+
+[proc,trawler_increase_flooding](int $player_count)
+def_int $leak_count = 0;
+def_int $i = 0;
+while ($i < enum_getoutputcount(trawler_hulls)) {
+    if (loc_find(enum(int, coord, trawler_hulls, $i), game_trawler_leak) = true) {
+        $leak_count = add($leak_count, 1);
+        %npc_trawler_flood_status = add(%npc_trawler_flood_status, 1);
+    }
+    $i = add($i, 1);
+}
+// max leaks:
+// 1p = 4
+// 2p = 7
+def_int $max_leaks = min(add(multiply($player_count, 3), 1), 9);
+def_int $leak_chance = max(divide(32, $player_count), 2);
+$i = 0;
+while ($i < enum_getoutputcount(trawler_hulls) & $leak_count < $max_leaks) {
+    if (loc_find(enum(int, coord, trawler_hulls, $i), game_trawler_hull) = true | loc_find(enum(int, coord, trawler_hulls, $i), game_trawler_repaired_leak) = true) {
+        if (random($leak_chance) = 0) { // complete guess
+            ~trawler_leak;
+            if (random(5) = 0) {
+                npc_queue(6, 0, 0);
+            }
+            $leak_count = add($leak_count, 1);
+        }
+    }
+    $i = add($i, 1);
+}
+
+// from 1697 caught, a player got an equal cut of 20 fish. theres 200 rolls in a trawler game on each player
+// https://youtu.be/Yzu2wp2hJOw?list=PLn23LiLYLb1b7Lj_u-lnuUOa40FGWslbp This game, each player got 20 fish
+// with a final caught of 1697. Means a 1/10 chance per roll for each player
+[proc,trawler_catch_fish](int $player_count)
+if (~trawler_net_ripped = true) {
+    return;
+}
+def_int $i = 0;
+while ($i < $player_count) {
+    if (random(10) = 0) {
+        %npc_trawler_fish_caught = add(%npc_trawler_fish_caught, 1);
+    }
+    $i = add($i, 1);
+}

--- a/data/src/scripts/minigames/game_trawler/scripts/trawler_control.rs2
+++ b/data/src/scripts/minigames/game_trawler/scripts/trawler_control.rs2
@@ -9,7 +9,6 @@ if ($player_count < 1) {
 }
 if (%npc_int = 200) { // 1000 ticks
     ~trawler_win(divide(%npc_trawler_fish_caught, $player_count));
-    ~trawler_reset;
     return;
 }
 

--- a/data/src/scripts/minigames/game_trawler/scripts/trawler_control.rs2
+++ b/data/src/scripts/minigames/game_trawler/scripts/trawler_control.rs2
@@ -39,7 +39,6 @@ if ($player_count < 1) {
 }
 if (%npc_int = 200) { // 1000 ticks
     ~trawler_win(divide(%npc_trawler_fish_caught, $player_count));
-    ~trawler_reset;
     return;
 }
 
@@ -49,7 +48,6 @@ if (%npc_int = 200) { // 1000 ticks
 
 if (%npc_trawler_flood_status >= 100) {
     ~trawler_sink;
-    ~trawler_reset;
     return;
 }
 if (%npc_trawler_flood_status < 1) {

--- a/data/src/scripts/minigames/game_trawler/scripts/trawler_control.rs2
+++ b/data/src/scripts/minigames/game_trawler/scripts/trawler_control.rs2
@@ -66,7 +66,7 @@ npc_settimer(5); // this is important
 
 [proc,trawler_murphy_say]
 if (modulo(%npc_int, 20) = 0 & %npc_int >= 20) {
-    npc_say("<~pluralise(divide(%npc_int, 20), "minute")> left!");
+    npc_say("<~pluralise(sub(10, divide(%npc_int, 20)), "minute")> left!");
     return;
 }
 if (random(5) = 0) { // handle murphy's sayings

--- a/data/src/scripts/minigames/game_trawler/scripts/trawler_flood.rs2
+++ b/data/src/scripts/minigames/game_trawler/scripts/trawler_flood.rs2
@@ -51,19 +51,7 @@ if (last_useitem = swamp_paste) {
     ~displaymessage(^dm_default);
 }
 
-[oplocu,game_trawler_repaired_leak]
-if (last_useitem = swamp_paste) {
-    @trawler_fix_leak; // in osrs theres no message if using swamp paste on hull/repaired leak
-} else {
-    ~displaymessage(^dm_default);
-}
-
-[oplocu,game_trawler_hull]
-if (last_useitem = swamp_paste) {
-    @trawler_fix_leak;
-} else {
-    ~displaymessage(^dm_default);
-}
+// using paste on repaired leak has NIH message: https://youtu.be/XtcZ1VTN9ik?list=PLn23LiLYLb1b7Lj_u-lnuUOa40FGWslbp&t=25
 
 [label,trawler_fix_leak]
 if (loc_type = game_trawler_leak) {

--- a/data/src/scripts/minigames/game_trawler/scripts/trawler_flood.rs2
+++ b/data/src/scripts/minigames/game_trawler/scripts/trawler_flood.rs2
@@ -1,4 +1,14 @@
 [proc,trawler_flood]
+if (.npc_find(^trawler_flood_center_under, murphy_flood, 8, 0) = false) {
+    return;
+}
+.%npc_int2 = ^trawler_control_flooded;
+%npc_int2 = ^trawler_control_flooded;
+
+.%npc_int = %npc_int;
+.%npc_trawler_flood_status = %npc_trawler_flood_status;
+.%npc_trawler_fish_caught = %npc_trawler_fish_caught;
+
 huntall(^trawler_start_center_under, 8, 0);
 while (huntnext = true) {
     if_close;
@@ -11,6 +21,16 @@ while (huntnext = true) {
 }
 
 [proc,trawler_unflood]
+if (.npc_find(^trawler_start_center_under, murphy_nonflood, 8, 0) = false) {
+    return;
+}
+.%npc_int2 = ^trawler_control_nonflooded;
+%npc_int2 = ^trawler_control_nonflooded;
+
+.%npc_int = %npc_int;
+.%npc_trawler_flood_status = %npc_trawler_flood_status;
+.%npc_trawler_fish_caught = %npc_trawler_fish_caught;
+
 huntall(^trawler_flood_center_under, 8, 0);
 while (huntnext = true) {
     if_close;

--- a/data/src/scripts/minigames/game_trawler/scripts/trawler_gangplank.rs2
+++ b/data/src/scripts/minigames/game_trawler/scripts/trawler_gangplank.rs2
@@ -17,9 +17,9 @@ switch_int (loc_angle) {
 p_delay(0);
 if (~playercount_coord_pair_table(trawler_game_zones) > 0) {
     mes("There is already someone on a fishing trip!"); //https://youtu.be/Yzu2wp2hJOw?list=PLn23LiLYLb1b7Lj_u-lnuUOa40FGWslbp&t=14
-}
-if (~playercount_coord_pair_table(trawler_lobby_zones) < 1 & ~playercount_coord_pair_table(trawler_game_zones) < 1) {
-    if (npc_find(^trawler_lobby_murphy_spawn, murphy, 5, 0) = true) {
+} else if (npc_find(^trawler_lobby_murphy_spawn, murphy, 5, 0) = true) {
+    if (%npc_trawler_start < map_clock) { // this could be a sorta npc_gettimer?
+        %npc_trawler_start = add(map_clock, 100); // this is just used to check if the npc timer is active
         npc_settimer(100);
     }
 }
@@ -37,4 +37,9 @@ switch_int (loc_angle) {
         p_teleport(loc_coord);
         p_delay(0);
         p_telejump(movecoord(coord, 0, -1, calc(2 * $dir_mod)));
+}
+
+[debugproc,debug_murph]
+if (npc_find(^trawler_lobby_murphy_spawn, murphy, 5, 0) = true) {
+    mes("<tostring(map_clock)>: Murphy - %npc_trawler_start: <tostring(%npc_trawler_start)>");
 }

--- a/data/src/scripts/minigames/game_trawler/scripts/trawler_gangplank.rs2
+++ b/data/src/scripts/minigames/game_trawler/scripts/trawler_gangplank.rs2
@@ -18,9 +18,9 @@ p_delay(0);
 if (~playercount_coord_pair_table(trawler_game_zones) > 0) {
     mes("There is already someone on a fishing trip!"); //https://youtu.be/Yzu2wp2hJOw?list=PLn23LiLYLb1b7Lj_u-lnuUOa40FGWslbp&t=14
 } else if (npc_find(^trawler_lobby_murphy_spawn, murphy, 5, 0) = true) {
-    if (%npc_trawler_start < map_clock) { // this could be a sorta npc_gettimer?
-        %npc_trawler_start = add(map_clock, 100); // this is just used to check if the npc timer is active
-        npc_settimer(100);
+    if (%npc_int < map_clock) { // this could be a sorta npc_getqueue?
+        %npc_int = add(map_clock, 100);
+        npc_queue(5, 0, 100);
     }
 }
 p_telejump($jump_coord);
@@ -41,5 +41,5 @@ switch_int (loc_angle) {
 
 [debugproc,debug_murph]
 if (npc_find(^trawler_lobby_murphy_spawn, murphy, 5, 0) = true) {
-    mes("<tostring(map_clock)>: Murphy - %npc_trawler_start: <tostring(%npc_trawler_start)>");
+    mes("<tostring(map_clock)>: Murphy - %npc_trawler_start: <tostring(%npc_int)>");
 }

--- a/data/src/scripts/minigames/game_trawler/scripts/trawler_net.rs2
+++ b/data/src/scripts/minigames/game_trawler/scripts/trawler_net.rs2
@@ -1,4 +1,16 @@
+[proc,trawler_net_ripped]()(boolean)
+if (loc_find(^trawler_start_net1, game_trawler_fish_net_broken1) = true) {
+    return(true);
+}
+if (loc_find(^trawler_start_net2, game_trawler_fish_net_broken2) = true) {
+    return(true);
+}
+return(false);
+
 [proc,trawler_rip_net]
+if (~trawler_net_ripped = true) {
+    return;
+}
 if (loc_find(^trawler_start_net1, game_trawler_fish_net1) = true) {
     loc_change(game_trawler_fish_net_broken1, 1000);
 }

--- a/data/src/scripts/minigames/game_trawler/scripts/trawler_sink.rs2
+++ b/data/src/scripts/minigames/game_trawler/scripts/trawler_sink.rs2
@@ -83,39 +83,30 @@ switch_int (random(5)) {
 npc_settimer(~random_range(9, 21)); // osrs
 
 [ai_timer,game_trawler_shark1]
-npc_settimer(0);
-npc_tele(movecoord(npc_coord, 0, 0, 2));
-npc_delay(29);
-npc_tele(movecoord(npc_coord, 1, 0, 1));
-npc_delay(29);
-npc_tele(movecoord(npc_coord, 2, 0, 0));
-npc_delay(29);
-npc_tele(movecoord(npc_coord, 1, 0, -1));
-npc_delay(29);
-npc_tele(movecoord(npc_coord, 0, 0, -2));
-npc_delay(29);
-npc_tele(movecoord(npc_coord, -1, 0, -1));
-npc_delay(29);
-npc_tele(movecoord(npc_coord, -2, 0, 0));
-npc_delay(29);
-npc_tele(movecoord(npc_coord, -1, 0, 1));
-npc_settimer(30);
+%npc_int = modulo(add(%npc_int, 1), 8);
+switch_int(%npc_int) {
+    case 0 : npc_tele(movecoord(npc_coord, 0, 0, 2));
+    case 1 : npc_tele(movecoord(npc_coord, 1, 0, 1));
+    case 2 : npc_tele(movecoord(npc_coord, 2, 0, 0));
+    case 3 : npc_tele(movecoord(npc_coord, 1, 0, -1));
+    case 4 : npc_tele(movecoord(npc_coord, 0, 0, -2));
+    case 5 : npc_tele(movecoord(npc_coord, -1, 0, -1));
+    case 6 : npc_tele(movecoord(npc_coord, -2, 0, 0));
+    case 7 : npc_tele(movecoord(npc_coord, -1, 0, 1));
+    case default : %npc_int = 0;
+}
+
 
 [ai_timer,game_trawler_shark2]
-npc_settimer(0);
-npc_tele(movecoord(npc_coord, 2, 0, 2));
-npc_delay(29);
-npc_tele(movecoord(npc_coord, 2, 0, 0));
-npc_delay(29);
-npc_tele(movecoord(npc_coord, 2, 0, -2));
-npc_delay(29);
-npc_tele(movecoord(npc_coord, 0, 0, -2));
-npc_delay(29);
-npc_tele(movecoord(npc_coord, -2, 0, -2));
-npc_delay(29);
-npc_tele(movecoord(npc_coord, -2, 0, 0));
-npc_delay(29);
-npc_tele(movecoord(npc_coord, -2, 0, 2));
-npc_delay(29);
-npc_tele(movecoord(npc_coord, 0, 0, 2));
-npc_settimer(30);
+%npc_int = modulo(add(%npc_int, 1), 8);
+switch_int(%npc_int) {
+    case 0 : npc_tele(movecoord(npc_coord, 2, 0, 2));
+    case 1 : npc_tele(movecoord(npc_coord, 2, 0, 0));
+    case 2 : npc_tele(movecoord(npc_coord, 2, 0, -2));
+    case 3 : npc_tele(movecoord(npc_coord, 0, 0, -2));
+    case 4 : npc_tele(movecoord(npc_coord, -2, 0, -2));
+    case 5 : npc_tele(movecoord(npc_coord, -2, 0, 0));
+    case 6 : npc_tele(movecoord(npc_coord, -2, 0, 2));
+    case 7 : npc_tele(movecoord(npc_coord, 0, 0, 2));
+    case default : %npc_int = 0;
+}

--- a/data/src/scripts/minigames/game_trawler/scripts/trawler_start.rs2
+++ b/data/src/scripts/minigames/game_trawler/scripts/trawler_start.rs2
@@ -19,10 +19,8 @@ while (huntnext = true) {
     }
 }
 
-if (~playercount_coord_pair_table(trawler_lobby_zones) < 1) {
-    npc_settimer(0);
-}
-
+npc_settimer(0);
+%npc_trawler_start = null;
 ~trawler_reset;
 
 if (npc_find(^trawler_start_center_under, murphy_nonflood, 5, 0) = true) {

--- a/data/src/scripts/minigames/game_trawler/scripts/trawler_start.rs2
+++ b/data/src/scripts/minigames/game_trawler/scripts/trawler_start.rs2
@@ -1,6 +1,5 @@
-[ai_timer,murphy]
+[ai_queue5,murphy]
 if (~playercount_coord_pair_table(trawler_game_zones) > 0 | ~playercount_coord_pair_table(trawler_lobby_zones) < 1) {
-    npc_settimer(0);
     return;
 }
 
@@ -19,15 +18,13 @@ while (huntnext = true) {
     }
 }
 
-npc_settimer(0);
-%npc_trawler_start = null;
 ~trawler_reset;
 
 if (npc_find(^trawler_start_center_under, murphy_nonflood, 5, 0) = true) {
-    //~trawler_reset;
-    %npc_trawler_start = map_clock;
-    npc_settimer(30);
-
+    npc_queue(5, 0, 33); // 21 ticks from ship journey... After journey is over, trawler starts after 17 ticks (10s)
+}
+if (npc_find(^trawler_flood_center_under, murphy_flood, 5, 0) = true) {
+    npc_queue(5, 0, 33); // 21 ticks from ship journey... After journey is over, trawler starts after 17 ticks (10s)
 }
 
 [queue,trawler_start]
@@ -48,3 +45,9 @@ if_openmain(trawler_help);
 // CamShake(type = 1, shakeIntensity = 0, movementIntensity = 20, speed = 5)
 cam_shake(4, 0, 20, 4);
 cam_shake(1, 0, 20, 5);
+
+[ai_queue5,murphy_nonflood]
+npc_settimer(5);
+
+[ai_queue5,murphy_flood]
+npc_settimer(5);

--- a/data/src/scripts/minigames/game_trawler/scripts/trawler_win.rs2
+++ b/data/src/scripts/minigames/game_trawler/scripts/trawler_win.rs2
@@ -49,6 +49,7 @@ if_openmain(ship_journey);
 p_delay(20);
 if_close;
 ~update_all(null);
+cam_reset;
 p_teleport(map_findsquare(^trawler_lobby_murphy_spawn, 0, 4, ^map_findsquare_lineofwalk));
 
 [oploc1,game_trawler_reward_net]

--- a/data/src/scripts/player/scripts/appearance.rs2
+++ b/data/src/scripts/player/scripts/appearance.rs2
@@ -106,7 +106,6 @@ if (staffmodlevel >= 3 & inv_getobj(worn, ^wearpos_rhand) = poisoned_dagger) {
 if (p_finduid(uid) = true) {
     p_animprotect(^false);
 }
-cam_reset;
 ~update_weight_equipment; // replace weight-reducing equipment
 ~update_bas; // update appearance
 ~update_bonuses; // update bonuses if


### PR DESCRIPTION
Has old trawler commits cuz i forgor to make a new branch...

Turns out there were two main issues with trawler:
- map_playercount command doesnt support two coords with different levels, so I just changed the trawler dbrow
- Timers werent defined in the npc config for murphy... So if murphy went through defaultMode it'd remove the timer

some other fixes:
- Trawler locs were resetting immediately on trawler win/lose  - this doesnt match old videos
- Cam reset would be called every time you equipped an item
- Trawler was started too early, every vid ive seen has it start 17 ticks (10s) after the sailing interface.
- Only full trawler leaks were reset between trawler games, fixed leaks are only reset naturally (after 10 minutes)
- Old videos show that theres no opu trigger for fixed/non broken hulls