### PR TITLE
chore(content): destroy_death param, fix script errors with remaining locs using next_loc_stage

### DIFF
--- a/data/src/scripts/areas/area_alkharid/configs/shantay_pass.loc
+++ b/data/src/scripts/areas/area_alkharid/configs/shantay_pass.loc
@@ -10,4 +10,3 @@ name=Prison door
 desc=It looks fairly sturdy.
 model=model_loc_37
 op1=Open
-param=next_loc_stage,loc_1541

--- a/data/src/scripts/areas/area_alkharid/scripts/shantay_pass.rs2
+++ b/data/src/scripts/areas/area_alkharid/scripts/shantay_pass.rs2
@@ -61,7 +61,7 @@ if (%shantay_jail_progress = ^put_in_shantay_jail & npc_find(coord, shantay, 12,
     @multi2("Yes, okay.", shantay_yes_okay_ill_pay_the_fine, "No thanks, you're not having my money.", shantay_no_thanks_youre_not_having_my_money);
 }
 
-~open_and_close_metal_gate(loc_param(next_loc_stage), $is_inside, false);
+~open_and_close_metal_gate(loc_1541, $is_inside, false);
 
 [oploc1,shantay_pass]
 if (map_members = false) {

--- a/data/src/scripts/areas/area_mage_arena/configs/mage_arena.obj
+++ b/data/src/scripts/areas/area_mage_arena/configs/mage_arena.obj
@@ -28,6 +28,7 @@ param=stabdefence,1
 param=slashdefence,1
 param=crushdefence,2
 param=magicdefence,10
+param=destroy_death,^true
 param=lose_cape_message,Saradomin reclaims the cape as it touches the ground.
 tradeable=no
 
@@ -61,6 +62,7 @@ param=stabdefence,1
 param=slashdefence,1
 param=crushdefence,2
 param=magicdefence,10
+param=destroy_death,^true
 param=lose_cape_message,Guthix reclaims the cape as it touches the ground.
 tradeable=no
 
@@ -94,6 +96,7 @@ param=stabdefence,1
 param=slashdefence,1
 param=crushdefence,2
 param=magicdefence,10
+param=destroy_death,^true
 param=lose_cape_message,Zamorak reclaims the cape as it touches the ground.
 tradeable=no
 

--- a/data/src/scripts/doors/scripts/doors.rs2
+++ b/data/src/scripts/doors/scripts/doors.rs2
@@ -3,6 +3,7 @@
 // ~loc_shape_debug(loc_shape);
 // mes(tostring(loc_angle));
 def_coord $new_loc_coord = ~movecoord_loc_return(~door_open(loc_angle, loc_shape));
+def_loc $new_loc = loc_param(next_loc_stage);
 if (coord = $new_loc_coord & loc_shape = wall_diagonal) {
     // todo: this is supposed to be p_walk i think. p_walk is broke rn
     p_teleport(movecoord(coord, ~door_open_move_player_out_of_way(loc_angle)));
@@ -11,7 +12,7 @@ if (coord = $new_loc_coord & loc_shape = wall_diagonal) {
 sound_synth(door_open, 0, 0);
 // Temp note: dur does not need updated
 loc_del(500);
-loc_add($new_loc_coord, loc_param(next_loc_stage), modulo(add(loc_angle, 1), 4), loc_shape, 500);
+loc_add($new_loc_coord, $new_loc, modulo(add(loc_angle, 1), 4), loc_shape, 500);
 // mes("Loc coord: <~coord_tostring(loc_coord)>");
 
 [oploc1,_door_opened]
@@ -19,6 +20,7 @@ loc_add($new_loc_coord, loc_param(next_loc_stage), modulo(add(loc_angle, 1), 4),
 // ~loc_shape_debug(loc_shape);
 // mes(tostring(loc_angle));
 def_coord $new_loc_coord = ~movecoord_loc_return(~door_close(loc_angle, loc_shape));
+def_loc $new_loc = loc_param(next_loc_stage);
 if (coord = $new_loc_coord & loc_shape = wall_diagonal) {
     // todo: this is supposed to be p_walk i think. p_walk is broke rn
     p_teleport(movecoord(coord, ~door_close_move_player_out_of_way(loc_angle)));
@@ -27,5 +29,5 @@ if (coord = $new_loc_coord & loc_shape = wall_diagonal) {
 sound_synth(door_close, 0, 0);
 // Temp note: dur does not need updated
 loc_del(500);
-loc_add($new_loc_coord, loc_param(next_loc_stage), modulo(add(loc_angle, 3), 4), loc_shape, 500);
+loc_add($new_loc_coord, $new_loc, modulo(add(loc_angle, 3), 4), loc_shape, 500);
 // mes("Loc coord: <~coord_tostring(loc_coord)>");

--- a/data/src/scripts/player/configs/death.param
+++ b/data/src/scripts/player/configs/death.param
@@ -1,0 +1,3 @@
+[destroy_death]
+type=int
+default=0

--- a/data/src/scripts/player/scripts/death.rs2
+++ b/data/src/scripts/player/scripts/death.rs2
@@ -154,7 +154,7 @@ def_int $i = 0;
 while ($i < $size_inv) {
     if (inv_getnum(inv, $i) > 0) {
         $currentitem = inv_getobj(inv, $i);
-        if (oc_category($currentitem) ! armour_godcape) { // TODO: param or property for items that can not be kept on death?
+        if (oc_param($currentitem, destroy_death) ! ^true) { // TODO: param or property for items that can not be kept on death?
             if (oc_cost($currentitem) > $biggest_price) {
                 $biggest_price = oc_cost($currentitem);
                 $priciest_item = $currentitem;
@@ -167,7 +167,7 @@ $i = 0;
 while ($i < $size_worn) {
     if (inv_getnum(worn, $i) > 0) {
         $currentitem = inv_getobj(worn, $i);
-        if (oc_category($currentitem) ! armour_godcape) {
+        if (oc_param($currentitem, destroy_death) ! ^true) {
             if (oc_cost($currentitem) > $biggest_price) {
                 $is_worn = true;
                 $biggest_price = oc_cost($currentitem);

--- a/data/src/scripts/player/scripts/death.rs2
+++ b/data/src/scripts/player/scripts/death.rs2
@@ -154,7 +154,7 @@ def_int $i = 0;
 while ($i < $size_inv) {
     if (inv_getnum(inv, $i) > 0) {
         $currentitem = inv_getobj(inv, $i);
-        if (oc_param($currentitem, destroy_death) ! ^true) { // TODO: param or property for items that can not be kept on death?
+        if (oc_param($currentitem, destroy_death) ! ^true) {
             if (oc_cost($currentitem) > $biggest_price) {
                 $biggest_price = oc_cost($currentitem);
                 $priciest_item = $currentitem;

--- a/data/src/scripts/quests/quest_blackknight/scripts/quest_blackknight.rs2
+++ b/data/src/scripts/quests/quest_blackknight/scripts/quest_blackknight.rs2
@@ -81,13 +81,14 @@ if ($is_inside = false) {
 }
 
 [label,blackknight_banquet_hall_fortress_guard](boolean $is_inside)
+def_loc $next_loc = loc_param(next_loc_stage);
 ~chatnpc("<p,neutral>I wouldn't go in there if I woz you.|Those Black Knights are in an important meeting;|They said they'd kill anyone who went in there!");
 def_int $option = ~p_choice2("Ok I won't.", 1, "I don't care. I'm going in anyway.", 2);
 if ($option = 1) {
     ~chatplayer("<p,neutral>Ok I won't.");
 } else {
    ~chatplayer("<p,neutral>I don't care. I'm going in anyway.");
-   ~open_and_close_door(loc_param(next_loc_stage), $is_inside, false);
+   ~open_and_close_door($next_loc, $is_inside, false);
    // black knights in the banquet hall will aggress the player
    ~set_black_knight_aggro(0_47_54_13_59);
    ~set_black_knight_aggro(0_47_54_21_59);

--- a/data/src/scripts/quests/quest_desertrescue/configs/desertrescue.obj
+++ b/data/src/scripts/quests/quest_desertrescue/configs/desertrescue.obj
@@ -58,6 +58,7 @@ members=yes
 iop1=Look
 weight=32kg
 tradeable=no
+param=destroy_death,^true
 
 [desertrescue_ironkey]
 name=Wrought iron key

--- a/data/src/scripts/quests/quest_elena/scripts/doors.rs2
+++ b/data/src/scripts/quests/quest_elena/scripts/doors.rs2
@@ -3,8 +3,9 @@
 [oploc1,loc_2535] mes("This door is locked."); // todo probs not right but yolo in 225 seems only 1 door is the correct one.
 
 [label,west_ardougne_plague_house_doors]
+def_loc $next_loc = loc_param(next_loc_stage);
 if (~check_axis(coord, loc_coord, loc_angle) = false) {
-    ~open_and_close_door(loc_param(next_loc_stage), ~check_axis(coord, loc_coord, loc_angle), false);
+    ~open_and_close_door($next_loc, ~check_axis(coord, loc_coord, loc_angle), false);
     return;
 }
 switch_int(%elena_progress) {
@@ -19,12 +20,12 @@ switch_int(%elena_progress) {
             ~chatnpcrange("<p,neutral>I'd stand away from there. That black cross means that house has been touched by the plague.");
             ~chatplayer("<p,neutral>I have a warrant from <nc_name(bravek)> to enter here.");
             if_close;
-            ~open_and_close_door(loc_param(next_loc_stage), ~check_axis(coord, loc_coord, loc_angle), false);
+            ~open_and_close_door($next_loc, ~check_axis(coord, loc_coord, loc_angle), false);
         } else if (npc_find(coord, mourner_blacksuit_3, 14, 0) = true) {
             ~mesbox("The door won't open.|You notice a black cross on the door.");
             ~chatnpcrange("<p,neutral>I'd stand away from there. That black cross means that house has been touched by the plague.");
         }
-    case ^quest_elena_freed_elena, ^elena_complete, ^elena_complete_read_scroll : ~open_and_close_door(loc_param(next_loc_stage), ~check_axis(coord, loc_coord, loc_angle), false);
+    case ^quest_elena_freed_elena, ^elena_complete, ^elena_complete_read_scroll : ~open_and_close_door($next_loc, ~check_axis(coord, loc_coord, loc_angle), false);
     case default :
         ~mesbox("The door won't open.|You notice a black cross on the door.");
         if (npc_find(coord, mourner_blacksuit_3, 14, 0) = true) {
@@ -61,8 +62,9 @@ switch_int(%elena_progress) {
 ~chatplayer("<p,neutral>Thanks for the warning.");
 
 [label,rehnissons_enter_house]
+def_loc $next_loc = loc_param(next_loc_stage);
 if (%elena_progress >= ^quest_elena_returned_book) {
-    ~open_and_close_door(loc_param(next_loc_stage), ~check_axis(coord, loc_coord, loc_angle), false);
+    ~open_and_close_door($next_loc, ~check_axis(coord, loc_coord, loc_angle), false);
     return;
 }
 if (npc_find(coord, ted_rehnison, 7, 0) = false) {
@@ -76,7 +78,7 @@ switch_int(%elena_progress) {
             ~chatnpc("<p,neutral>Oh... Why didn't you say, come in then.");
             if_close; // very regarded
             ~quest_elena_set_progress(^quest_elena_returned_book);
-            ~open_and_close_door(loc_param(next_loc_stage), ~check_axis(coord, loc_coord, loc_angle), false);
+            ~open_and_close_door($next_loc, ~check_axis(coord, loc_coord, loc_angle), false);
             inv_del(inv, elena_book, 1);
             ~objbox(elena_book, "You hand the book to Ted as you enter.", 250, 0, divide(^objbox_height, 2));
             ~chatnpc("<p,happy>Thanks, I've been missing that.");

--- a/data/src/scripts/skill_fishing/scripts/fishing_guild.rs2
+++ b/data/src/scripts/skill_fishing/scripts/fishing_guild.rs2
@@ -6,7 +6,7 @@ if ($is_inside = false) {
         @fishing_guild_level_fail;
     }
 }
-    ~open_and_close_door(loc_param(next_loc_stage), $is_inside, false);
+~open_and_close_door(loc_param(next_loc_stage), $is_inside, false);
 
 [label,fishing_guild_level_fail]
 // find master fisher


### PR DESCRIPTION
- fix remaining possible script errors in locs using next_loc_stage
- create a param for objs that are never kept on death (currently only applied to god capes and ana in a barrel)