### PR TITLE
fix(engine): Npc events (respawn, despawn, changetype) are now scheduled better

### DIFF
--- a/src/engine/World.ts
+++ b/src/engine/World.ts
@@ -700,7 +700,6 @@ class World {
                                 this.npcEventQueue.addTail(new NpcEventRequest(NpcEventType.DESPAWN, script, npc));
                             }
                         }
-                        npc.setLifeCycle(-1);
                     } catch (err) {
                         // there was an error adding or removing them, try again next tick...
                         // ex: server is full on npc IDs (did we have a leak somewhere?) and we don't want to re-use the last ID (syncing related)
@@ -712,6 +711,7 @@ class World {
 
                         printError(`[World] NPC type:${npc.type} lifecycle:${npc.lifecycle} ID:${npc.nid}`);
                         console.error(err);
+                        npc.setLifeCycle(1);
                     }
                 }
 

--- a/src/engine/World.ts
+++ b/src/engine/World.ts
@@ -680,7 +680,7 @@ class World {
                 }
 
                 // - Npc Events (Respawn, Revert, Despawn)
-                if (npc.lifecycleTick > -1 && npc.lifecycleTick <= this.currentTick) {
+                if (--npc.lifecycleTick === 0) {
                     try {
                         // Respawn NPC
                         if (npc.lifecycle === EntityLifeCycle.RESPAWN && !npc.isActive) {
@@ -712,8 +712,6 @@ class World {
 
                         printError(`[World] NPC type:${npc.type} lifecycle:${npc.lifecycle} ID:${npc.nid}`);
                         console.error(err);
-
-                        npc.setLifeCycle(this.currentTick + 1); // retry next tick
                     }
                 }
 
@@ -1349,7 +1347,7 @@ class World {
         }
 
         if (duration > -1) {
-            npc.setLifeCycle(this.currentTick + duration);
+            npc.setLifeCycle(duration);
         }
     }
 
@@ -1374,7 +1372,7 @@ class World {
             this.npcs.remove(npc.nid);
             npc.cleanup();
         } else if (npc.lifecycle === EntityLifeCycle.RESPAWN && duration > -1) {
-            npc.setLifeCycle(this.currentTick + adjustedDuration);
+            npc.setLifeCycle(adjustedDuration);
         }
     }
 

--- a/src/engine/entity/Npc.ts
+++ b/src/engine/entity/Npc.ts
@@ -1023,10 +1023,10 @@ export default class Npc extends PathingEntity {
         this.uid = (type << 16) | this.nid;
         this.resetOnRevert = reset;
 
-        if (type === this.baseType) {
+        if (type === this.baseType && this.lifecycle === EntityLifeCycle.RESPAWN) {
             this.setLifeCycle(-1);
         } else {
-            this.setLifeCycle(World.currentTick + duration);
+            this.setLifeCycle(duration);
         }
     }
 


### PR DESCRIPTION
Npc events now decrement and compare to 0 rather than scheduling for a tick

This is extremely minor, but it causes slight behavioral difference when an Npc is `npc_delay()`'d, because this causes the counter to not decrement 