### PR TITLE
fix(engine): Npc queues now consider if the Npc has changed type 

### DIFF
--- a/src/engine/World.ts
+++ b/src/engine/World.ts
@@ -37,7 +37,6 @@ import WordEnc from '#/cache/wordenc/WordEnc.js';
 import BlockWalk from '#/engine/entity/BlockWalk.js';
 import EntityLifeCycle from '#/engine/entity/EntityLifeCycle.js';
 import { NpcList, PlayerList } from '#/engine/entity/EntityList.js';
-import { EntityQueueState, PlayerQueueType } from '#/engine/entity/EntityQueueRequest.js';
 import { PlayerTimerType } from '#/engine/entity/EntityTimer.js';
 import HuntModeType from '#/engine/entity/hunt/HuntModeType.js';
 import HuntNobodyNear from '#/engine/entity/hunt/HuntNobodyNear.js';
@@ -49,6 +48,7 @@ import NpcStat from '#/engine/entity/NpcStat.js';
 import Obj from '#/engine/entity/Obj.js';
 import Player from '#/engine/entity/Player.js';
 import { PlayerLoading } from '#/engine/entity/PlayerLoading.js';
+import { EntityQueueState, PlayerQueueType } from '#/engine/entity/PlayerQueueRequest.js';
 import { PlayerStat } from '#/engine/entity/PlayerStat.js';
 import { SessionLog } from '#/engine/entity/tracking/SessionLog.js';
 import GameMap, { changeLocCollision, changeNpcCollision, changePlayerCollision } from '#/engine/GameMap.js';
@@ -1040,9 +1040,7 @@ class World {
             player.reorient();
             player.buildArea.rebuildNormal(); // set origin before compute player is why this is above.
 
-            const appearance = player.masks & PlayerInfoProt.APPEARANCE
-                ? player.generateAppearance()
-                : player.lastAppearanceBytes ?? player.generateAppearance();
+            const appearance = player.masks & PlayerInfoProt.APPEARANCE ? player.generateAppearance() : (player.lastAppearanceBytes ?? player.generateAppearance());
 
             rsbuf.computePlayer(
                 player.x,
@@ -1085,7 +1083,7 @@ class World {
                 player.exactEndZ,
                 player.exactMoveStart,
                 player.exactMoveEnd,
-                player.exactMoveDirection,
+                player.exactMoveDirection
             );
         }
 
@@ -1116,7 +1114,7 @@ class World {
                 npc.chat,
                 npc.graphicId,
                 npc.graphicHeight,
-                npc.graphicDelay,
+                npc.graphicDelay
             );
         }
     }

--- a/src/engine/entity/EntityQueueRequest.ts
+++ b/src/engine/entity/EntityQueueRequest.ts
@@ -2,9 +2,9 @@ import ScriptFile from '#/engine/script/ScriptFile.js';
 import ScriptState from '#/engine/script/ScriptState.js';
 import Linkable from '#/util/Linkable.js';
 
-export enum NpcQueueType {
-    NORMAL
-}
+// export enum NpcQueueType {
+//     NORMAL
+// }
 
 export enum PlayerQueueType {
     NORMAL,
@@ -15,7 +15,7 @@ export enum PlayerQueueType {
     SOFT // OSRS
 }
 
-export type QueueType = NpcQueueType | PlayerQueueType;
+export type QueueType = PlayerQueueType;
 export type ScriptArgument = number | string;
 
 export class EntityQueueRequest extends Linkable {

--- a/src/engine/entity/EntityQueueRequest.ts
+++ b/src/engine/entity/EntityQueueRequest.ts
@@ -2,10 +2,6 @@ import ScriptFile from '#/engine/script/ScriptFile.js';
 import ScriptState from '#/engine/script/ScriptState.js';
 import Linkable from '#/util/Linkable.js';
 
-// export enum NpcQueueType {
-//     NORMAL
-// }
-
 export enum PlayerQueueType {
     NORMAL,
     LONG, // like normal with dev-controlled logout behavior

--- a/src/engine/entity/EntityTimer.ts
+++ b/src/engine/entity/EntityTimer.ts
@@ -1,4 +1,4 @@
-import { ScriptArgument } from '#/engine/entity/EntityQueueRequest.js';
+import { ScriptArgument } from '#/engine/entity/PlayerQueueRequest.js';
 import ScriptFile from '#/engine/script/ScriptFile.js';
 
 export enum NpcTimerType {

--- a/src/engine/entity/Npc.ts
+++ b/src/engine/entity/Npc.ts
@@ -343,7 +343,7 @@ export default class Npc extends PathingEntity {
     }
 
     processQueue() {
-        for (let request = this.queue.head(); request !== null; request = this.queue.next()) {
+        for (const request of this.queue.all()) {
             // purposely only decrements the delay when the npc is not delayed
             if (!this.delayed) {
                 request.delay--;
@@ -351,7 +351,6 @@ export default class Npc extends PathingEntity {
 
             if (!this.delayed && request.delay <= 0) {
                 request.unlink();
-                const save = this.queue.cursor; // LinkList-specific behavior so we can getqueue/clearqueue inside of this
                 const type: NpcType = NpcType.get(this.type);
                 const script = ScriptProvider.getByTrigger(request.queueId, type.id, type.category);
                 if (script) {
@@ -359,8 +358,6 @@ export default class Npc extends PathingEntity {
                     state.lastInt = request.lastInt;
                     this.executeScript(state);
                 }
-
-                this.queue.cursor = save;
             }
         }
     }

--- a/src/engine/entity/NpcQueueRequest.ts
+++ b/src/engine/entity/NpcQueueRequest.ts
@@ -1,4 +1,4 @@
-import { ScriptArgument } from '#/engine/entity/EntityQueueRequest.js';
+import { ScriptArgument } from '#/engine/entity/PlayerQueueRequest.js';
 import Linkable from '#/util/Linkable.js';
 
 export class NpcQueueRequest extends Linkable {

--- a/src/engine/entity/NpcQueueRequest.ts
+++ b/src/engine/entity/NpcQueueRequest.ts
@@ -1,0 +1,25 @@
+import { ScriptArgument } from '#/engine/entity/EntityQueueRequest.js';
+import Linkable from '#/util/Linkable.js';
+
+export class NpcQueueRequest extends Linkable {
+    queueId: number;
+
+    /**
+     * The arguments to execute the script with.
+     */
+    args: ScriptArgument[];
+
+    /**
+     * The number of ticks remaining until the queue executes.
+     */
+    delay: number;
+
+    lastInt: number = 0;
+
+    constructor(queueId: number, args: ScriptArgument[], delay: number) {
+        super();
+        this.queueId = queueId;
+        this.args = args;
+        this.delay = delay;
+    }
+}

--- a/src/engine/entity/Player.ts
+++ b/src/engine/entity/Player.ts
@@ -21,7 +21,6 @@ import BuildArea from '#/engine/entity/BuildArea.js';
 import CameraInfo from '#/engine/entity/CameraInfo.js';
 import Entity from '#/engine/entity/Entity.js';
 import EntityLifeCycle from '#/engine/entity/EntityLifeCycle.js';
-import { EntityQueueRequest, PlayerQueueType, QueueType, ScriptArgument } from '#/engine/entity/EntityQueueRequest.js';
 import { EntityTimer, PlayerTimerType } from '#/engine/entity/EntityTimer.js';
 import HeroPoints from '#/engine/entity/HeroPoints.js';
 import Loc from '#/engine/entity/Loc.js';
@@ -32,6 +31,7 @@ import { isClientConnected } from '#/engine/entity/NetworkPlayer.js';
 import Npc from '#/engine/entity/Npc.js';
 import Obj from '#/engine/entity/Obj.js';
 import PathingEntity from '#/engine/entity/PathingEntity.js';
+import { PlayerQueueRequest, PlayerQueueType, QueueType, ScriptArgument } from '#/engine/entity/PlayerQueueRequest.js';
 import { PlayerStat, PlayerStatEnabled, PlayerStatFree } from '#/engine/entity/PlayerStat.js';
 import InputTracking from '#/engine/entity/tracking/InputTracking.js';
 import { changeNpcCollision, changePlayerCollision, findNaivePath, reachedEntity, reachedLoc, reachedObj } from '#/engine/GameMap.js';
@@ -354,9 +354,9 @@ export default class Player extends PathingEntity {
     // ---
 
     // script variables
-    queue: LinkList<EntityQueueRequest> = new LinkList();
-    weakQueue: LinkList<EntityQueueRequest> = new LinkList();
-    engineQueue: LinkList<EntityQueueRequest> = new LinkList();
+    queue: LinkList<PlayerQueueRequest> = new LinkList();
+    weakQueue: LinkList<PlayerQueueRequest> = new LinkList();
+    engineQueue: LinkList<PlayerQueueRequest> = new LinkList();
     cameraPackets: LinkList<CameraInfo> = new LinkList();
     timers: Map<number, EntityTimer> = new Map();
     tabs: number[] = new Array(14).fill(-1);
@@ -781,7 +781,7 @@ export default class Player extends PathingEntity {
      * @param args
      */
     enqueueScript(script: ScriptFile, type: QueueType = PlayerQueueType.NORMAL, delay = 0, args: ScriptArgument[] = []) {
-        const request = new EntityQueueRequest(type, script, args, delay);
+        const request = new PlayerQueueRequest(type, script, args, delay);
         if (type === PlayerQueueType.ENGINE) {
             request.delay = 0;
             this.engineQueue.addTail(request);

--- a/src/engine/entity/PlayerQueueRequest.ts
+++ b/src/engine/entity/PlayerQueueRequest.ts
@@ -14,7 +14,7 @@ export enum PlayerQueueType {
 export type QueueType = PlayerQueueType;
 export type ScriptArgument = number | string;
 
-export class EntityQueueRequest extends Linkable {
+export class PlayerQueueRequest extends Linkable {
     /**
      * The type of queue request.
      */

--- a/src/engine/script/ScriptRunner.ts
+++ b/src/engine/script/ScriptRunner.ts
@@ -1,10 +1,9 @@
-
 import Entity from '#/engine/entity/Entity.js';
-import { ScriptArgument } from '#/engine/entity/EntityQueueRequest.js';
 import Loc from '#/engine/entity/Loc.js';
 import Npc from '#/engine/entity/Npc.js';
 import Obj from '#/engine/entity/Obj.js';
 import Player from '#/engine/entity/Player.js';
+import { ScriptArgument } from '#/engine/entity/PlayerQueueRequest.js';
 import CoreOps from '#/engine/script/handlers/CoreOps.js';
 import DbOps from '#/engine/script/handlers/DbOps.js';
 import DebugOps from '#/engine/script/handlers/DebugOps.js';

--- a/src/engine/script/ScriptState.ts
+++ b/src/engine/script/ScriptState.ts
@@ -1,10 +1,10 @@
 import DbTableType from '#/cache/config/DbTableType.js';
 import Entity from '#/engine/entity/Entity.js';
-import { ScriptArgument } from '#/engine/entity/EntityQueueRequest.js';
 import Loc from '#/engine/entity/Loc.js';
 import Npc from '#/engine/entity/Npc.js';
 import Obj from '#/engine/entity/Obj.js';
 import Player from '#/engine/entity/Player.js';
+import { ScriptArgument } from '#/engine/entity/PlayerQueueRequest.js';
 import ScriptFile from '#/engine/script/ScriptFile.js';
 import ScriptPointer from '#/engine/script/ScriptPointer.js';
 import ServerTriggerType from '#/engine/script/ServerTriggerType.js';

--- a/src/engine/script/handlers/NpcOps.ts
+++ b/src/engine/script/handlers/NpcOps.ts
@@ -16,7 +16,6 @@ import Obj from '#/engine/entity/Obj.js';
 import { NpcIterator } from '#/engine/script/ScriptIterators.js';
 import ScriptOpcode from '#/engine/script/ScriptOpcode.js';
 import ScriptPointer, { ActiveNpc, checkedHandler } from '#/engine/script/ScriptPointer.js';
-import ScriptProvider from '#/engine/script/ScriptProvider.js';
 import { CommandHandlers } from '#/engine/script/ScriptRunner.js';
 import ScriptState from '#/engine/script/ScriptState.js';
 import { check, CoordValid, DurationValid, HitTypeValid, HuntTypeValid, HuntVisValid, NpcModeValid, NpcStatValid, NpcTypeValid, NumberNotNull, ParamTypeValid, QueueValid, SpotAnimTypeValid } from '#/engine/script/ScriptValidators.js';
@@ -147,12 +146,12 @@ const NpcOps: CommandHandlers = {
         const arg = state.popInt();
         const queueId = check(state.popInt(), QueueValid);
 
-        const npcType: NpcType = check(state.activeNpc.type, NpcTypeValid);
-        const script = ScriptProvider.getByTrigger(ServerTriggerType.AI_QUEUE1 + queueId - 1, npcType.id, npcType.category);
+        // const npcType: NpcType = check(state.activeNpc.type, NpcTypeValid);
+        // const script = ScriptProvider.getByTrigger(ServerTriggerType.AI_QUEUE1 + queueId - 1, npcType.id, npcType.category);
 
-        if (script) {
-            state.activeNpc.enqueueScript(script, delay, arg);
-        }
+        // if (script) {
+        state.activeNpc.enqueueScript(ServerTriggerType.AI_QUEUE1 + queueId - 1, delay, arg);
+        // }
     }),
 
     [ScriptOpcode.NPC_RANGE]: checkedHandler(ActiveNpc, state => {

--- a/src/engine/script/handlers/NpcOps.ts
+++ b/src/engine/script/handlers/NpcOps.ts
@@ -146,12 +146,7 @@ const NpcOps: CommandHandlers = {
         const arg = state.popInt();
         const queueId = check(state.popInt(), QueueValid);
 
-        // const npcType: NpcType = check(state.activeNpc.type, NpcTypeValid);
-        // const script = ScriptProvider.getByTrigger(ServerTriggerType.AI_QUEUE1 + queueId - 1, npcType.id, npcType.category);
-
-        // if (script) {
         state.activeNpc.enqueueScript(ServerTriggerType.AI_QUEUE1 + queueId - 1, delay, arg);
-        // }
     }),
 
     [ScriptOpcode.NPC_RANGE]: checkedHandler(ActiveNpc, state => {

--- a/src/engine/script/handlers/PlayerOps.ts
+++ b/src/engine/script/handlers/PlayerOps.ts
@@ -6,11 +6,11 @@ import SpotanimType from '#/cache/config/SpotanimType.js';
 import VarPlayerType from '#/cache/config/VarPlayerType.js';
 import { CoordGrid } from '#/engine/CoordGrid.js';
 import CameraInfo from '#/engine/entity/CameraInfo.js';
-import { PlayerQueueType, ScriptArgument } from '#/engine/entity/EntityQueueRequest.js';
 import { PlayerTimerType } from '#/engine/entity/EntityTimer.js';
 import Interaction from '#/engine/entity/Interaction.js';
 import { isBufferFull } from '#/engine/entity/NetworkPlayer.js';
 import Player from '#/engine/entity/Player.js';
+import { PlayerQueueType, ScriptArgument } from '#/engine/entity/PlayerQueueRequest.js';
 import { PlayerStat } from '#/engine/entity/PlayerStat.js';
 import { findPath } from '#/engine/GameMap.js';
 import ScriptOpcode from '#/engine/script/ScriptOpcode.js';
@@ -493,7 +493,7 @@ const PlayerOps: CommandHandlers = {
         const base = player.baseLevels[stat];
         const current = player.levels[stat];
 
-        const boost = ((constant + (base * percent) / 100) | 0);
+        const boost = (constant + (base * percent) / 100) | 0;
         const boosted = Math.min(current + boost, base + boost);
         player.levels[stat] = Math.min(boosted, 255);
         if (stat === PlayerStat.HITPOINTS && player.levels[PlayerStat.HITPOINTS] >= player.baseLevels[PlayerStat.HITPOINTS]) {


### PR DESCRIPTION
The script lookup was happening when we queue the script, but this means if the npc does a `npc_changetype` it would run the script from the old Npc type

Now, we look up the script when the queue executes, and so the current Npc type will be reflected