### PR TITLE
fix(content): only bring up trades menu if you've recieved a trade recently

### DIFF
--- a/data/src/scripts/interface_trade/configs/trade.constant
+++ b/data/src/scripts/interface_trade/configs/trade.constant
@@ -1,0 +1,5 @@
+^tradestatus_reset = 0
+^tradestatus_received = 1
+^tradestatus_pending_accept = 2
+^tradestatus_accept = 3
+^tradestatus_pending_confirm = 4

--- a/data/src/scripts/interface_trade/scripts/trade.rs2
+++ b/data/src/scripts/interface_trade/scripts/trade.rs2
@@ -37,7 +37,7 @@ if (.busy = true) {
 mes("Sending trade offer...");
 %tradepartner = .uid;
 
-if (.%tradepartner = uid) {
+if (.%tradepartner = uid & %tradestatus = ^tradestatus_received) {
     if (.p_finduid(.uid) = true) {
         .p_stopaction;
     }
@@ -58,17 +58,18 @@ if (.%tradepartner = uid) {
     if_openmain_side(trademain, tradeside);
     .if_openmain_side(trademain, tradeside);
 
-    %tradestatus = 0;
-    .%tradestatus = 0;
+    %tradestatus = ^tradestatus_reset;
+    .%tradestatus = ^tradestatus_reset;
 } else {
+    .%tradestatus = ^tradestatus_received;
     .mes("<displayname>:tradereq:");
 }
 
 [if_button,trademain:accept]
-%tradestatus = 1;
+%tradestatus = ^tradestatus_pending_accept;
 
 if (.finduid(%tradepartner) = true) {
-    if (.%tradestatus = 1) {
+    if (.%tradestatus = ^tradestatus_pending_accept) {
         inv_stoptransmit(trademain:inv);
         inv_stoptransmit(trademain:otherinv);
         inv_stoptransmit(tradeside:inv);
@@ -138,8 +139,8 @@ if (.finduid(%tradepartner) = true) {
         if_settext(tradeconfirm:com_91, "Are you sure you want to make this trade?");
         .if_settext(tradeconfirm:com_91, "Are you sure you want to make this trade?");
 
-        %tradestatus = 2;
-        .%tradestatus = 2;
+        %tradestatus = ^tradestatus_accept;
+        .%tradestatus = ^tradestatus_accept;
     } else {
         if_settext(trademain:status, "Waiting for other player..."); // https://youtu.be/uSO-ilQk5XY?list=PLn23LiLYLb1bQ7Hwp77KoNBjKvpZQTfJT&t=817
         .if_settext(trademain:status,"Other player has accepted."); // https://storage.googleapis.com/tannerdino/images/06Dec14-16.jpg
@@ -243,10 +244,10 @@ if (.finduid(%tradepartner) = true) {
 %tradepartner = null;
 
 [if_button,tradeconfirm:accept]
-%tradestatus = 3;
+%tradestatus = ^tradestatus_pending_confirm;
 
 if (.finduid(%tradepartner) = true) {
-    if (.%tradestatus = 3) {
+    if (.%tradestatus = ^tradestatus_pending_confirm) {
         mes("Accepted trade.");
         .mes("Accepted trade.");
 
@@ -298,11 +299,11 @@ def_int $total = inv_total(tempinv, $obj);
 if ($amount < $total) $total = $amount;
 inv_moveitem(tempinv, inv, $obj, $total);
 
-%tradestatus = 0;
+%tradestatus = ^tradestatus_reset;
 if_settext(trademain:status, "");
 if (.finduid(%tradepartner) = true) {
     session_log(^log_moderator, "Removed offer <oc_debugname($obj)> x<tostring($total)> to <.name>");
-    .%tradestatus = 0;
+    .%tradestatus = ^tradestatus_reset;
     .if_settext(trademain:status, "");
 }
 
@@ -337,10 +338,10 @@ def_int $total = inv_total(inv, $obj);
 if ($amount < $total) $total = $amount;
 inv_moveitem(inv, tempinv, $obj, $total);
 
-%tradestatus = 0;
+%tradestatus = ^tradestatus_reset;
 if_settext(trademain:status, "");
 if (.finduid(%tradepartner) = true) {
     session_log(^log_moderator, "Added offer <oc_debugname($obj)> x<tostring($total)> to <.name>");
-    .%tradestatus = 0;
+    .%tradestatus = ^tradestatus_reset;
     .if_settext(trademain:status, "");
 }

--- a/data/src/scripts/minigames/game_duelarena/configs/duelarena.constant
+++ b/data/src/scripts/minigames/game_duelarena/configs/duelarena.constant
@@ -25,3 +25,11 @@
 ^duelstatus_lost = 5
 ^duelstatus_victory = 6
 ^duelstatus_opponent_resigned = 7
+
+^duelstatus_reset = 0
+^duelstatus_received = 1
+^duelstatus_pending_accept = 2
+^duelstatus_accept = 3
+^duelstatus_pending_confirm = 4
+^duelstatus_confirm = 5
+^duelstatus_start = 6

--- a/data/src/scripts/minigames/game_duelarena/scripts/duel_arena.rs2
+++ b/data/src/scripts/minigames/game_duelarena/scripts/duel_arena.rs2
@@ -47,7 +47,7 @@ mes("Sending duel offer...");
 %duel_settings = 0;
 %duelpartner = .uid;
 
-if (.%duelpartner = uid) {
+if (.%duelpartner = uid & %duelstatus = ^duelstatus_received) {
     if (.p_finduid(.uid) = true) {
         .p_stopaction;
     }
@@ -69,9 +69,10 @@ if (.%duelpartner = uid) {
     if_openmain_side(duel_select_type, duel_side);
     .if_openmain_side(duel_select_type, duel_side);
     
-    %duelstatus = 0;
-    .%duelstatus = 0;
+    %duelstatus = ^duelstatus_reset;
+    .%duelstatus = ^duelstatus_reset;
 } else {
+    .%duelstatus = ^duelstatus_received;
     .mes("<displayname>:duelreq:");
 }
 
@@ -107,9 +108,9 @@ if (.finduid(%duelpartner) = true) {
 %duelpartner = null;
 
 [if_button,duel_select_type:accept]
-%duelstatus = 1;
+%duelstatus = ^duelstatus_pending_accept;
 if (.finduid(%duelpartner) = true & ~enough_duel_space = true) { // https://youtu.be/WHpZQ5fbr5w
-    if (.%duelstatus = 1 & ~.enough_duel_space = true) {
+    if (.%duelstatus = ^duelstatus_pending_accept & ~.enough_duel_space = true) {
         // Accept stake and move onto second screen!
         inv_stoptransmit(duel_select_type:inv);
         inv_stoptransmit(duel_select_type:otherinv);
@@ -160,8 +161,8 @@ if (.finduid(%duelpartner) = true & ~enough_duel_space = true) { // https://yout
         if_settext(duel_confirm:com_97, "Are you sure you want to fight this duel?");
         .if_settext(duel_confirm:com_97, "Are you sure you want to fight this duel?");
 
-        %duelstatus = 2;
-        .%duelstatus = 2;
+        %duelstatus = ^duelstatus_accept;
+        .%duelstatus = ^duelstatus_accept;
     } else {
         .if_settext(duel_select_type:status, "Other player has accepted...");
         if_settext(duel_select_type:status, "Waiting for other player...");
@@ -287,18 +288,18 @@ return(true);
 
 
 [if_button,duel_confirm:accept]
-%duelstatus = 3;
+%duelstatus = ^duelstatus_pending_confirm;
 
 if (.finduid(%duelpartner) = true) {
-    if (.%duelstatus = 3) {
+    if (.%duelstatus = ^duelstatus_pending_confirm) {
         mes("Accepted stake and duel options.");
         .mes("Accepted stake and duel options.");
 
         // both_moveinv(inv, inv);
         // .both_moveinv(tempinv, inv);
 
-        %duelstatus = 4;
-        .%duelstatus = 4;
+        %duelstatus = ^duelstatus_confirm;
+        .%duelstatus = ^duelstatus_confirm;
 
         if_close;
         .if_close;
@@ -328,10 +329,10 @@ def_int $total = inv_total(tempinv, $obj);
 if ($amount < $total) $total = $amount;
 inv_moveitem(tempinv, inv, $obj, $total);
 
-%duelstatus = 0;
+%duelstatus = ^duelstatus_reset;
 if_settext(duel_select_type:status, "");
 if (.finduid(%duelpartner) = true) {
-    .%duelstatus = 0;
+    .%duelstatus = ^duelstatus_reset;
     .if_settext(duel_select_type:status, "");
 }
 
@@ -365,10 +366,10 @@ def_int $total = inv_total(inv, $obj);
 if ($amount < $total) $total = $amount;
 inv_moveitem(inv, tempinv, $obj, $total);
 
-%duelstatus = 0;
+%duelstatus = ^duelstatus_reset;
 if_settext(duel_select_type:status, "");
 if (.finduid(%duelpartner) = true) {
-    .%duelstatus = 0;
+    .%duelstatus = ^duelstatus_reset;
     .if_settext(duel_select_type:status, "");
 }
 
@@ -383,7 +384,7 @@ if (.uid ! %duelpartner) {
     mes("You can only attack your opponent!"); // https://storage.googleapis.com/tannerdino/images/batwifahat-purpl.jpg
     return(false);
 }
-if (%duelstatus < 5 & .%duelstatus < 5) {
+if (%duelstatus < ^duelstatus_start & .%duelstatus < ^duelstatus_start) {
     mes("The duel has not started yet!"); // https://youtu.be/64GEUr-lgS8?t=106
     return(false);
 }
@@ -412,12 +413,12 @@ if (~in_duel_arena(coord) = false) {
     return;
 }
 if (.finduid(%duelpartner) = true) {
-    .%duelstatus = 0;
+    .%duelstatus = ^duelstatus_reset;
     .%duelpartner = null;
     .if_close;
     .queue(duel_arena_disconnect, 0);
 }
-%duelstatus = 0;
+%duelstatus = ^duelstatus_reset;
 %duelpartner = null;
 ~duel_give_stake_back;
 

--- a/data/src/scripts/minigames/game_duelarena/scripts/duel_arena_finish.rs2
+++ b/data/src/scripts/minigames/game_duelarena/scripts/duel_arena_finish.rs2
@@ -77,7 +77,7 @@ clearqueue(player_death_default);
 ~clear_poison;
 ~update_all(inv_getobj(worn, ^wearpos_rhand));
 hint_stop;
-%duelstatus = 0;
+%duelstatus = ^duelstatus_reset;
 %duelpartner = null;
 
 [proc,duel_give_stake_back]

--- a/data/src/scripts/minigames/game_duelarena/scripts/duel_arena_settings.rs2
+++ b/data/src/scripts/minigames/game_duelarena/scripts/duel_arena_settings.rs2
@@ -85,10 +85,10 @@ if (~duel_arena_flower_power_check = true) {
 %duel_settings = togglebit(%duel_settings, $setting);
 if (.finduid(%duelpartner) = true) {
     .%duel_settings = %duel_settings;
-    .%duelstatus = 0;
+    .%duelstatus = ^duelstatus_reset;
     .if_settext(duel_select_type:status, "");
 }
-%duelstatus = 0;
+%duelstatus = ^duelstatus_reset;
 if_settext(duel_select_type:status, "");
 
 [proc,unequip_duel](enum $enum)

--- a/data/src/scripts/minigames/game_duelarena/scripts/duel_arena_start.rs2
+++ b/data/src/scripts/minigames/game_duelarena/scripts/duel_arena_start.rs2
@@ -4,7 +4,7 @@ if (.finduid(%duelpartner) = true) {
     def_coord $random_coord2 = $random_coord1;
 
     if ($random_coord1 = null) {
-        %duelstatus = 0;
+        %duelstatus = ^duelstatus_reset;
         %duelpartner = null;
         ~mesbox("All arenas of this type are full! Select another type of arena, try|again in a few minutes or try a different server."); // https://youtu.be/TcrIr9O92sw?t=89
         return;
@@ -144,7 +144,7 @@ if (~in_duel_arena(coord) = false) {
     return;
 }
 say("FIGHT!");
-%duelstatus = 5;
+%duelstatus = ^duelstatus_start;
 clearsofttimer(duel_arena_start_fight);
 
 [walktrigger,duel_arena_no_move]
@@ -158,7 +158,7 @@ if (~in_duel_arena(coord) = false) {
     clearsofttimer(duel_arena_time_limit);
     return;
 }
-%duelstatus = 0;
+%duelstatus = ^duelstatus_reset;
 %duelpartner = null;
 if_close;
 queue(duel_arena_time_limit, 0);


### PR DESCRIPTION
Initially reported by White Turtle on discord:
```
Player A trades Player B
Player B logs out
Player B logs back in quickly
Player B trades Player A
Trade screen immediately appears without confirmation from player A
```

To confirm ours works like the above steps:

https://github.com/user-attachments/assets/9945d09c-9661-421b-8815-a4c0dc86305b


Osrs doesnt work like ours does:

https://github.com/user-attachments/assets/5a6da0d0-0077-4814-a012-19c0aaa13557


2004Scape with my fixes:

https://github.com/user-attachments/assets/6f2bab76-5ecf-487f-9975-d4245f778b84

