### PR TITLE
fix(content): Typo at lvl20 smithing level up

### DIFF
--- a/data/src/scripts/levelup/scripts/levelup_unlocks_smithing.rs2
+++ b/data/src/scripts/levelup/scripts/levelup_unlocks_smithing.rs2
@@ -18,7 +18,7 @@ switch_int(stat_base(smithing)) {
     case 17 : ~objbox(iron_mace,"You can now make @dbl@Iron Maces.", 250, 0, divide(^objbox_height, 2));
     case 18 : ~doubleobjbox(bronze_platebody,iron_med_helm," You can now make @dbl@Bronze Plate Bodies and Iron||@dbl@Medium Helms. ||", 200);
     case 19 : ~doubleobjbox(iron_sword,iron_dart_tip,"You can now make @dbl@Iron Short Swords@bla@ and members|can make @dbl@Iron Dart Tips@bla@.", 200);
-    case 20 : ~doubleobjbox(silver_ore,iron_scimitar,"You can now smlet @dbl@Silver Ore@bla@ and make @dbl@Iron|@dbl@Scimitars@bla@ and members can make @dbl@Iron Arrow Heads@bla@.", 200);
+    case 20 : ~doubleobjbox(silver_ore,iron_scimitar,"You can now smelt @dbl@Silver Ore@bla@ and make @dbl@Iron|@dbl@Scimitars@bla@ and members can make @dbl@Iron Arrow Heads@bla@.", 200);
     case 21 : ~objbox(iron_longsword,"You can now make @dbl@Iron Long Swords.", 250, 0, 0);
     case 22 : ~doubleobjbox(iron_full_helm,iron_knife,"You can now make @dbl@Iron Full Helms@bla@ and members can|make @dbl@Iron Throwing Knives@bla@.", 200);
     case 23 : ~objbox(iron_sq_shield,"You can now make @dbl@Iron Square Shields.", 250, 0, 0);


### PR DESCRIPTION
Typo at lvl 20 message. Not sure if authentic, can't find source