### PR TITLE
chore: update .env.example 

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -44,6 +44,7 @@
 # LOGGER_PORT=43501
 
 ## database
+# DB_BACKEND=sqlite
 # DATABASE_URL=mysql://root:password@localhost:3306/lostcity
 # DB_HOST=localhost
 # DB_NAME=lostcity


### PR DESCRIPTION
The login server assumes a sqlite backend, which can lead to confusing behavior when starting a fresh multi-world environment.

I'm adding this to .env.example to clarify that mysql is not being used by default.