### PR TITLE
fix(content): observatory quest reward was missing sapphire

### DIFF
--- a/data/src/scripts/quests/quest_itgronigen/scripts/quest_itgronigen.rs2
+++ b/data/src/scripts/quests/quest_itgronigen/scripts/quest_itgronigen.rs2
@@ -259,6 +259,7 @@ switch_int($constellation_numb) {
         inv_add(inv, amulet_of_defence, 1);
 }
 stat_advance(crafting, 22500);
+inv_add(inv, uncut_sapphire, 1);
 %itgronigen_progress = ^itgronigen_complete;
 %questpoints = calc(%questpoints + ^itgronigen_questpoints);
 queue(itgronigen_quest_complete, 0);


### PR DESCRIPTION
https://classic.runescape.wiki/w/Observatory_quest
https://oldschool.runescape.wiki/w/Observatory_Quest/Quick_guide

both wikis show an uncut sapphire as a reward for observatory quest

https://github.com/2004Scape/Server/issues/1527 issue posted here