### PR TITLE
fix(client): Auto sizing client conflicting with 2x and 3x sizes

### DIFF
--- a/view/client.ejs
+++ b/view/client.ejs
@@ -136,6 +136,7 @@
             }
             canvas.style.width = (789 * size) + 'px';
             canvas.style.height = (532 * size) + 'px';
+            canvas.style.maxWidth = 'none';
             
             let element = document.getElementById('canvasSize');
             element.textContent = size + "x size";


### PR DESCRIPTION
If you toggled auto client sizing on, then clicked 2x or 3x sizing, the max width style would mean that the client width is much smaller than it should be.

Thanks to @Collin-M for bringing this to my attention. Their image below for reference.

![image](https://github.com/user-attachments/assets/997a8518-7442-4894-adb0-11f5f7b222a7)

Fix is just to clear the max width when the sizing changes.

No changes needed for fullscreen mode.