### PR TITLE
fix(content): fixes to plague series quests, rope swings

### DIFF
--- a/data/src/scripts/areas/area_ardougne_west/configs/doors.loc
+++ b/data/src/scripts/areas/area_ardougne_west/configs/doors.loc
@@ -8,7 +8,6 @@ retex1s=wall
 retex1d=door
 recol2s=6342
 recol2d=11458
-param=next_loc_stage,loc_2035
 
 [loc_2035]
 name=Door
@@ -30,7 +29,6 @@ retex1s=wall
 retex1d=door
 recol2s=6342
 recol2d=11458
-param=next_loc_stage,loc_2037
 
 [loc_2037]
 name=Door

--- a/data/src/scripts/areas/area_ardougne_west/scripts/doors.rs2
+++ b/data/src/scripts/areas/area_ardougne_west/scripts/doors.rs2
@@ -3,11 +3,11 @@ if(~check_axis(coord, loc_coord, loc_angle) = false & inv_total(worn, doctors_go
     mes("The mourner is refusing to open the door.");
     return;
 }
-~open_and_close_door2(loc_param(next_loc_stage), ~check_axis(coord, loc_coord, loc_angle), door_open);
+~open_and_close_door2(loc_2035, ~check_axis(coord, loc_coord, loc_angle), door_open);
 
 [oploc1,loc_2036] 
 if(~check_axis(coord, loc_coord, loc_angle) = false) {
-    ~open_and_close_door2(loc_param(next_loc_stage), ~check_axis(coord, loc_coord, loc_angle), door_open);
+    ~open_and_close_door2(loc_2037, ~check_axis(coord, loc_coord, loc_angle), door_open);
 } else {
     @west_ardougne_mourner_headquarters_doors;
 }
@@ -59,7 +59,7 @@ switch_int(%biohazard_progress) {
         if(inv_total(worn, doctors_gown) > 0) {
             ~chatnpc_specific(nc_name(npc_357), npc_357, "<p,neutral>In you go doc.");
             if_close;
-            ~open_and_close_door2(loc_param(next_loc_stage), ~check_axis(coord, loc_coord, loc_angle), door_open);
+            ~open_and_close_door2(loc_2037, ~check_axis(coord, loc_coord, loc_angle), door_open);
             return;
         }
         ~chatnpc_specific(nc_name(npc_357), npc_357, "<p,neutral>Stay away from there.");

--- a/data/src/scripts/quests/quest_elena/scripts/alrena.rs2
+++ b/data/src/scripts/quests/quest_elena/scripts/alrena.rs2
@@ -27,7 +27,7 @@ switch_int(%elena_progress) {
             ~objbox(gasmask, "<nc_name(alrena)> has given you a gas mask.", 250, 0, divide(^objbox_height, 2));
             ~chatnpc("<p,neutral>While you two are digging, I'll make a spare mask.|I'll hide it in the cupboard incase the mourners come in.");
         }
-    case ^quest_elena_started_mud_patch, ^quest_elena_mud_patch1, ^quest_elena_mud_patch2, ^quest_elena_mud_patch3 :
+    case ^quest_elena_gasmask, ^quest_elena_started_mud_patch, ^quest_elena_mud_patch1, ^quest_elena_mud_patch2, ^quest_elena_mud_patch3 :
         ~chatplayer("<p,happy>Hello <nc_name(alrena)>.");
         ~chatnpc("<p,happy>Hello darling,|how's that tunnel coming along?");
         ~chatplayer("<p,neutral>We're getting there...");

--- a/data/src/scripts/quests/quest_upass/configs/quest_upass.vars
+++ b/data/src/scripts/quests/quest_upass/configs/quest_upass.vars
@@ -4,3 +4,4 @@
 
 [upass_area2_pipe_used]
 
+[upass_area1_pipe_used]

--- a/data/src/scripts/quests/quest_upass/scripts/upass_obstacles.rs2
+++ b/data/src/scripts/quests/quest_upass/scripts/upass_obstacles.rs2
@@ -57,6 +57,11 @@ mes("You cannot open the grill from this side.");
 
 [oploc1,loc_3235]
 p_arrivedelay;
+if(%upass_area1_pipe_used >= map_clock) {
+    mes("The pipe is being used"); // todo: confirm, using the same as gnome course
+    return;
+}
+%upass_area1_pipe_used = calc(map_clock + 6);
 mes("You open the grating.");
 // Temp note: dur updated!!! nice even number :)
 loc_change(loc_3236, 10);
@@ -121,18 +126,18 @@ mes("You've lost your rope.");
 [oploc1,loc_2274]
 def_coord $start_pos = movecoord(loc_coord, 4, 0, 0);
 def_int $delay = distance(coord, $start_pos);
-if(coordz(coord) < coordz($start_pos)) {
+if(coordx(coord) < coordx(movecoord($start_pos, -1, 0, 0))) {
     mes("You cannot do that from here.");
     return;
 }
 p_delay(0);
 p_teleport($start_pos);
-if(%barb_ropeswing_used >= map_clock) {
+if(%upass_swampswing_used >= map_clock) {
     ~mesbox("The rope swing is being used");
     return;
 }
-%barb_ropeswing_used = calc(map_clock + 3);
-p_delay($delay);
+%upass_swampswing_used = calc(map_clock + 3);
+if($delay > 0) p_delay($delay);
 loc_anim(rope_swing);
 ~agility_exactmove(human_ropeswing, 20, 1, $start_pos, movecoord($start_pos, -5, 0, 0), 45, 70, ^exact_west, false);
 mes("You skillfully swing across.");

--- a/data/src/scripts/skill_agility/scripts/barbarian_course.rs2
+++ b/data/src/scripts/skill_agility/scripts/barbarian_course.rs2
@@ -22,7 +22,7 @@ if(%barb_ropeswing_used >= map_clock) {
     return;
 }
 %barb_ropeswing_used = calc(map_clock + 3);
-p_delay($delay);
+if($delay > 0) p_delay($delay);
 loc_anim(rope_swing);
 ~agility_exactmove(human_ropeswing, 20, 1, $start_pos, movecoord($start_pos, 0, 0, -5), 45, 70, ^exact_south, false);
 mes("You skillfully swing across.");

--- a/data/src/scripts/skill_agility/scripts/shortcuts.rs2
+++ b/data/src/scripts/skill_agility/scripts/shortcuts.rs2
@@ -101,7 +101,7 @@ switch_coord (loc_param(start_coord)) {
 }
 
 [oploc1,_island_rope_swing]
-def_int $dist = distance(coord, loc_param(start_coord));
+def_int $dist = ~total_distance(coord, loc_param(start_coord));
 if($dist > 3) {
     mes("You cannot do that from here.");
     return;
@@ -111,8 +111,8 @@ if(loc_type ! loc_2323 & stat(agility) < 10) {
     mes("You need an agility level of 10 to attempt to swing on this vine.");
     return;
 }
+p_delay(0);
 if(coord ! loc_param(start_coord)) {
-    p_delay(0);
     p_walk(loc_param(start_coord));
 }
 if(~get_island_rope_var >= map_clock) {
@@ -120,7 +120,17 @@ if(~get_island_rope_var >= map_clock) {
     return;
 }
 ~set_island_rope_var(calc(map_clock + 4));
-p_delay($dist);
+if($dist > 0) {
+    if(loc_type = loc_2323) {
+        if (%run = ^player_run_off) {
+            p_delay(sub($dist, 1));
+        } else {
+            p_delay(sub(divide($dist, 2), 1));
+        } 
+    } else {
+        p_delay(0);
+    }
+}
 loc_anim(rope_swing);
 ~agility_exactmove(human_ropeswing, 20, 1, coord, loc_param(end_coord), 45, 70, loc_param(dir), false);
 mes("You skillfully swing across.");

--- a/data/src/scripts/skill_agility/scripts/wilderness_course.rs2
+++ b/data/src/scripts/skill_agility/scripts/wilderness_course.rs2
@@ -71,7 +71,7 @@ if(coordz(coord) > coordz($start_pos)) {
 }
 p_delay(0);
 p_teleport($start_pos);
-p_delay($delay);
+if($delay > 0) p_delay($delay);
 if(stat_random(stat(agility), 175, 245) = false) {
     // todo: find actual rates, this is 82% at 52, 96% at 99
     ~agility_instant_fail(0_46_161_60_53, calc(((stat(hitpoints) * 15) / 100) + 1), "You slip and fall to the pit below.");


### PR DESCRIPTION
- Fixed Alrena missing dialogue on `^quest_elena_gasmask` stage
- changed mourner HQ to not call loc_param for doors through dialogue
- fixed check for rope swing in underground pass, also removed the additional 1t delay rope swings had before usage when starting standing next to them
- blocked usage of the grate pipe in underground pass when someone else is in it