### PR TITLE
fix(content): adjust firemaking tiles in fishing guild bank

### DIFF
--- a/data/src/scripts/skill_firemaking/configs/bank_zones.dbrow
+++ b/data/src/scripts/skill_firemaking/configs/bank_zones.dbrow
@@ -50,8 +50,7 @@ data=coord_pair,0_39_73_33_39,0_39_73_50_51
 // shantay pass bank
 data=coord_pair,0_51_48_44_47,0_51_48_45_49
 // fishing guild bank
-data=coord_pair,0_40_53_28_21,0_40_53_32_27
-data=coord_pair,0_40_53_23_26,0_40_53_29_30
+data=coord_pair,0_40_53_26_26,0_40_53_27_30
 // zanaris
 data=coord_pair,0_49_149_12_37,0_49_149_19_46
 // duel arena bank


### PR DESCRIPTION
from [video](https://youtu.be/NjOBkLNp5p0?si=YpO-Cfmrgi4ktvJh&t=89):

![VS--YouTube-OldRunescape2005screenshotsFromFebruarytoMarch2005-1’29”](https://github.com/user-attachments/assets/9b761f0c-26d3-41c8-b9c7-3adc2e79bf3f)
