### PR TITLE
feat(engine): Add mod action table

### DIFF
--- a/prisma/multiworld/migrations/20250324231534_add_mod_action_table/migration.sql
+++ b/prisma/multiworld/migrations/20250324231534_add_mod_action_table/migration.sql
@@ -1,0 +1,12 @@
+-- CreateTable
+CREATE TABLE `mod_action` (
+    `id` INTEGER NOT NULL AUTO_INCREMENT,
+    `account_id` INTEGER NOT NULL,
+    `target_id` INTEGER NULL,
+    `action_id` INTEGER NOT NULL,
+    `data` VARCHAR(191) NULL,
+    `ip` VARCHAR(191) NULL,
+    `timestamp` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;

--- a/prisma/multiworld/schema.prisma
+++ b/prisma/multiworld/schema.prisma
@@ -254,3 +254,15 @@ model message_status {
   read       DateTime?
   deleted    DateTime?
 }
+
+model mod_action {
+    id Int @id @default(autoincrement())
+
+    account_id Int
+    target_id  Int?
+
+    action_id Int
+    data      String?
+    ip        String?
+    timestamp DateTime @default(now())
+}

--- a/prisma/singleworld/migrations/20250324232003_add_mod_action_table/migration.sql
+++ b/prisma/singleworld/migrations/20250324232003_add_mod_action_table/migration.sql
@@ -1,0 +1,10 @@
+-- CreateTable
+CREATE TABLE "mod_action" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "account_id" INTEGER NOT NULL,
+    "target_id" INTEGER,
+    "action_id" INTEGER NOT NULL,
+    "data" TEXT,
+    "ip" TEXT,
+    "timestamp" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);

--- a/prisma/singleworld/schema.prisma
+++ b/prisma/singleworld/schema.prisma
@@ -254,3 +254,15 @@ model message_status {
   read       DateTime?
   deleted    DateTime?
 }
+
+model mod_action {
+    id Int @id @default(autoincrement())
+
+    account_id Int
+    target_id  Int?
+
+    action_id Int
+    data      String?
+    ip        String?
+    timestamp DateTime @default(now())
+}

--- a/src/db/types.ts
+++ b/src/db/types.ts
@@ -120,6 +120,15 @@ export type message_thread = {
     from_deleted: string | null;
     messages: Generated<number>;
 };
+export type mod_action = {
+    id: Generated<number>;
+    account_id: number;
+    target_id: number | null;
+    action_id: number;
+    data: string | null;
+    ip: string | null;
+    timestamp: Generated<string>;
+};
 export type newspost = {
     id: Generated<number>;
     category: number;
@@ -187,6 +196,7 @@ export type DB = {
     message: message;
     message_status: message_status;
     message_thread: message_thread;
+    mod_action: mod_action;
     newspost: newspost;
     private_chat: private_chat;
     public_chat: public_chat;


### PR DESCRIPTION
Adds a new `mod_action` table for the purpose of auditing moderator actions.

## Changes
- Added `mod_action` table in both Prisma schemas.
- Generated and included the necessary Prisma migrations.