### PR TITLE
fix(engine): After changing type, Npcs will now revert themselves automatically

### DIFF
--- a/data/src/scripts/_test/scripts/cheats/cheat_interactions.rs2
+++ b/data/src/scripts/_test/scripts/cheats/cheat_interactions.rs2
@@ -314,7 +314,7 @@ inv_clear(worn);
 p_opnpc(2);
 
 world_delay(4);
-npc_changetype(cow_1);
+npc_changetype(cow_1, 400);
 
 
 [proc,repathing_to_an_npc_on_your_last_waypoint]

--- a/data/src/scripts/_test/scripts/cheats/cheat_npc.rs2
+++ b/data/src/scripts/_test/scripts/cheats/cheat_npc.rs2
@@ -1,0 +1,39 @@
+[debugproc,npc_change_dynamic]
+if (p_finduid(uid) = true) {
+    p_telejump(0_37_55_32_9);
+    p_delay(0);
+    npc_add(0_37_55_33_9, man_brown, 7);
+    p_delay(5);
+    npc_changetype(cow_1);
+}
+
+
+[debugproc,npc_change_static]
+if (p_finduid(uid) = true) {
+    p_telejump(0_50_50_2_62);
+    npc_findallany(coord, 10, ^vis_off);
+    while (npc_findnext = true) {
+        npc_changetype(cow_1);
+    }
+}
+
+[debugproc,npc_del_change]
+if (p_finduid(uid) = true) {
+    p_telejump(0_37_55_32_9);
+    p_delay(0);
+    npc_add(0_37_55_33_9, man_brown, 7);
+    p_delay(1);
+    npc_del;
+    p_delay(1);
+    npc_changetype(cow_1);
+}
+
+[debugproc,npc_del_change_static]
+if (p_finduid(uid) = true) {
+    p_telejump(0_50_50_2_62);
+    npc_findallany(coord, 10, ^vis_off);
+    while (npc_findnext = true) {
+        npc_del;
+        npc_changetype(cow_1);
+    }
+}

--- a/data/src/scripts/_test/scripts/cheats/cheat_npc.rs2
+++ b/data/src/scripts/_test/scripts/cheats/cheat_npc.rs2
@@ -4,7 +4,7 @@ if (p_finduid(uid) = true) {
     p_delay(0);
     npc_add(0_37_55_33_9, man_brown, 7);
     p_delay(5);
-    npc_changetype(cow_1);
+    npc_changetype(cow_1, 10);
 }
 
 
@@ -13,7 +13,7 @@ if (p_finduid(uid) = true) {
     p_telejump(0_50_50_2_62);
     npc_findallany(coord, 10, ^vis_off);
     while (npc_findnext = true) {
-        npc_changetype(cow_1);
+        npc_changetype(cow_1, 10);
     }
 }
 
@@ -25,7 +25,7 @@ if (p_finduid(uid) = true) {
     p_delay(1);
     npc_del;
     p_delay(1);
-    npc_changetype(cow_1);
+    npc_changetype(cow_1, 10);
 }
 
 [debugproc,npc_del_change_static]
@@ -34,6 +34,6 @@ if (p_finduid(uid) = true) {
     npc_findallany(coord, 10, ^vis_off);
     while (npc_findnext = true) {
         npc_del;
-        npc_changetype(cow_1);
+        npc_changetype(cow_1, 10);
     }
 }

--- a/data/src/scripts/areas/area_draynor/scripts/prince_ali.rs2
+++ b/data/src/scripts/areas/area_draynor/scripts/prince_ali.rs2
@@ -16,7 +16,7 @@ if(inv_total(inv, bronze_key) >= 1 & inv_total(inv, wig_blonde) >= 1 & inv_total
     inv_del(inv, pink_skirt, 1);
     inv_del(inv, paste, 1);
     %prince_progress = ^prince_saved;
-    npc_changetype(prince_ali_disguised);
+    npc_changetype(prince_ali_disguised, ^max_32bit_int);
     ~chatnpc_specific("Prince Ali", lady_keli, "<p,happy>Thank you my friend, I must leave you now.|My father will pay you well for this.");
     ~chatplayer("<p,happy>Go to Leela, she is close to here.");
     npc_del;

--- a/data/src/scripts/areas/area_mage_arena/scripts/kolodion_fight.rs2
+++ b/data/src/scripts/areas/area_mage_arena/scripts/kolodion_fight.rs2
@@ -127,7 +127,7 @@ npc_setmode(none);
 npc_anim(delrith_banish, 30);
 spotanim_map(smokepuff_large, npc_coord, 124, 90);
 npc_delay(2);
-npc_changetype(kolodion_defeated);
+npc_changetype(kolodion_defeated, ^max_32bit_int);
 npc_anim(null, 0);
 npc_setmode(playerface);
 npc_delay(0);

--- a/data/src/scripts/engine.rs2
+++ b/data/src/scripts/engine.rs2
@@ -600,7 +600,7 @@
 // info: Teleport the secondary npc to $coord, short distances (1-2 tiles) will visually walk/run
 [command,.npc_tele](coord $coord)
 // info: Change the npc's current type - new npc properties will be inherited
-[command,npc_changetype](npc $type)
+[command,npc_changetype](npc $type, int $duration)
 // info: Return the current npc's ai mode
 [command,npc_getmode]()(npc_mode)
 // info: Return the secondary npc's ai mode

--- a/data/src/scripts/general/scripts/flavour_text/sheep.rs2
+++ b/data/src/scripts/general/scripts/flavour_text/sheep.rs2
@@ -6,7 +6,7 @@ if ($rand = 0) {
 } else if ($rand = 1) {
     // todo: figure out the original timing, based off the 2005 video
     // it seems like it might be around 1 minute average
-    npc_changetype(sheep_fluffy);
+    npc_changetype(sheep_fluffy, ^max_32bit_int);
 }
 
 [ai_timer,sheep_fluffy]

--- a/data/src/scripts/general_use/scripts/shear_sheep.rs2
+++ b/data/src/scripts/general_use/scripts/shear_sheep.rs2
@@ -13,7 +13,7 @@ if(random(4) = 0) {
     return;
 }
 inv_add(inv, wool, 1);
-npc_changetype(sheep_sheared);
+npc_changetype(sheep_sheared, ^max_32bit_int);
 mes("You get some wool.");
 npc_say("Baa!");
 ~objbox(wool, "You get some wool.", 250, 0, divide(^objbox_height, 2));

--- a/data/src/scripts/macro events/scripts/fishing/macro_event_big_fish.rs2
+++ b/data/src/scripts/macro events/scripts/fishing/macro_event_big_fish.rs2
@@ -4,7 +4,7 @@
 // todo: figure out sounds
 sound_synth(watersplash, 0, 0); // complete guess
 def_npc $old = npc_type;
-npc_changetype(macro_event_big_fish);
+npc_changetype(macro_event_big_fish, ^max_32bit_int);
 npc_anim(fish_seq_3, 20);
 
 p_delay(0);
@@ -18,7 +18,7 @@ npc_anim(fish_seq_5, 0);
 
 p_delay(3);
 // seems to teleport twice, + does splash spot anim: https://youtu.be/ypNPoqhh5aw?list=PLn23LiLYLb1am4weMQzkWn5m9b3m9fXv9&t=386
-npc_changetype($old);
+npc_changetype($old, ^max_32bit_int);
 npc_tele(~fishing_spot_random_coord($old)); // move fishing spot. 
 // Might have a chance to move to the same spot: 
 // https://youtu.be/9z5XLWq4lZU?list=PLn23LiLYLb1am4weMQzkWn5m9b3m9fXv9&t=88

--- a/data/src/scripts/macro events/scripts/fishing/macro_event_whirlpool.rs2
+++ b/data/src/scripts/macro events/scripts/fishing/macro_event_whirlpool.rs2
@@ -1,7 +1,7 @@
 [proc,macro_event_whirlpool_spawn]
 %macro_event = ^no_macro_event;
 
-npc_changetype(npc_param(whirlpool));
+npc_changetype(npc_param(whirlpool), ^max_32bit_int);
 sound_synth(whirlpool, 0, 0);
 
 [proc,macro_whirlpool_attempt_take_equipment](namedobj $fishing_equipment)

--- a/data/src/scripts/macro events/scripts/general/macro_event_triffid.rs2
+++ b/data/src/scripts/macro events/scripts/general/macro_event_triffid.rs2
@@ -31,7 +31,7 @@ if (%npc_int = ^triffid_ready_to_attack) { // turn hostile
     npc_anim(seq_351, 60);
     npc_delay(4);
 
-    npc_changetype(macro_event_triffid_hostile);
+    npc_changetype(macro_event_triffid_hostile, ^max_32bit_int);
     npc_delay(1);
     npc_settimer(1);
     if (finduid(%npc_macro_event_target) = true) {

--- a/data/src/scripts/minigames/game_gnomeball/scripts/gnome_baller.rs2
+++ b/data/src/scripts/minigames/game_gnomeball/scripts/gnome_baller.rs2
@@ -17,9 +17,9 @@ if (p_finduid(uid) = true) {
 [proc,npc_gnomeball_tackle_fail]
 def_npc $old = npc_type;
 npc_anim(midget_seq_207, 0);
-npc_changetype(npc_param(gnome_fallen));
+npc_changetype(npc_param(gnome_fallen), ^max_32bit_int);
 npc_delay(5);
-npc_changetype($old);
+npc_changetype($old, ^max_32bit_int);
 npc_anim(midget_seq_209, 0);
 npc_delay(0);
 %npc_attacking_uid = null;
@@ -27,7 +27,7 @@ npc_delay(0);
 [proc,npc_gnomeball_tackle_success]
 queue(damage_player, 0, add(random(2), 1));
 anim(seq_779, 0);
-npc_changetype(npc_param(gnome_hasball));
+npc_changetype(npc_param(gnome_hasball), ^max_32bit_int);
 npc_anim(midget_seq_210, 0);
 inv_delslot(worn, ^wearpos_rhand);
 ~update_all(gnomeball);
@@ -87,10 +87,10 @@ npc_anim(midget_seq_203, 30);
 npc_setmode(none);
 p_delay(0);
 ~update_all(gnomeball);
-npc_changetype(nc_param($original, gnome_tackled));
+npc_changetype(nc_param($original, gnome_tackled), ^max_32bit_int);
 npc_delay(9);
 npc_setmode(null);
-npc_changetype($original);
+npc_changetype($original, ^max_32bit_int);
 npc_anim(midget_seq_206, 0);
 npc_delay(0);
 
@@ -117,7 +117,7 @@ p_delay(0);
 if (stat_random(stat(agility), 30, 220) = true) { // 50% guess for now
     inv_setslot(worn, ^wearpos_rhand, gnomeball, 1);
     def_npc $original = npc_param(gnome_original);
-    npc_changetype($original);
+    npc_changetype($original, ^max_32bit_int);
     ~player_gnomeball_tackle_success($original);
     %npc_attacking_uid = null;
 } else {

--- a/data/src/scripts/minigames/game_gnomeball/scripts/gnome_winger.rs2
+++ b/data/src/scripts/minigames/game_gnomeball/scripts/gnome_winger.rs2
@@ -38,7 +38,7 @@ npc_facesquare(coord);
 %npc_lastcombat = map_clock;
 
 npc_delay($delay);
-npc_changetype(gnome_winger2);
+npc_changetype(gnome_winger2, ^max_32bit_int);
 
 // no idea if this is how they do it but if you pass before 10 ticks after u first 
 // passed to them, they will always pass 10 ticks later
@@ -57,7 +57,7 @@ inv_setslot(worn, ^wearpos_rhand, gnomeball, 1);
 if (finduid(%npc_attacking_uid) = false | ~inzone_coord_pair_table(gnomeball_zones, coord) = false) {
     if (add(%npc_lastcombat, 60) < map_clock & npc_type = gnome_winger2) {
         %npc_attacking_uid = null;
-        npc_changetype(gnome_winger1);
+        npc_changetype(gnome_winger1, ^max_32bit_int);
         npc_del;
         return;
     }
@@ -87,7 +87,7 @@ if (p_finduid(%npc_attacking_uid) = true) {
     p_delay(0);
     npc_facesquare(coord);
     p_delay(0);
-    npc_changetype(gnome_winger1);
+    npc_changetype(gnome_winger1, ^max_32bit_int);
     p_delay(0);
     inv_setslot(worn, ^wearpos_rhand, gnomeball, 1);
     ~update_all(gnomeball);

--- a/data/src/scripts/minigames/game_gnomeball/scripts/gnomeball.rs2
+++ b/data/src/scripts/minigames/game_gnomeball/scripts/gnomeball.rs2
@@ -81,12 +81,12 @@ while (npc_findnext = true) {
     if (.finduid(%npc_attacking_uid) = false) {
         %npc_attacking_uid = null;
         if (npc_param(gnome_original) ! null & nc_param(npc_param(gnome_original), gnome_hasball) = npc_type) {
-            npc_changetype(npc_param(gnome_original));
+            npc_changetype(npc_param(gnome_original), ^max_32bit_int);
         }
     } else if (~.inzone_coord_pair_table(gnomeball_zones, .coord) = false) {
         %npc_attacking_uid = null;
         if (npc_param(gnome_original) ! null & nc_param(npc_param(gnome_original), gnome_hasball) = npc_type) {
-            npc_changetype(npc_param(gnome_original));
+            npc_changetype(npc_param(gnome_original), ^max_32bit_int);
         }  
     }
 }

--- a/data/src/scripts/quests/quest_arthur/scripts/beggar.rs2
+++ b/data/src/scripts/quests/quest_arthur/scripts/beggar.rs2
@@ -36,7 +36,7 @@ switch_int (~p_choice2("Yes certainly.", 1, "No I don't have any bread with me."
 ~mesbox("You give bread to the beggar.");
 inv_del(inv, bread, 1);
 ~chatnpc("<p,happy>Thank you very much!");
-npc_changetype(lady_of_the_lake); // re add if beggar doesn't exist
+npc_changetype(lady_of_the_lake, ^max_32bit_int); // re add if beggar doesn't exist
 ~mesbox("The beggar has turned into the Lady of the Lake!");
 ~chatnpc("<p,neutral>Well done. You have passed my test.");
 ~chatnpc("<p,neutral>Here is Excalibur, guard it well.");

--- a/data/src/scripts/quests/quest_demon/scripts/delrith.rs2
+++ b/data/src/scripts/quests/quest_demon/scripts/delrith.rs2
@@ -15,7 +15,7 @@ if (npc_stat(hitpoints) = 0) {
 [queue,delrith_death]
 if_close;
 if (npc_find(coord, delrith, 8, 0) = true) {
-    npc_changetype(weakened_delrith);
+    npc_changetype(weakened_delrith, ^max_32bit_int);
     npc_setmode(none); // stop fighting
 }
 
@@ -46,7 +46,7 @@ if_close;
 if (npc_find(coord, weakened_delrith, 8, 0) = true) {
     // On restore Delrith does not keep attacking you in 2004
     // https://www.youtube.com/watch?v=rjQprrDDUfE
-    npc_changetype(delrith);
+    npc_changetype(delrith, ^max_32bit_int);
     npc_statheal(hitpoints, 0, 100);
     ~mesbox("Suddenly the vortex collapses. That was the wrong incantation");
     return;
@@ -66,6 +66,6 @@ if (npc_find(coord, weakened_delrith, 8, 0) = true) {
 // Everything below here is a guess. This is set up so if a player doesn't kill weakened delrith he becomes
 // Regular delrith again after a minute.
 [ai_timer,weakened_delrith]
-npc_changetype(delrith);
+npc_changetype(delrith, ^max_32bit_int);
 npc_statheal(hitpoints, 0, 100);
 npc_setmode(none);

--- a/data/src/scripts/quests/quest_desertrescue/scripts/mining_slave.rs2
+++ b/data/src/scripts/quests/quest_desertrescue/scripts/mining_slave.rs2
@@ -207,7 +207,7 @@ if(inv_total(worn, desert_boots) > 0 & $traded_boots = false) {
     inv_setslot(worn, ^wearpos_feet, slave_boots, 1);
 }
 ~update_bas;
-npc_changetype(escaping_slave);
+npc_changetype(escaping_slave, ^max_32bit_int);
 npc_settimer(200); // 200t osrs
 //npc_delay(9); // can't interact for 10t?
 ~chatnpc_specific(nc_name(escaping_slave), escaping_slave, "<p,neutral>Right, I'm off! Good luck!");
@@ -231,13 +231,13 @@ npc_settimer(200); // 200t osrs
 ~chatnpc("<p,silent>@dbl@-- The slave nods in agreement and goes back to@dbl@work.");
 
 [ai_timer,escaping_slave]
-npc_changetype(male_slave);
+npc_changetype(male_slave, ^max_32bit_int);
 
 [opnpc1,escaping_slave]
 if(%desertrescue_progress >= ^desertrescue_traded_clothes) {
     // this only checks worn
     if(inv_total(worn, slave_shirt) = 0 | inv_total(worn, slave_robe) = 0 | inv_total(worn, slave_boots) = 0) {
-        npc_changetype(male_slave);
+        npc_changetype(male_slave, ^max_32bit_int);
         ~chatnpc("<p,neutral>Oh bother, I was caught by the guards again... Listen, if you can get me some Desert Clothes, I'll trade you for my slaves clothes again.. Do you want to trade?");
         @multi2("Yes, I'll trade.", male_slave_trade, "No thanks...", male_slave_notrade);
     } else {

--- a/data/src/scripts/quests/quest_fluffs/scripts/pet.rs2
+++ b/data/src/scripts/quests/quest_fluffs/scripts/pet.rs2
@@ -41,7 +41,7 @@ if (npc_finduid(%follower_uid) = true) {
 
 [label,cat_growth]
 if (getbit_range(%cat_growth, 11, 19) = 320) {
-    npc_changetype(nc_param(npc_type, cat_next_id));
+    npc_changetype(nc_param(npc_type, cat_next_id), ^max_32bit_int);
     %follower_obj = nc_param(npc_type, pet_item_id);
     %cat_growth = 0; //according to ash, this gets wiped when the cat becomes overgrown
     npc_say("Meeeooowww!");
@@ -55,7 +55,7 @@ if ($attent = 0) {
     $attent = 28; //default attent for a new kitten is supposed to be 28
 }
 if (getbit_range(%cat_growth, 11, 19) = 120) {
-    npc_changetype(nc_param(npc_type, cat_next_id));
+    npc_changetype(nc_param(npc_type, cat_next_id), ^max_32bit_int);
     %follower_obj = nc_param(npc_type, pet_item_id);
     npc_say("Meeeooowww!");
     ~mesbox("Your kitten has grown into a healthy cat,|that can hunt for itself."); //imgur.com/ni0BBTb

--- a/data/src/scripts/quests/quest_haunted/scripts/quest_haunted.rs2
+++ b/data/src/scripts/quests/quest_haunted/scripts/quest_haunted.rs2
@@ -200,12 +200,12 @@ sound_synth(locked, 0, 0);
 
 [proc,change_ernest]
 if(npc_find(coord, ernest_chicken, 8, 0) = true) {
-    npc_changetype(ernest_human);
+    npc_changetype(ernest_human, ^max_32bit_int);
     npc_settimer(100);
 }
 
 [ai_timer,ernest_human]
-npc_changetype(ernest_chicken);
+npc_changetype(ernest_chicken, ^max_32bit_int);
 
 [queue,haunted_quest_complete]
 %haunted_progress = ^haunted_complete;

--- a/data/src/scripts/quests/quest_prince/scripts/quest_prince.rs2
+++ b/data/src/scripts/quests/quest_prince/scripts/quest_prince.rs2
@@ -52,7 +52,7 @@ if(coordz(coord) > coordz(loc_coord)) {
 ~open_and_close_metal_gate2(loc_1541, true, false);
 
 [ai_timer,prince_ali_disguised]
-npc_changetype(prince_ali);
+npc_changetype(prince_ali, ^max_32bit_int);
 
 [queue,prince_complete]
 %prince_progress = ^prince_complete;

--- a/src/engine/World.ts
+++ b/src/engine/World.ts
@@ -682,14 +682,22 @@ class World {
                     }
                 }
 
-                // - respawn
-                if (npc.updateLifeCycle(this.currentTick)) {
+                // - Npc Events (Respawn, Revert, Despawn)
+                if (npc.lifecycleTick > -1 && npc.lifecycleTick < this.currentTick) {
                     try {
-                        if (npc.lifecycle === EntityLifeCycle.RESPAWN) {
+                        // Respawn NPC
+                        if (npc.lifecycle === EntityLifeCycle.RESPAWN && !npc.isActive) {
                             this.addNpc(npc, -1, false);
-                        } else if (npc.lifecycle === EntityLifeCycle.DESPAWN) {
+                        }
+                        // Revert NPC
+                        if (npc.lifecycle === EntityLifeCycle.RESPAWN) {
+                            npc.revert();
+                        }
+                        // Despawn NPC
+                        else if (npc.lifecycle === EntityLifeCycle.DESPAWN) {
                             this.removeNpc(npc, -1);
                         }
+                        npc.setLifeCycle(-1);
                     } catch (err) {
                         // there was an error adding or removing them, try again next tick...
                         // ex: server is full on npc IDs (did we have a leak somewhere?) and we don't want to re-use the last ID (syncing related)

--- a/src/engine/entity/Loc.ts
+++ b/src/engine/entity/Loc.ts
@@ -5,20 +5,13 @@ import NonPathingEntity from '#/engine/entity/NonPathingEntity.js';
 
 export default class Loc extends NonPathingEntity {
     // constructor properties
-    private info: number;
-    private tempinfo: number;
+    private baseInfo: number;
+    private currentInfo: number;
 
     constructor(level: number, x: number, z: number, width: number, length: number, lifecycle: EntityLifeCycle, type: number, shape: number, angle: number) {
         super(level, x, z, width, length, lifecycle);
-        this.info = this.packInfo(type, shape, angle);
-        this.tempinfo = -1;
-    }
-
-    private get currentinfo() {
-        if (this.tempinfo !== -1) {
-            return this.tempinfo;
-        }
-        return this.info;
+        this.baseInfo = this.packInfo(type, shape, angle);
+        this.currentInfo = this.baseInfo;
     }
 
     private packInfo(type: number, shape: number, angle: number): number {
@@ -28,37 +21,30 @@ export default class Loc extends NonPathingEntity {
     }
 
     isChanged(): boolean {
-        return this.tempinfo !== -1;
+        return this.currentInfo !== this.baseInfo;
     }
 
     get type(): number {
-        return this.currentinfo & 0x3fff;
+        return this.currentInfo & 0x3fff;
     }
 
     get shape(): number {
-        return (this.currentinfo >> 14) & 0x1f;
+        return (this.currentInfo >> 14) & 0x1f;
     }
 
     get angle(): number {
-        return (this.currentinfo >> 19) & 0x3;
+        return (this.currentInfo >> 19) & 0x3;
     }
 
     get layer(): number {
-        return (this.info >> 21) & 0x3;
+        return (this.baseInfo >> 21) & 0x3;
     }
 
     change(type: number, shape: number, angle: number) {
-        // Static locs set the temp bits
-        if (this.lifecycle === EntityLifeCycle.RESPAWN) {
-            this.tempinfo = this.packInfo(type, shape, angle);
-        }
-        // Dynamic locs set their real bits
-        else if (this.lifecycle === EntityLifeCycle.DESPAWN) {
-            this.info = this.packInfo(type, shape, angle);
-        }
+        this.currentInfo = this.packInfo(type, shape, angle);
     }
 
     revert() {
-        this.tempinfo = -1;
+        this.currentInfo = this.baseInfo;
     }
 }

--- a/src/engine/entity/Npc.ts
+++ b/src/engine/entity/Npc.ts
@@ -1012,7 +1012,7 @@ export default class Npc extends PathingEntity {
     }
 
     changeType(type: number, duration: number) {
-        if (!this.isActive) {
+        if (!this.isActive || duration < 1) {
             return;
         }
         this.currentType = type;

--- a/src/engine/entity/Npc.ts
+++ b/src/engine/entity/Npc.ts
@@ -1011,10 +1011,23 @@ export default class Npc extends PathingEntity {
         return this.currentType;
     }
 
-    changeType(type: number) {
+    changeType(type: number, duration: number) {
+        if (!this.isActive) {
+            return;
+        }
         this.currentType = type;
         this.masks |= InfoProt.NPC_CHANGE_TYPE.id;
         this.uid = (type << 16) | this.nid;
+
+        this.setLifeCycle(World.currentTick + duration);
+    }
+
+    revert(): void {
+        this.currentType = this.baseType;
+        this.masks |= InfoProt.NPC_CHANGE_TYPE.id;
+        this.uid = (this.type << 16) | this.nid;
+
+        this.setLifeCycle(-1);
     }
 
     isValid(_hash64?: bigint): boolean {

--- a/src/engine/entity/Npc.ts
+++ b/src/engine/entity/Npc.ts
@@ -24,7 +24,7 @@ import Obj from '#/engine/entity/Obj.js';
 import PathingEntity from '#/engine/entity/PathingEntity.js';
 import Player from '#/engine/entity/Player.js';
 import Visibility from '#/engine/entity/Visibility.js';
-import { isFlagged , findNaivePath } from '#/engine/GameMap.js';
+import { isFlagged, findNaivePath } from '#/engine/GameMap.js';
 import ScriptFile from '#/engine/script/ScriptFile.js';
 import { HuntIterator } from '#/engine/script/ScriptIterators.js';
 import ScriptPointer from '#/engine/script/ScriptPointer.js';
@@ -39,9 +39,9 @@ import LinkList from '#/util/LinkList.js';
 export default class Npc extends PathingEntity {
     // constructor properties
     nid: number;
-    type: number;
     uid: number;
-    origType: number;
+    baseType: number;
+    currentType: number;
     startX: number;
     startZ: number;
     startLevel: number;
@@ -76,12 +76,12 @@ export default class Npc extends PathingEntity {
     constructor(level: number, x: number, z: number, width: number, length: number, lifecycle: EntityLifeCycle, nid: number, type: number, moveRestrict: MoveRestrict, blockWalk: BlockWalk) {
         super(level, x, z, width, length, lifecycle, moveRestrict, blockWalk, MoveStrategy.NAIVE, InfoProt.NPC_FACE_COORD.id, InfoProt.NPC_FACE_ENTITY.id);
         this.nid = nid;
-        this.type = type;
+        this.baseType = type;
+        this.currentType = type;
         this.uid = (type << 16) | nid;
         this.startX = this.x;
         this.startZ = this.z;
         this.startLevel = this.level;
-        this.origType = type;
 
         const npcType = NpcType.get(type);
 
@@ -126,7 +126,7 @@ export default class Npc extends PathingEntity {
 
     resetEntity(respawn: boolean) {
         if (respawn) {
-            this.type = this.origType;
+            this.currentType = this.baseType;
             this.uid = (this.type << 16) | this.nid;
             this.unfocus();
             this.playAnimation(-1, 0); // reset animation or last anim has a chance to appear on respawn
@@ -1007,13 +1007,14 @@ export default class Npc extends PathingEntity {
         this.focus(CoordGrid.fine(x, 1), CoordGrid.fine(z, 1), true);
     }
 
+    get type(): number {
+        return this.currentType;
+    }
+
     changeType(type: number) {
-        this.type = type;
+        this.currentType = type;
         this.masks |= InfoProt.NPC_CHANGE_TYPE.id;
         this.uid = (type << 16) | this.nid;
-
-        const npcType: NpcType = NpcType.get(type);
-        this.setTimer(npcType.timer);
     }
 
     isValid(_hash64?: bigint): boolean {

--- a/src/engine/script/handlers/NpcOps.ts
+++ b/src/engine/script/handlers/NpcOps.ts
@@ -389,7 +389,7 @@ const NpcOps: CommandHandlers = {
     }),
 
     [ScriptOpcode.NPC_CHANGETYPE]: checkedHandler(ActiveNpc, state => {
-        state.activeNpc.changeType(check(state.popInt(), NpcTypeValid).id);
+        state.activeNpc.changeType(check(state.popInt(), NpcTypeValid).id, 10);
     }),
 
     [ScriptOpcode.NPC_GETMODE]: checkedHandler(ActiveNpc, state => {

--- a/src/engine/script/handlers/NpcOps.ts
+++ b/src/engine/script/handlers/NpcOps.ts
@@ -389,7 +389,11 @@ const NpcOps: CommandHandlers = {
     }),
 
     [ScriptOpcode.NPC_CHANGETYPE]: checkedHandler(ActiveNpc, state => {
-        state.activeNpc.changeType(check(state.popInt(), NpcTypeValid).id, 10);
+        const [id, duration] = state.popInts(2);
+        const npcType: number = check(id, NpcTypeValid).id;
+        check(duration, DurationValid);
+
+        state.activeNpc.changeType(npcType, duration);
     }),
 
     [ScriptOpcode.NPC_GETMODE]: checkedHandler(ActiveNpc, state => {

--- a/src/engine/zone/Zone.ts
+++ b/src/engine/zone/Zone.ts
@@ -121,7 +121,7 @@ export default class Zone {
                 World.removeLoc(loc, 0);
             } else if (loc.lifecycle === EntityLifeCycle.RESPAWN && loc.isChanged()) {
                 World.revertLoc(loc);
-            } else if (loc.lifecycle === EntityLifeCycle.RESPAWN) {
+            } else if (loc.lifecycle === EntityLifeCycle.RESPAWN && !loc.isActive) {
                 World.addLoc(loc, 0);
             }
         }
@@ -179,11 +179,11 @@ export default class Zone {
                 continue;
             }
             // Send dynamic locs to the client
-            if (loc.lifecycle === EntityLifeCycle.DESPAWN && loc.isValid()) {
+            if (loc.lifecycle === EntityLifeCycle.DESPAWN && loc.isActive) {
                 player.write(new LocAddChange(CoordGrid.packZoneCoord(loc.x, loc.z), loc.type, loc.shape, loc.angle));
             }
             // Inform the client that a static loc is not currently active
-            else if (loc.lifecycle === EntityLifeCycle.RESPAWN && !loc.isValid()) {
+            else if (loc.lifecycle === EntityLifeCycle.RESPAWN && !loc.isActive) {
                 player.write(new LocDel(CoordGrid.packZoneCoord(loc.x, loc.z), loc.shape, loc.angle));
             }
             // Send 'changed' static locs to the client


### PR DESCRIPTION
Before we were having to manually revert Npcs after changing their type

Now, `npc_changetype(Npc type, int duration)` takes in a `duration` and the engine will handle reverting the Npc after the duration has elapsed

I've gone ahead and filled all the examples in runescript of the command with a placeholder `^max_32bit_int`, so the feature is dormant for the time being