### PR TITLE
fix(content): Fixing lava eel fishing for loc

### DIFF
--- a/data/src/scripts/skill_fishing/scripts/fishing_spots/lavafish_loc.rs2
+++ b/data/src/scripts/skill_fishing/scripts/fishing_spots/lavafish_loc.rs2
@@ -67,3 +67,4 @@ if (%action_delay < map_clock) {
 } else if (%action_delay = map_clock) {
     ~fish_roll_loc(raw_lava_eel, null, fishing_bait);
 }
+p_oploc(3);


### PR DESCRIPTION
There was no increment on the action delay while fishing for lava eels from the loc object, so it would perpetually try to fish but never catch anything in the spawns in the lava maze.