### PR TITLE
fix(content): no longer delete pets when finishing a duel

### DIFF
--- a/data/src/scripts/minigames/game_duelarena/scripts/duel_arena_finish.rs2
+++ b/data/src/scripts/minigames/game_duelarena/scripts/duel_arena_finish.rs2
@@ -67,7 +67,6 @@ while ($i < inv_size(tempinv)) {
 
 buildappearance(worn);
 ~prayer_deactivate_all;
-~follower_death;
 p_telejump(~duel_arena_finish_coord(coord));
 anim(null, 0);
 p_stopaction;


### PR DESCRIPTION
![VS--YouTube-duelarena-2’29”](https://github.com/user-attachments/assets/c602b2b1-40c1-4b9f-babf-1f08de0327e9)

Plenty of vids and screenshots of people brining pets into duels