### PR TITLE
fix(content): lastcombat change, update zam wiz

### DIFF
--- a/data/src/scripts/general_use/scripts/spade.rs2
+++ b/data/src/scripts/general_use/scripts/spade.rs2
@@ -50,7 +50,7 @@ if(map_members = true & ~trail_hasclue_inv = true) {
                     npc_say("Die, human!");
                     %aggressive_npc = npc_uid;
                     // this prevents other players from attacking w/manual cast, this might've been a later change
-                    %npc_lastcombat = ^max_32bit_int;
+                    %npc_lastcombat = sub(^max_32bit_int, 8);
                     %npc_aggressive_player = uid;
                     npc_setmode(applayer2);
                     return;

--- a/data/src/scripts/skill_combat/scripts/npc/npc_combat.rs2
+++ b/data/src/scripts/skill_combat/scripts/npc/npc_combat.rs2
@@ -329,7 +329,7 @@ if (map_multiway(npc_coord) = false & %npc_attacking_uid ! uid & %npc_attacking_
     %npc_action_delay = add(map_clock, 8);
 }
 %npc_aggressive_player = uid;
-%npc_lastcombat = map_clock;
+if(%npc_lastcombat < map_clock) %npc_lastcombat = map_clock;
 
 [proc,.npc_retaliate](int $queue_delay)
 .npc_queue(1, 0, $queue_delay);
@@ -338,7 +338,7 @@ if (map_multiway(.npc_coord) = false & .%npc_attacking_uid ! uid & .%npc_attacki
     .%npc_action_delay = add(map_clock, 8);
 }
 .%npc_aggressive_player = uid;
-.%npc_lastcombat = map_clock;
+if(.%npc_lastcombat < map_clock) .%npc_lastcombat = map_clock;
 
 [proc,npc_set_attack_vars]
 %lastcombat = map_clock;


### PR DESCRIPTION
Only update %npc_lastcombat when map_clock is greater than the current value, also small fix for the zamorak wizard script