### PR TITLE
fix: Adds aggression exemption for rogues

### DIFF
--- a/data/src/scripts/_unpack/all.npc
+++ b/data/src/scripts/_unpack/all.npc
@@ -4919,8 +4919,6 @@ param=damagetype,^stab_style
 param=attack_anim,human_sword_stab
 param=defend_anim,human_sword_defend2
 param=attack_sound,hacksword_stab
-huntmode=cowardly
-huntrange=1
 // Stats match osrs version but our version Vislvl is different.
 // https://raw.githubusercontent.com/Joshua-F/osrs-dumps/refs/heads/master/config/dump.npc npc_526
 


### PR DESCRIPTION
https://github.com/2004Scape/Server/issues/1509

addressing this issue here, it looks like they've provided proof on discord.

The issue seems to  be everything in the wilderness is treated as aggressive so somebody at the time must have written a carve out for them? 