### PR TITLE
feat(content): %mcannon_stage varp and cannon timer arg

### DIFF
--- a/data/src/pack/varp.pack
+++ b/data/src/pack/varp.pack
@@ -1,6 +1,6 @@
 0=mcannon_progress
 1=mcannon_railings
-2=mcannon_clock
+2=mcannon_stage
 3=mcannon_ammo
 4=mcannon_coord
 5=grail_progress

--- a/data/src/scripts/quests/quest_mcannon/configs/cannon.constant
+++ b/data/src/scripts/quests/quest_mcannon/configs/cannon.constant
@@ -1,1 +1,7 @@
 ^cannon_decay_length = 2500
+
+^cannon_stage_none = 0
+^cannon_stage_base = 1
+^cannon_stage_stand = 2
+^cannon_stage_barrels = 3
+^cannon_stage_full = 4

--- a/data/src/scripts/quests/quest_mcannon/configs/quest_mcannon.varp
+++ b/data/src/scripts/quests/quest_mcannon/configs/quest_mcannon.varp
@@ -4,7 +4,7 @@ scope=perm
 [mcannon_railings]
 scope=perm
 
-[mcannon_clock]
+[mcannon_stage]
 scope=perm
 
 [mcannon_ammo]

--- a/data/src/scripts/quests/quest_mcannon/scripts/cannon_fire.rs2
+++ b/data/src/scripts/quests/quest_mcannon/scripts/cannon_fire.rs2
@@ -1,13 +1,17 @@
-[timer,cannon_rotate]
+[timer,cannon_rotate](int $dir)
+// automatically starts spinning: https://youtu.be/TeQXQDaawO0?t=234, https://youtu.be/Vsnkdq8OOMg
+// at https://youtu.be/WWyNTsMXjTE?t=26 the cannon doesnt auto rotate immediately 
+// but at https://youtu.be/WWyNTsMXjTE?t=219 the cannon does
+
+// i think this is because picking up the cannon doesnt reset the timer.
+settimer(cannon_rotate, 1, modulo(add($dir, 1), 8));
 if (%mcannon_coord = null | loc_find(%mcannon_coord, cannon) = false) {
-    cleartimer(cannon_rotate);
     return;
 }
 def_coord $center = movecoord(loc_coord, 1, 0, 1);
 def_coord $close_range = movecoord($center, 0, 0, 3);
 def_coord $medium_range = movecoord($center, 0, 0, 7);
 def_coord $long_range = movecoord($center, 0, 0, 14);
-def_int $dir = modulo(%mcannon_clock, 8);
 // start north, going clockwise
 if ($dir = 0) {
     // automatically starts spinning: https://youtu.be/TeQXQDaawO0?t=234
@@ -58,7 +62,6 @@ if ($dir = 0) {
     $long_range = movecoord($center, -12, 0, 12);
     loc_anim(cannon_west);
 }
-%mcannon_clock = add(%mcannon_clock, 1);
 
 // check close range
 npc_huntall($close_range, 1, 1);
@@ -128,6 +131,7 @@ if (random(4) = 0 & %mcannon_coord ! null) { // guess
         mes("Your cannon has been destroyed!");
         loc_del(1);
         %mcannon_coord = null;
+        %mcannon_stage = ^cannon_stage_none;
         %mcannon_ammo = 0;
         cleartimer(cannon_rotate);
     }
@@ -138,13 +142,14 @@ if (random(4) = 0 & %mcannon_coord ! null) { // guess
 if (%mcannon_coord ! null) {
     mes(tostring(coordx(%mcannon_coord)));
 }
-mes(tostring(map_clock));
+mes(tostring(%mcannon_stage));
 
 [debugproc,givemc]
 inv_add(inv, cannon_base, 1);
 inv_add(inv, cannon_stand, 1);
 inv_add(inv, cannon_barrels, 1);
 inv_add(inv, cannon_furnace, 1);
+inv_add(inv, mcannonball, 1000);
 
 [debugproc,completemc]
 queue(mcannon_complete, 0);

--- a/data/src/scripts/quests/quest_mcannon/scripts/cannon_setup.rs2
+++ b/data/src/scripts/quests/quest_mcannon/scripts/cannon_setup.rs2
@@ -6,17 +6,10 @@ if (%mcannon_coord = null) {
 if (loc_find(%mcannon_coord, cannon) = false) {
     mes("Your cannon has decayed."); // https://runescape.wiki/w/Update:Patch_Notes_(6_May_2009)
     cleartimer(cannon_decay);
-    cleartimer(cannon_rotate);
 }
 
 [label,cannon_ready_start]
 settimer(cannon_decay, 5); // OSRS: Checks every 5 ticks if the cannon still exists. THIS DOESNT SET AGAIN ON LOGIN!
-// automatically starts spinning: https://youtu.be/TeQXQDaawO0?t=234
-// at https://youtu.be/WWyNTsMXjTE?t=26 the cannon doesnt auto rotate immediately 
-// but at https://youtu.be/WWyNTsMXjTE?t=219 the cannon does
-if (modulo(%mcannon_clock, 8) ! 0) {  // if rotation isnt north, rotate back to north
-    settimer(cannon_rotate, 1);
-}
 
 [proc,cannon_belongs_to_player]()(boolean)
 if (loc_coord = %mcannon_coord) {
@@ -120,7 +113,7 @@ p_delay(0);
 
 def_coord $origin = movecoord($center, -1, 0, -1); // south-west tile
 %mcannon_coord = $origin;
-// %mcannon_world = map_world;
+%mcannon_stage = ^cannon_stage_base;
 %mcannon_ammo = 0;
 
 anim(human_pickupfloor, 0);
@@ -139,6 +132,7 @@ if (inv_freespace(inv) < 1) {
     return;
 }
 %mcannon_coord = null;
+%mcannon_stage = ^cannon_stage_none;
 mes("You pick up the cannon,");
 mes("It's really heavy.");
 sound_synth(pick, 0, 0);
@@ -155,6 +149,7 @@ if (last_useitem = cannon_stand) {
     inv_del(inv, cannon_stand, 1);
     loc_change(cannon_stand, ^cannon_decay_length);
     mes("You add the stand.");
+    %mcannon_stage = ^cannon_stage_stand;
     return;
 }
 // in osrs, if you use a cannon base on a cannon base, itll have this message...
@@ -179,6 +174,7 @@ if (inv_freespace(inv) < 2) {
     return;
 }
 %mcannon_coord = null;
+%mcannon_stage = ^cannon_stage_none;
 mes("You pick up the cannon,");
 mes("It's really heavy.");
 sound_synth(pick, 0, 0);
@@ -196,6 +192,7 @@ if (last_useitem = cannon_barrels) {
     inv_del(inv, cannon_barrels, 1);
     loc_change(cannon_barrels, ^cannon_decay_length);
     mes("You add the barrels.");
+    %mcannon_stage = ^cannon_stage_barrels;
     return;
 }
 if (oc_category(last_useitem) = cannon_parts & last_useitem ! cannon_stand) { 
@@ -216,6 +213,7 @@ if (inv_freespace(inv) < 3) {
     return;
 }
 %mcannon_coord = null;
+%mcannon_stage = ^cannon_stage_none;
 mes("You pick up the cannon,");
 mes("It's really heavy.");
 sound_synth(pick, 0, 0);
@@ -234,6 +232,7 @@ if (last_useitem = cannon_furnace) {
     inv_del(inv, cannon_furnace, 1);
     mes("You add the furnace.");
     loc_change(cannon, ^cannon_decay_length);
+    %mcannon_stage = ^cannon_stage_full;
     @cannon_ready_start;
 }
 if (oc_category(last_useitem) = cannon_parts & last_useitem ! cannon_barrels) { 
@@ -258,7 +257,7 @@ mes("You pick up the cannon,"); // https://youtu.be/TeQXQDaawO0?t=518
 mes("It's really heavy.");
 sound_synth(pick, 0, 0);
 %mcannon_coord = null;
-cleartimer(cannon_rotate);
+%mcannon_stage = ^cannon_stage_none;
 inv_add(inv, cannon_base, 1);
 inv_add(inv, cannon_stand, 1);
 inv_add(inv, cannon_barrels, 1);
@@ -286,7 +285,7 @@ if (%mcannon_ammo < 1) {
     mes("Your cannon is out of ammo!"); // https://youtu.be/TeQXQDaawO0?t=239
     return;
 }
-settimer(cannon_rotate, 1);
+settimer(cannon_rotate, 1, 0);
 
 [oplocu,cannon]
 if (last_useitem = mcannonball) {

--- a/data/src/scripts/quests/quest_mcannon/scripts/npcs/nulodion.rs2
+++ b/data/src/scripts/quests/quest_mcannon/scripts/npcs/nulodion.rs2
@@ -121,11 +121,23 @@ if (%mcannon_coord ! null) {
 mes("The dwarf gives you a new cannon.");
 ~chatnpc("<p,neutral>Keep that quiet or I'll be in real trouble!");
 ~chatplayer("<p,neutral>Of course.");
+if (%mcannon_stage = ^cannon_stage_base) {
+    inv_add(inv, cannon_base, 1);
+} else if (%mcannon_stage = ^cannon_stage_stand) {
+    inv_add(inv, cannon_base, 1);
+    inv_add(inv, cannon_stand, 1);
+} else if (%mcannon_stage = ^cannon_stage_barrels) {
+    inv_add(inv, cannon_base, 1);
+    inv_add(inv, cannon_stand, 1);
+    inv_add(inv, cannon_barrels, 1);
+} else if (%mcannon_stage = ^cannon_stage_full) {
+    inv_add(inv, cannon_base, 1);
+    inv_add(inv, cannon_stand, 1);
+    inv_add(inv, cannon_barrels, 1);
+    inv_add(inv, cannon_furnace, 1);
+}
 %mcannon_coord = null;
-inv_add(inv, cannon_base, 1);
-inv_add(inv, cannon_stand, 1);
-inv_add(inv, cannon_barrels, 1);
-inv_add(inv, cannon_furnace, 1);
+%mcannon_stage = ^cannon_stage_none;
 
 [label,ill_take_a_cannon]
 ~chatplayer("<p,neutral>Ok, I'll take a cannon please.");

--- a/data/src/scripts/quests/quest_mcannon/scripts/npcs/nulodion.rs2
+++ b/data/src/scripts/quests/quest_mcannon/scripts/npcs/nulodion.rs2
@@ -118,19 +118,22 @@ if (%mcannon_coord ! null) {
         return;
     }
 }
-mes("The dwarf gives you a new cannon.");
 ~chatnpc("<p,neutral>Keep that quiet or I'll be in real trouble!");
 ~chatplayer("<p,neutral>Of course.");
 if (%mcannon_stage = ^cannon_stage_base) {
+    mes("The dwarf gives you a new cannon part."); // osrs
     inv_add(inv, cannon_base, 1);
 } else if (%mcannon_stage = ^cannon_stage_stand) {
+    mes("The dwarf gives you new cannon parts."); // osrs
     inv_add(inv, cannon_base, 1);
     inv_add(inv, cannon_stand, 1);
 } else if (%mcannon_stage = ^cannon_stage_barrels) {
+    mes("The dwarf gives you new cannon parts."); // osrs
     inv_add(inv, cannon_base, 1);
     inv_add(inv, cannon_stand, 1);
     inv_add(inv, cannon_barrels, 1);
 } else if (%mcannon_stage = ^cannon_stage_full) {
+    mes("The dwarf gives you a new cannon."); // osrs
     inv_add(inv, cannon_base, 1);
     inv_add(inv, cannon_stand, 1);
     inv_add(inv, cannon_barrels, 1);


### PR DESCRIPTION
- Var2 is used for cannon stage 0-4: https://chisel.weirdgloop.org/varbs/display?varplayer=2
- You can claim partial cannon parts that are lost after placement:

![reclaim1](https://github.com/user-attachments/assets/809dcd7e-0771-4bc3-ad03-7474f42b5e0d)
![reclaim2](https://github.com/user-attachments/assets/abb0632b-c9f0-44e0-9bf8-0b07317c3956)
![reclaim3](https://github.com/user-attachments/assets/6ceb8fa1-3716-4f16-84fd-d4314ee9bd8e)

- cannon rotate timer continues to tick until logout or out of ammo
    Videos:
    - https://youtu.be/Vsnkdq8OOMg?t=81
    - https://youtu.be/TeQXQDaawO0?t=234
    - https://www.youtube.com/watch?v=WWyNTsMXjTE&t=219s


The first video is particularly useful, you can see that he places a cannon (starts north), and picks it up when its facing east
    
![image](https://github.com/user-attachments/assets/2cd24029-ecba-4a6d-8c1b-bb31fee4e7e3)

Then he places another cannon later in the video, which starts south east (spinning until it reaches north and hits the ammo check)
    
![image](https://github.com/user-attachments/assets/e45e2173-cb28-49b5-b412-336fa8bf35a1)
