### PR TITLE
feat(security): add 2fa schema changes

### DIFF
--- a/prisma/multiworld/migrations/20250322112523_2fa/migration.sql
+++ b/prisma/multiworld/migrations/20250322112523_2fa/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE `account` ADD COLUMN `tfa_enabled` BOOLEAN NOT NULL DEFAULT false,
+    ADD COLUMN `tfa_incorrect_attempts` INTEGER NOT NULL DEFAULT 0,
+    ADD COLUMN `tfa_last_code` INTEGER NOT NULL DEFAULT 0,
+    ADD COLUMN `tfa_secret_base32` VARCHAR(191) NULL;

--- a/prisma/multiworld/schema.prisma
+++ b/prisma/multiworld/schema.prisma
@@ -40,6 +40,15 @@ model account {
     notes_updated DateTime?
 
     members Boolean @default(true)
+
+    // Whether 2FA is enabled
+    tfa_enabled Boolean @default(false)
+    // To prevent replay attacks
+    tfa_last_code Int @default(0)
+    // Secret key for code generation
+    tfa_secret_base32 String?
+    // How many incorrect attempts have been made in a row
+    tfa_incorrect_attempts Int @default(0)
 }
 
 model session {

--- a/prisma/singleworld/migrations/20250322112532_2fa/migration.sql
+++ b/prisma/singleworld/migrations/20250322112532_2fa/migration.sql
@@ -1,0 +1,31 @@
+-- RedefineTables
+PRAGMA defer_foreign_keys=ON;
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_account" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "username" TEXT NOT NULL,
+    "password" TEXT NOT NULL,
+    "email" TEXT,
+    "registration_ip" TEXT,
+    "registration_date" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "logged_in" INTEGER NOT NULL DEFAULT 0,
+    "login_time" DATETIME,
+    "logged_out" INTEGER NOT NULL DEFAULT 0,
+    "logout_time" DATETIME,
+    "muted_until" DATETIME,
+    "banned_until" DATETIME,
+    "staffmodlevel" INTEGER NOT NULL DEFAULT 0,
+    "notes" TEXT,
+    "notes_updated" DATETIME,
+    "members" BOOLEAN NOT NULL DEFAULT true,
+    "tfa_enabled" BOOLEAN NOT NULL DEFAULT false,
+    "tfa_last_code" INTEGER NOT NULL DEFAULT 0,
+    "tfa_secret_base32" TEXT,
+    "tfa_incorrect_attempts" INTEGER NOT NULL DEFAULT 0
+);
+INSERT INTO "new_account" ("banned_until", "email", "id", "logged_in", "logged_out", "login_time", "logout_time", "members", "muted_until", "notes", "notes_updated", "password", "registration_date", "registration_ip", "staffmodlevel", "username") SELECT "banned_until", "email", "id", "logged_in", "logged_out", "login_time", "logout_time", "members", "muted_until", "notes", "notes_updated", "password", "registration_date", "registration_ip", "staffmodlevel", "username" FROM "account";
+DROP TABLE "account";
+ALTER TABLE "new_account" RENAME TO "account";
+CREATE UNIQUE INDEX "account_username_key" ON "account"("username");
+PRAGMA foreign_keys=ON;
+PRAGMA defer_foreign_keys=OFF;

--- a/prisma/singleworld/schema.prisma
+++ b/prisma/singleworld/schema.prisma
@@ -40,6 +40,15 @@ model account {
     notes_updated DateTime?
 
     members       Boolean  @default(true)
+
+    // Whether 2FA is enabled
+    tfa_enabled Boolean @default(false)
+    // To prevent replay attacks
+    tfa_last_code Int @default(0)
+    // Secret key for code generation
+    tfa_secret_base32 String?
+    // How many incorrect attempts have been made in a row
+    tfa_incorrect_attempts Int @default(0)
 }
 
 // logged in sessions

--- a/src/db/types.ts
+++ b/src/db/types.ts
@@ -21,6 +21,10 @@ export type account = {
     notes: string | null;
     notes_updated: string | null;
     members: Generated<number>;
+    tfa_enabled: Generated<number>;
+    tfa_last_code: Generated<number>;
+    tfa_secret_base32: string | null;
+    tfa_incorrect_attempts: Generated<number>;
 };
 export type account_session = {
     id: Generated<number>;


### PR DESCRIPTION
This only contains raw database schema changes to support account-based 2FA.