### PR TITLE
fix(engine): Loc and Obj events are now handled in the correct order (fixed the gnome stronghold door)

### DIFF
--- a/data/src/scripts/areas/area_gnome/scripts/gnome_gate.rs2
+++ b/data/src/scripts/areas/area_gnome/scripts/gnome_gate.rs2
@@ -35,10 +35,11 @@ if(coordz(coord) > coordz($loc_coord) & coord ! $north_entrance) {
 p_delay(0);
 // replace gate
 // Temp note: dur updated
-loc_change(loc_191, 5);
+loc_del(5);
 loc_add(movecoord($loc_coord, 3, 0, 0), loc_192, 0, loc_shape, 5); // opened right side
 loc_add(movecoord($loc_coord, 2, 0, 0), loc_83, 3, loc_shape, 5); // blocks whole path
-loc_add(movecoord($loc_coord, 2, 0, 1), loc_83, 1, loc_shape, 5);
+loc_add(movecoord($loc_coord, 2, 0, 1), loc_83, 2, loc_shape, 5);
+loc_add($loc_coord, loc_191, 2, loc_shape, 5);
 p_delay(0);
 // walk to dest
 if(coordz(coord) > coordz($loc_coord)) {

--- a/data/src/scripts/areas/area_gnome/scripts/gnome_gate.rs2
+++ b/data/src/scripts/areas/area_gnome/scripts/gnome_gate.rs2
@@ -38,7 +38,7 @@ p_delay(0);
 loc_del(5);
 loc_add(movecoord($loc_coord, 3, 0, 0), loc_192, 0, loc_shape, 5); // opened right side
 loc_add(movecoord($loc_coord, 2, 0, 0), loc_83, 3, loc_shape, 5); // blocks whole path
-loc_add(movecoord($loc_coord, 2, 0, 1), loc_83, 2, loc_shape, 5);
+loc_add(movecoord($loc_coord, 2, 0, 1), loc_83, 1, loc_shape, 5);
 loc_add($loc_coord, loc_191, 2, loc_shape, 5);
 p_delay(0);
 // walk to dest

--- a/src/engine/World.ts
+++ b/src/engine/World.ts
@@ -1550,16 +1550,8 @@ class World {
     }
 
     revealObj(obj: Obj): void {
-        // printDebug(`[World] revealObj => name: ${ObjType.get(obj.type).name}`);
-        // const duration: number = obj.reveal;
-        // const change: number = obj.lastChange;
         const zone: Zone = this.gameMap.getZone(obj.x, obj.z, obj.level);
         zone.revealObj(obj);
-        // objs next life cycle always starts from the last time they changed + the inputted duration.
-        // accounting for reveal time here.
-        // const nextLifecycle: number = (change !== -1 ? Obj.REVEAL - (this.currentTick - change) : 0) + this.currentTick + duration;
-        // obj.setLifeCycle(nextLifecycle);
-        // this.trackZone(nextLifecycle, zone);
         this.trackZone(zone);
     }
 

--- a/src/engine/World.ts
+++ b/src/engine/World.ts
@@ -1434,10 +1434,13 @@ class World {
         if (loc.lifecycle === EntityLifeCycle.DESPAWN && !loc.isValid()) {
             return;
         }
-        // Remove previous collision from game world
-        const fromType: LocType = LocType.get(loc.type);
-        if (fromType.blockwalk) {
-            changeLocCollision(loc.shape, loc.angle, fromType.blockrange, fromType.length, fromType.width, fromType.active, loc.x, loc.z, loc.level, false);
+
+        // Remove previous collision from game world if loc is active
+        if (loc.isActive) {
+            const fromType: LocType = LocType.get(loc.type);
+            if (fromType.blockwalk) {
+                changeLocCollision(loc.shape, loc.angle, fromType.blockrange, fromType.length, fromType.width, fromType.active, loc.x, loc.z, loc.level, false);
+            }
         }
 
         // Update loc to new type

--- a/src/engine/World.ts
+++ b/src/engine/World.ts
@@ -1035,8 +1035,6 @@ class World {
             for (const zone of this.zonesTracking) {
                 zone.computeShared();
             }
-
-            this.zonesTracking.clear();
         } catch (err) {
             if (err instanceof Error) {
                 printError(`Error during processZones: ${err.message}`);
@@ -1191,8 +1189,8 @@ class World {
         const tick: number = this.currentTick;
 
         // - reset zones
-        // this.zonesTracking.get(tick)?.forEach(zone => zone.reset());
-        // this.zonesTracking.delete(tick);
+        this.zonesTracking.forEach(zone => zone.reset());
+        this.zonesTracking.clear();
 
         // - reset players
         for (const player of this.players) {

--- a/src/engine/World.ts
+++ b/src/engine/World.ts
@@ -1515,6 +1515,7 @@ class World {
     }
 
     addObj(obj: Obj, receiver64: bigint, duration: number): void {
+        // Dev note: This function is slightly messy. Perhaps this can be organized better
         // Check if we need to changeobj first
         if (ObjType.get(obj.type).stackable && obj.lifecycle === EntityLifeCycle.DESPAWN) {
             const existing = this.getObjOfReceiver(obj.x, obj.z, obj.level, obj.type, receiver64);
@@ -1545,7 +1546,11 @@ class World {
         // If the obj is dropped to all
         else {
             obj.reveal = -1;
-            this.trackLocObj(obj, duration);
+            if (duration > 0) {
+                this.trackLocObj(obj, duration);
+            } else {
+                obj.untrack();
+            }
         }
     }
 
@@ -1568,7 +1573,11 @@ class World {
         const adjustedDuration = this.scaleByPlayerCount(duration);
         zone.removeObj(obj);
         this.trackZone(zone);
-        this.trackLocObj(obj, adjustedDuration);
+        if (duration > 0) {
+            this.trackLocObj(obj, adjustedDuration);
+        } else {
+            obj.untrack();
+        }
     }
 
     animMap(level: number, x: number, z: number, spotanim: number, height: number, delay: number): void {

--- a/src/engine/World.ts
+++ b/src/engine/World.ts
@@ -1021,17 +1021,18 @@ class World {
     private processZones(): void {
         const start: number = Date.now();
         try {
-            // - loc/obj despawn/respawn
-            // - compute shared buffer
             for (const event of this.locObjTracker.all()) {
                 // Check if the event is still valid
                 if (event.check()) {
                     event.entity.turn();
-                } else {
-                    event.unlink();
+                }
+                // If this is false, we have not constructed our LinkedList properly somewhere
+                else {
+                    console.error('Loc Obj event is invalid');
                 }
             }
 
+            // Compute shared for tracked zones
             for (const zone of this.zonesTracking) {
                 zone.computeShared();
             }

--- a/src/engine/World.ts
+++ b/src/engine/World.ts
@@ -1516,7 +1516,6 @@ class World {
 
     addObj(obj: Obj, receiver64: bigint, duration: number): void {
         // Check if we need to changeobj first
-        const zone: Zone = this.gameMap.getZone(obj.x, obj.z, obj.level);
         if (ObjType.get(obj.type).stackable && obj.lifecycle === EntityLifeCycle.DESPAWN) {
             const existing = this.getObjOfReceiver(obj.x, obj.z, obj.level, obj.type, receiver64);
             if (existing && existing.lifecycle === EntityLifeCycle.DESPAWN) {
@@ -1524,12 +1523,13 @@ class World {
                 if (nextCount <= Inventory.STACK_LIMIT) {
                     // If an obj of the same type exists and is stackable and have the same receiver, then we merge them.
                     this.changeObj(existing, nextCount);
-                    this.trackZone(zone);
                     this.trackLocObj(existing, duration + Obj.REVEAL);
                     return;
                 }
             }
         }
+
+        const zone: Zone = this.gameMap.getZone(obj.x, obj.z, obj.level);
         zone.addObj(obj, receiver64);
         this.trackZone(zone);
         // If the obj is dropped to a specific person

--- a/src/engine/World.ts
+++ b/src/engine/World.ts
@@ -42,6 +42,7 @@ import { PlayerTimerType } from '#/engine/entity/EntityTimer.js';
 import HuntModeType from '#/engine/entity/hunt/HuntModeType.js';
 import HuntNobodyNear from '#/engine/entity/hunt/HuntNobodyNear.js';
 import Loc from '#/engine/entity/Loc.js';
+import LocObjEvent from '#/engine/entity/LocObjEvent.js';
 import { isClientConnected, NetworkPlayer } from '#/engine/entity/NetworkPlayer.js';
 import Npc from '#/engine/entity/Npc.js';
 import { NpcEventRequest, NpcEventType } from '#/engine/entity/NpcEventRequest.js';
@@ -137,7 +138,8 @@ class World {
     readonly npcs: NpcList;
 
     // zones
-    readonly zonesTracking: Map<number, Set<Zone>>;
+    readonly zonesTracking: Set<Zone>;
+    readonly locObjTracker: LinkList<LocObjEvent>;
     readonly queue: LinkList<EntityQueueState>;
     readonly npcEventQueue: LinkList<NpcEventRequest>;
 
@@ -162,7 +164,8 @@ class World {
         this.newPlayers = new Set();
         this.players = new PlayerList(World.PLAYERS);
         this.npcs = new NpcList(World.NPCS);
-        this.zonesTracking = new Map();
+        this.zonesTracking = new Set();
+        this.locObjTracker = new LinkList();
         this.queue = new LinkList();
         this.npcEventQueue = new LinkList();
         this.lastCycleStats = new Array(12).fill(0);
@@ -1017,11 +1020,23 @@ class World {
     // - compute shared buffer
     private processZones(): void {
         const start: number = Date.now();
-        const tick: number = this.currentTick;
         try {
             // - loc/obj despawn/respawn
             // - compute shared buffer
-            this.zonesTracking.get(tick)?.forEach(zone => zone.tick(tick));
+            for (const event of this.locObjTracker.all()) {
+                // Check if the event is still valid
+                if (event.check()) {
+                    event.entity.turn();
+                } else {
+                    event.unlink();
+                }
+            }
+
+            for (const zone of this.zonesTracking) {
+                zone.computeShared();
+            }
+
+            this.zonesTracking.clear();
         } catch (err) {
             if (err instanceof Error) {
                 printError(`Error during processZones: ${err.message}`);
@@ -1176,8 +1191,8 @@ class World {
         const tick: number = this.currentTick;
 
         // - reset zones
-        this.zonesTracking.get(tick)?.forEach(zone => zone.reset());
-        this.zonesTracking.delete(tick);
+        // this.zonesTracking.get(tick)?.forEach(zone => zone.reset());
+        // this.zonesTracking.delete(tick);
 
         // - reset players
         for (const player of this.players) {
@@ -1390,21 +1405,13 @@ class World {
         return this.gameMap.getZone(x, z, level).getObjOfReceiver(x, z, objId, receiver64);
     }
 
-    trackZone(tick: number, zone: Zone): void {
-        const tracking: Map<number, Set<Zone>> = this.zonesTracking;
-        const zones: Set<Zone> = (tracking.get(tick) ?? new Set()).add(zone);
-        if (!tracking.has(tick)) {
-            tracking.set(tick, zones);
-        }
+    trackZone(zone: Zone): void {
+        this.zonesTracking.add(zone);
     }
 
-    trackLocObj(entity: Loc | Obj, zone: Zone, duration: number): void {
-        // In OSRS I suspect they use a counter per Loc/Obj to keep track of events rather than scheduling for a tick
-        // In 2004scape, we schedule for a tick. Scheduling for a tick ends up naturally 1 tick slower, so we do a -1 to compensate to match OSRS behavior
-        // - Bea5
-        entity.setLifeCycle(this.currentTick + duration - 1);
-        this.trackZone(this.currentTick + duration - 1, zone);
-        this.trackZone(this.currentTick, zone);
+    trackLocObj(entity: Loc | Obj, duration: number): void {
+        entity.setLifeCycle(duration);
+        this.locObjTracker.addTail(new LocObjEvent(entity));
     }
 
     addLoc(loc: Loc, duration: number): void {
@@ -1416,7 +1423,12 @@ class World {
 
         const zone: Zone = this.gameMap.getZone(loc.x, loc.z, loc.level);
         zone.addLoc(loc);
-        this.trackLocObj(loc, zone, duration);
+        this.trackZone(zone);
+        if (duration > 0) {
+            this.trackLocObj(loc, duration);
+        } else {
+            loc.untrack();
+        }
     }
 
     changeLoc(loc: Loc, typeID: number, shape: number, angle: number, duration: number) {
@@ -1442,21 +1454,22 @@ class World {
         // Notify zone that loc has been changed
         const zone: Zone = this.gameMap.getZone(loc.x, loc.z, loc.level);
         zone.changeLoc(loc);
-        this.trackLocObj(loc, zone, duration);
+        this.trackZone(zone);
+        this.trackLocObj(loc, duration);
     }
 
     mergeLoc(loc: Loc, player: Player, startCycle: number, endCycle: number, south: number, east: number, north: number, west: number): void {
         // printDebug(`[World] mergeLoc => name: ${LocType.get(loc.type).name}`);
         const zone: Zone = this.gameMap.getZone(loc.x, loc.z, loc.level);
         zone.mergeLoc(loc, player, startCycle, endCycle, south, east, north, west);
-        this.trackZone(this.currentTick, zone);
+        this.trackZone(zone);
     }
 
     animLoc(loc: Loc, seq: number): void {
         // printDebug(`[World] animLoc => name: ${LocType.get(loc.type).name}, seq: ${seq}`);
         const zone: Zone = this.gameMap.getZone(loc.x, loc.z, loc.level);
         zone.animLoc(loc, seq);
-        this.trackZone(this.currentTick, zone);
+        this.trackZone(zone);
     }
 
     removeLoc(loc: Loc, duration: number): void {
@@ -1468,7 +1481,12 @@ class World {
 
         const zone: Zone = this.gameMap.getZone(loc.x, loc.z, loc.level);
         zone.removeLoc(loc);
-        this.trackLocObj(loc, zone, duration);
+        this.trackZone(zone);
+        if (duration > 0) {
+            this.trackLocObj(loc, duration);
+        } else {
+            loc.untrack();
+        }
     }
 
     revertLoc(loc: Loc) {
@@ -1490,55 +1508,64 @@ class World {
         // Notify zone that loc has been changed
         const zone: Zone = this.gameMap.getZone(loc.x, loc.z, loc.level);
         zone.changeLoc(loc);
-        this.trackZone(this.currentTick, zone);
+        loc.untrack();
+        this.trackZone(zone);
     }
 
     addObj(obj: Obj, receiver64: bigint, duration: number): void {
-        // printDebug(`[World] addObj => name: ${ObjType.get(obj.type).name}, receiverId: ${receiverId}, duration: ${duration}`);
-        // check if we need to changeobj first.
+        // Check if we need to changeobj first
+        const zone: Zone = this.gameMap.getZone(obj.x, obj.z, obj.level);
         if (ObjType.get(obj.type).stackable && obj.lifecycle === EntityLifeCycle.DESPAWN) {
             const existing = this.getObjOfReceiver(obj.x, obj.z, obj.level, obj.type, receiver64);
             if (existing && existing.lifecycle === EntityLifeCycle.DESPAWN) {
                 const nextCount = obj.count + existing.count;
                 if (nextCount <= Inventory.STACK_LIMIT) {
-                    // if an obj of the same type exists and is stackable and have the same receiver, then we merge them.
-                    this.changeObj(existing, receiver64, nextCount);
+                    // If an obj of the same type exists and is stackable and have the same receiver, then we merge them.
+                    this.changeObj(existing, nextCount);
+                    this.trackZone(zone);
+                    this.trackLocObj(existing, duration + Obj.REVEAL);
                     return;
                 }
             }
         }
-        const zone: Zone = this.gameMap.getZone(obj.x, obj.z, obj.level);
         zone.addObj(obj, receiver64);
+        this.trackZone(zone);
+        // If the obj is dropped to a specific person
         if (receiver64 !== Obj.NO_RECEIVER) {
             // objs with a receiver always attempt to reveal 100 ticks after being dropped.
             // items that can't be revealed (untradable, members obj in f2p) will be skipped in revealObj
-            this.trackLocObj(obj, zone, Obj.REVEAL);
+            this.trackLocObj(obj, duration + Obj.REVEAL);
             obj.receiver64 = receiver64;
-            obj.reveal = duration;
-        } else {
-            this.trackLocObj(obj, zone, duration);
+
+            // Reveal Obj in 100 ticks
+            obj.reveal = Obj.REVEAL;
+        }
+        // If the obj is dropped to all
+        else {
+            obj.reveal = -1;
+            this.trackLocObj(obj, duration);
         }
     }
 
     revealObj(obj: Obj): void {
         // printDebug(`[World] revealObj => name: ${ObjType.get(obj.type).name}`);
-        const duration: number = obj.reveal;
-        const change: number = obj.lastChange;
+        // const duration: number = obj.reveal;
+        // const change: number = obj.lastChange;
         const zone: Zone = this.gameMap.getZone(obj.x, obj.z, obj.level);
-        zone.revealObj(obj, obj.receiver64);
+        zone.revealObj(obj);
         // objs next life cycle always starts from the last time they changed + the inputted duration.
         // accounting for reveal time here.
-        const nextLifecycle: number = (change !== -1 ? Obj.REVEAL - (this.currentTick - change) : 0) + this.currentTick + duration;
-        obj.setLifeCycle(nextLifecycle);
-        this.trackZone(nextLifecycle, zone);
-        this.trackZone(this.currentTick, zone);
+        // const nextLifecycle: number = (change !== -1 ? Obj.REVEAL - (this.currentTick - change) : 0) + this.currentTick + duration;
+        // obj.setLifeCycle(nextLifecycle);
+        // this.trackZone(nextLifecycle, zone);
+        this.trackZone(zone);
     }
 
-    changeObj(obj: Obj, receiver64: bigint, newCount: number): void {
+    changeObj(obj: Obj, newCount: number): void {
         // printDebug(`[World] changeObj => name: ${ObjType.get(obj.type).name}, receiverId: ${receiverId}, newCount: ${newCount}`);
         const zone: Zone = this.gameMap.getZone(obj.x, obj.z, obj.level);
-        zone.changeObj(obj, receiver64, obj.count, newCount);
-        this.trackZone(this.currentTick, zone);
+        zone.changeObj(obj, obj.count, newCount);
+        this.trackZone(zone);
     }
 
     removeObj(obj: Obj, duration: number): void {
@@ -1546,19 +1573,20 @@ class World {
         const zone: Zone = this.gameMap.getZone(obj.x, obj.z, obj.level);
         const adjustedDuration = this.scaleByPlayerCount(duration);
         zone.removeObj(obj);
-        this.trackLocObj(obj, zone, adjustedDuration);
+        this.trackZone(zone);
+        this.trackLocObj(obj, adjustedDuration);
     }
 
     animMap(level: number, x: number, z: number, spotanim: number, height: number, delay: number): void {
         const zone: Zone = this.gameMap.getZone(x, z, level);
         zone.animMap(x, z, spotanim, height, delay);
-        this.trackZone(this.currentTick, zone);
+        this.trackZone(zone);
     }
 
     mapProjAnim(level: number, x: number, z: number, dstX: number, dstZ: number, target: number, spotanim: number, srcHeight: number, dstHeight: number, startDelay: number, endDelay: number, peak: number, arc: number): void {
         const zone: Zone = this.gameMap.getZone(x, z, level);
         zone.mapProjAnim(x, z, dstX, dstZ, target, spotanim, srcHeight, dstHeight, startDelay, endDelay, peak, arc);
-        this.trackZone(this.currentTick, zone);
+        this.trackZone(zone);
     }
 
     // ----

--- a/src/engine/entity/Loc.ts
+++ b/src/engine/entity/Loc.ts
@@ -50,7 +50,9 @@ export default class Loc extends NonPathingEntity {
     }
 
     turn() {
-        if (--this.lifecycleTick === 0) {
+        // Decrement lifecycle tick
+        --this.lifecycleTick;
+        if (this.lifecycleTick === 0) {
             if (this.lifecycle === EntityLifeCycle.DESPAWN) {
                 World.removeLoc(this, 0);
             } else if (this.lifecycle === EntityLifeCycle.RESPAWN && this.isChanged()) {
@@ -61,6 +63,10 @@ export default class Loc extends NonPathingEntity {
                 // Fail safe in case no conditions are met (should never happen)
                 this.untrack();
             }
+        } else if (this.lifecycleTick < 0) {
+            // Fail safe in case this is tracked but isn't supposed to be
+            this.untrack();
+            console.error('Loc is tracked but has a negative lifecycle tick');
         }
     }
 }

--- a/src/engine/entity/Loc.ts
+++ b/src/engine/entity/Loc.ts
@@ -57,6 +57,9 @@ export default class Loc extends NonPathingEntity {
                 World.revertLoc(this);
             } else if (this.lifecycle === EntityLifeCycle.RESPAWN && !this.isActive) {
                 World.addLoc(this, 0);
+            } else {
+                // Fail safe in case no conditions are met (should never happen)
+                this.untrack();
             }
         }
     }

--- a/src/engine/entity/Loc.ts
+++ b/src/engine/entity/Loc.ts
@@ -2,6 +2,7 @@ import { locShapeLayer } from '@2004scape/rsmod-pathfinder';
 
 import EntityLifeCycle from '#/engine/entity/EntityLifeCycle.js';
 import NonPathingEntity from '#/engine/entity/NonPathingEntity.js';
+import World from '#/engine/World.js';
 
 export default class Loc extends NonPathingEntity {
     // constructor properties
@@ -46,5 +47,17 @@ export default class Loc extends NonPathingEntity {
 
     revert() {
         this.currentInfo = this.baseInfo;
+    }
+
+    turn() {
+        if (--this.lifecycleTick === 0) {
+            if (this.lifecycle === EntityLifeCycle.DESPAWN) {
+                World.removeLoc(this, 0);
+            } else if (this.lifecycle === EntityLifeCycle.RESPAWN && this.isChanged()) {
+                World.revertLoc(this);
+            } else if (this.lifecycle === EntityLifeCycle.RESPAWN && !this.isActive) {
+                World.addLoc(this, 0);
+            }
+        }
     }
 }

--- a/src/engine/entity/LocObjEvent.ts
+++ b/src/engine/entity/LocObjEvent.ts
@@ -1,0 +1,17 @@
+import Linkable from '#/util/Linkable.js';
+
+import NonPathingEntity from './NonPathingEntity.js';
+
+export default class LocObjEvent extends Linkable {
+    entity: NonPathingEntity;
+
+    constructor(entity: NonPathingEntity) {
+        super();
+        this.entity = entity;
+        entity.eventTracker = this;
+    }
+
+    check(): boolean {
+        return this === this.entity.eventTracker;
+    }
+}

--- a/src/engine/entity/LocObjEvent.ts
+++ b/src/engine/entity/LocObjEvent.ts
@@ -8,7 +8,7 @@ export default class LocObjEvent extends Linkable {
     constructor(entity: NonPathingEntity) {
         super();
         this.entity = entity;
-        entity.eventTracker = this;
+        entity.track(this);
     }
 
     check(): boolean {

--- a/src/engine/entity/NonPathingEntity.ts
+++ b/src/engine/entity/NonPathingEntity.ts
@@ -1,5 +1,18 @@
 import Entity from '#/engine/entity/Entity.js';
+
+import LocObjEvent from './LocObjEvent.js';
 export default abstract class NonPathingEntity extends Entity {
+    eventTracker: LocObjEvent | null = null;
+
+    abstract turn(): void;
+
+    untrack() {
+        if (this.eventTracker) {
+            this.eventTracker.unlink();
+            this.eventTracker = null;
+        }
+    }
+
     resetEntity(_respawn: boolean) {
         // nothing happens here
     }

--- a/src/engine/entity/NonPathingEntity.ts
+++ b/src/engine/entity/NonPathingEntity.ts
@@ -13,6 +13,11 @@ export default abstract class NonPathingEntity extends Entity {
         }
     }
 
+    track(event: LocObjEvent) {
+        this.untrack();
+        this.eventTracker = event;
+    }
+
     resetEntity(_respawn: boolean) {
         // nothing happens here
     }

--- a/src/engine/entity/Obj.ts
+++ b/src/engine/entity/Obj.ts
@@ -1,5 +1,6 @@
 import EntityLifeCycle from '#/engine/entity/EntityLifeCycle.js';
 import NonPathingEntity from '#/engine/entity/NonPathingEntity.js';
+import World from '#/engine/World.js';
 
 export default class Obj extends NonPathingEntity {
     /**
@@ -14,7 +15,6 @@ export default class Obj extends NonPathingEntity {
 
     // runtime
     receiver64: bigint = Obj.NO_RECEIVER;
-    isRevealed: boolean = false;
     reveal: number = -1;
     lastChange: number = -1;
 
@@ -24,8 +24,21 @@ export default class Obj extends NonPathingEntity {
         this.count = count;
     }
 
+    turn() {
+        if (this.reveal > -1 && --this.reveal === 0) {
+            World.revealObj(this);
+        }
+        if (--this.lifecycleTick === 0) {
+            if (this.lifecycle === EntityLifeCycle.DESPAWN) {
+                World.removeObj(this, 0);
+            } else if (this.lifecycle === EntityLifeCycle.RESPAWN) {
+                World.addObj(this, Obj.NO_RECEIVER, 0);
+            }
+        }
+    }
+
     isValid(hash64?: bigint): boolean {
-        if (!this.isRevealed && hash64 && hash64 !== this.receiver64) {
+        if (this.reveal > -1 && hash64 && hash64 !== this.receiver64) {
             return false;
         }
 

--- a/src/engine/entity/Obj.ts
+++ b/src/engine/entity/Obj.ts
@@ -28,7 +28,11 @@ export default class Obj extends NonPathingEntity {
         if (this.reveal > -1 && --this.reveal === 0) {
             World.revealObj(this);
         }
-        if (--this.lifecycleTick === 0) {
+
+        // Decrement lifecycle tick
+        --this.lifecycleTick;
+
+        if (this.lifecycleTick === 0) {
             if (this.lifecycle === EntityLifeCycle.DESPAWN) {
                 World.removeObj(this, 0);
             } else if (this.lifecycle === EntityLifeCycle.RESPAWN) {
@@ -37,6 +41,10 @@ export default class Obj extends NonPathingEntity {
                 // Fail safe in case no conditions are met (should never happen)
                 this.untrack();
             }
+        } else if (this.lifecycleTick < 0) {
+            // Fail safe in case this is tracked but isn't supposed to be
+            this.untrack();
+            console.error('Obj is tracked but has a negative lifecycle tick');
         }
     }
 

--- a/src/engine/entity/Obj.ts
+++ b/src/engine/entity/Obj.ts
@@ -33,8 +33,10 @@ export default class Obj extends NonPathingEntity {
                 World.removeObj(this, 0);
             } else if (this.lifecycle === EntityLifeCycle.RESPAWN) {
                 World.addObj(this, Obj.NO_RECEIVER, 0);
+            } else {
+                // Fail safe in case no conditions are met (should never happen)
+                this.untrack();
             }
-            this.untrack();
         }
     }
 

--- a/src/engine/entity/Obj.ts
+++ b/src/engine/entity/Obj.ts
@@ -34,6 +34,7 @@ export default class Obj extends NonPathingEntity {
             } else if (this.lifecycle === EntityLifeCycle.RESPAWN) {
                 World.addObj(this, Obj.NO_RECEIVER, 0);
             }
+            this.untrack();
         }
     }
 

--- a/src/engine/zone/Zone.ts
+++ b/src/engine/zone/Zone.ts
@@ -137,13 +137,7 @@ export default class Zone {
             if (typeof encoder === 'undefined') {
                 continue;
             }
-            try {
-                encoder.enclose(buf, event.message);
-            } catch (e) {
-                // e;
-                console.error(e, this.x, this.z);
-                // console.log(event.message);
-            }
+            encoder.enclose(buf, event.message);
         }
 
         if (buf.pos === 0) {

--- a/src/engine/zone/Zone.ts
+++ b/src/engine/zone/Zone.ts
@@ -97,38 +97,6 @@ export default class Zone {
         }
     }
 
-    tick(tick: number): void {
-        for (const obj of this.getAllObjsUnsafe()) {
-            if (!obj.updateLifeCycle(tick) || obj.lastLifecycleTick === tick) {
-                continue;
-            }
-            if (obj.lifecycle === EntityLifeCycle.DESPAWN) {
-                if (obj.reveal !== -1) {
-                    World.revealObj(obj);
-                } else {
-                    World.removeObj(obj, 0);
-                }
-            } else if (obj.lifecycle === EntityLifeCycle.RESPAWN) {
-                World.addObj(obj, Obj.NO_RECEIVER, 0);
-            }
-        }
-
-        for (const loc of this.getAllLocsUnsafe()) {
-            if (!loc.updateLifeCycle(tick) || loc.lastLifecycleTick === tick) {
-                continue;
-            }
-            if (loc.lifecycle === EntityLifeCycle.DESPAWN) {
-                World.removeLoc(loc, 0);
-            } else if (loc.lifecycle === EntityLifeCycle.RESPAWN && loc.isChanged()) {
-                World.revertLoc(loc);
-            } else if (loc.lifecycle === EntityLifeCycle.RESPAWN && !loc.isActive) {
-                World.addLoc(loc, 0);
-            }
-        }
-
-        this.computeShared();
-    }
-
     computeShared(): void {
         const buf: Packet = Packet.alloc(1);
         for (const event of this.enclosed()) {


### PR DESCRIPTION
We need Loc and Obj events (specifically Loc) to be processed in the order they are initialized. Previously, they would process in the order that they exist within the Zone's LinkedList. This would give incorrect behavior when multiple events need to happen on the same tick. Specifically, gnome stronghold door was behaving erratically

Now the events are stored in a nice event queue LinkedList stored on World. This makes Loc and Obj events match RSProx output and osrs behavior. It also gets rid of the jank `duration -1` that existed inside of `trackLocObj`