### PR TITLE
fix(content): update damage queue uses

### DIFF
--- a/data/src/scripts/areas/area_wilderness/scripts/king_black_dragon.rs2
+++ b/data/src/scripts/areas/area_wilderness/scripts/king_black_dragon.rs2
@@ -158,7 +158,7 @@ if (randominc($attack_roll) > randominc($defence_roll)) {
         mes("You're horribly burnt by the dragon's fiery breath!"); // https://youtu.be/R3ozXHcQkgs?list=PLn23LiLYLb1bYAFU3Vdk3N9niuHs-b-4-&t=78
     }
 }
-queue(damage_player, calc($duration / 30), $damage);
+queue(combat_damage_player, calc($duration / 30), $damage);
 queue(playerhit_n_retaliate, calc($duration / 30), npc_uid); // this should be a queue* command
 ~npc_set_attack_vars;
 // ------------
@@ -184,7 +184,7 @@ if (randominc($attack_roll) > randominc($defence_roll)) {
     }
 
 }
-queue(damage_player, 0, $damage);
+queue(combat_damage_player, 0, $damage);
 queue(playerhit_n_retaliate, 0, npc_uid); // this should be a queue* command
 ~npc_set_attack_vars;
 
@@ -215,7 +215,7 @@ if (randominc($attack_roll) > randominc($defence_roll)) {
         queue(poison_player, 0, 36); // poison the player starting at 8 damage
     }
 }
-queue(damage_player, 0, $damage);
+queue(combat_damage_player, 0, $damage);
 queue(playerhit_n_retaliate, 0, npc_uid); // this should be a queue* command
 ~npc_set_attack_vars;
 
@@ -257,7 +257,7 @@ if (randominc($attack_roll) > randominc($defence_roll)) {
         }
     }
 }
-queue(damage_player, 0, $damage);
+queue(combat_damage_player, 0, $damage);
 queue(playerhit_n_retaliate, 0, npc_uid); // this should be a queue* command
 ~npc_set_attack_vars;
 // ------------
@@ -292,7 +292,7 @@ if (randominc($attack_roll) > randominc($defence_roll)) {
         queue(kbd_freeze_player, 0, 10); // freeze the player
     }
 }
-queue(damage_player, 0, $damage);
+queue(combat_damage_player, 0, $damage);
 queue(playerhit_n_retaliate, 0, npc_uid); // this should be a queue* command
 ~npc_set_attack_vars;
 

--- a/data/src/scripts/macro events/scripts/general/macro_event_drunken_dwarf.rs2
+++ b/data/src/scripts/macro events/scripts/general/macro_event_drunken_dwarf.rs2
@@ -107,5 +107,5 @@ if (randominc($attack_roll) > randominc($defence_roll)) {
 }
 if_close; // close the player interface when taking a hit.
 anim(%com_defendanim, 60);
-queue(damage_player, 1, $damage);
+queue(combat_damage_player, 1, $damage);
 queue(playerhit_n_retaliate, 1, npc_uid); // this should be a queue* command

--- a/data/src/scripts/macro events/scripts/mining/macro_event_rock_golem.rs2
+++ b/data/src/scripts/macro events/scripts/mining/macro_event_rock_golem.rs2
@@ -59,7 +59,7 @@ if (randominc($attack_roll) > randominc($defence_roll)) {
 if (~check_protect_prayer(^melee_style) = true) {
     $damage = 0;
 }
-queue(damage_player, calc($delay/60), $damage);
+queue(combat_damage_player, calc($delay/60), $damage);
 queue(playerhit_n_retaliate, calc($delay/60), npc_uid); // this should be a queue* command
 %npc_action_delay = add(map_clock, 4);
 ~npc_set_attack_vars;

--- a/data/src/scripts/npc/scripts/dragon.rs2
+++ b/data/src/scripts/npc/scripts/dragon.rs2
@@ -109,7 +109,7 @@ if (map_clock < %antifire) {
 }
 
 def_int $damage = randominc(max($maxhit, 0));
-queue(damage_player, 0, $damage);
+queue(combat_damage_player, 0, $damage);
 queue(playerhit_n_retaliate, 0, npc_uid); // this should be a queue* command
 %npc_action_delay = add(map_clock, 4);
 ~npc_set_attack_vars;

--- a/data/src/scripts/player/scripts/combat_clearqueue.rs2
+++ b/data/src/scripts/player/scripts/combat_clearqueue.rs2
@@ -1,11 +1,11 @@
 [proc,combat_clearqueue]
 clearqueue(playerhit_n_retaliate);
-clearqueue(damage_player);
+clearqueue(combat_damage_player);
 clearqueue(pvp_damage);
 clearqueue(pvp_retaliate);
 
 [proc,.combat_clearqueue]
 .clearqueue(playerhit_n_retaliate);
-.clearqueue(damage_player);
+.clearqueue(combat_damage_player);
 .clearqueue(pvp_damage);
 .clearqueue(pvp_retaliate);

--- a/data/src/scripts/player/scripts/damage.rs2
+++ b/data/src/scripts/player/scripts/damage.rs2
@@ -21,6 +21,9 @@ if (stat(hitpoints) = 0){
 
 ~ring_of_life_check;
 
+[queue,damage_player](int $amount)
+~damage_self($amount);
+
 [proc,human_hit_sound]
 def_int $rand;
 def_synth $sound;

--- a/data/src/scripts/quests/quest_dragon/scripts/elvarg.rs2
+++ b/data/src/scripts/quests/quest_dragon/scripts/elvarg.rs2
@@ -72,7 +72,7 @@ def_int $damage = randominc($maxhit);
 // not sure if this was a thing, but this video has it https://youtu.be/ucaYfz3ihWs?list=PLn23LiLYLb1aqrojPTi1_Np81LJku2Nd0&t=130
 stat_drain(prayer, 0, 10); // 10%
 
-queue(damage_player, 0, $damage);
+queue(combat_damage_player, 0, $damage);
 queue(playerhit_n_retaliate, 0, npc_uid); // this should be a queue* command
 ~npc_set_attack_vars;
 
@@ -94,7 +94,7 @@ def_int $damage = randominc($maxhit);
 // not sure if this was a thing, but this video has it https://youtu.be/ucaYfz3ihWs?list=PLn23LiLYLb1aqrojPTi1_Np81LJku2Nd0&t=130
 stat_drain(prayer, 0, 10); // 10%
 
-queue(damage_player, calc($duration / 30), $damage);
+queue(combat_damage_player, calc($duration / 30), $damage);
 queue(playerhit_n_retaliate, calc($duration / 30), npc_uid); // this should be a queue* command
 ~npc_set_attack_vars;
 

--- a/data/src/scripts/quests/quest_dragon/scripts/melzar_the_mad.rs2
+++ b/data/src/scripts/quests/quest_dragon/scripts/melzar_the_mad.rs2
@@ -82,7 +82,7 @@ if (~npc_player_hit_roll(^magic_style) = true) {
     $damage = randominc($maxhit);
 }
 if ($damage > 0) {
-    queue(damage_player, 0, $damage);
+    queue(combat_damage_player, 0, $damage);
     queue(playerhit_n_retaliate, 0, npc_uid);
 }
 %npc_action_delay = add(map_clock, $attackspeed);

--- a/data/src/scripts/skill_combat/scripts/npc/npc_combat.rs2
+++ b/data/src/scripts/skill_combat/scripts/npc/npc_combat.rs2
@@ -310,7 +310,7 @@ switch_int ($style) {
 error("style of <tostring($style)> not defined in switch for npc_combat_defencebonus");
 
 //  this should be strong queued. Some damage is queued, some isnt
-[queue,damage_player](int $damage)
+[queue,combat_damage_player](int $damage)
 if (inv_getobj(worn, ^wearpos_ring) = ring_of_recoil & npc_finduid(%aggressive_npc) = true & %npc_attacking_uid = uid & $damage > 0 & stat(hitpoints) > 0) {
     // https://oldschool.runescape.wiki/w/Update:Clue_Scroll_Step_Counter
     // - "Recoil damage will now always target the entity that caused the initial damage, rather than the most recent entity to deal damage."

--- a/data/src/scripts/skill_combat/scripts/npc/npc_combat_magic.rs2
+++ b/data/src/scripts/skill_combat/scripts/npc/npc_combat_magic.rs2
@@ -118,7 +118,7 @@ sound_synth(db_getfield($spell_data, magic_spell_table:sound_success, 0), 0, 0);
 def_int $damage = randominc($maxhit);
 if ($maxhit ! null) {
     // npc vs player spells have no 1t extra damage delay. Whereas player vs npc spells do (osrs)
-    queue(damage_player, calc($duration / 30), $damage);
+    queue(combat_damage_player, calc($duration / 30), $damage);
     if (npc_param(poison_severity) > 0 & $damage > 0) {
         queue(poison_player, 0, npc_param(poison_severity));
     }

--- a/data/src/scripts/skill_combat/scripts/npc/npc_combat_melee.rs2
+++ b/data/src/scripts/skill_combat/scripts/npc/npc_combat_melee.rs2
@@ -42,7 +42,7 @@ if (npc_stat(hitpoints) = 0) {
     return; // melee npc's on 0 health play the hit animation but dont actually damage you
     // but ranged/mage npcs do! This is unique to melee!
 }
-queue(damage_player, 0, $damage);
+queue(combat_damage_player, 0, $damage);
 if (npc_param(poison_severity) > 0 & $damage > 0) {
     queue(poison_player, 0, npc_param(poison_severity));
 }

--- a/data/src/scripts/skill_combat/scripts/npc/npc_combat_ranged.rs2
+++ b/data/src/scripts/skill_combat/scripts/npc/npc_combat_ranged.rs2
@@ -46,7 +46,7 @@ if (randominc($attack_roll) > randominc($defence_roll)) {
 [proc,playerhit_n_ranged](int $damage, int $duration, int $delay)
 if_close; // close the player interface when taking a hit.
 // not sure if this is correct
-queue(damage_player, calc($duration / 30), $damage);
+queue(combat_damage_player, calc($duration / 30), $damage);
 if (npc_param(poison_severity) > 0 & $damage > 0) {
     queue(poison_player, 0, npc_param(poison_severity));
 }

--- a/data/src/scripts/tutorial/scripts/npcs/tut_giant_rat.rs2
+++ b/data/src/scripts/tutorial/scripts/npcs/tut_giant_rat.rs2
@@ -43,7 +43,7 @@ if (stat(hitpoints) = 1) {
 } else if (randominc($attack_roll) > randominc($defence_roll)) {
     $damage = randominc($maxhit);
 }
-queue(damage_player, 1, $damage);
+queue(combat_damage_player, 1, $damage);
 queue(playerhit_n_retaliate, 1, npc_uid); // this should be a queue* command
 ~npc_set_attack_vars;
 


### PR DESCRIPTION
most uses of the damage_player queue are non-combat related, but when the queue executes it will put the player in combat, preventing logout, this PR renames the old proc to be used specifically for combat, and updates all combat related usages.