### PR TITLE
fix(engine):  Npcs will now stop facing player when interaction is cleared

### DIFF
--- a/src/engine/entity/Npc.ts
+++ b/src/engine/entity/Npc.ts
@@ -437,11 +437,14 @@ export default class Npc extends PathingEntity {
     }
 
     noMode(): void {
-        // this.clearInteraction();
         this.updateMovement(false);
-        // this.targetOp = NpcMode.NONE;
-        // this.faceEntity = -1;
-        // this.masks |= InfoProt.NPC_FACE_ENTITY.id;
+    }
+
+    clearInteraction(): void {
+        super.clearInteraction();
+        this.targetOp = NpcMode.NONE;
+        this.faceEntity = -1;
+        this.masks |= NpcInfoProt.FACE_ENTITY;
     }
 
     defaultMode(): void {


### PR DESCRIPTION
This code had been commented out of nomode() because it didn't belong there. Instead it now is called directly when clearinteraction() gets called