### PR TITLE
fix(engine): Npcs will now reset properly if they have not wandered in 500 ticks

### DIFF
--- a/data/src/scripts/skill_thieving/scripts/thieving.rs2
+++ b/data/src/scripts/skill_thieving/scripts/thieving.rs2
@@ -33,6 +33,7 @@ return(stat_random($current_level, $low, $high));
 [proc,fail_pick_pocket](int $damage, int $stun_ticks, string $pocket)
 npc_say("What do you think you're doing?");
 mes("You fail to pick the <$pocket>.");
+// Todo: Should this be playerfaceclose?
 npc_setmode(playerface);
 p_delay(0);
 // Birds above head.

--- a/data/src/scripts/skill_thieving/scripts/thieving.rs2
+++ b/data/src/scripts/skill_thieving/scripts/thieving.rs2
@@ -33,7 +33,6 @@ return(stat_random($current_level, $low, $high));
 [proc,fail_pick_pocket](int $damage, int $stun_ticks, string $pocket)
 npc_say("What do you think you're doing?");
 mes("You fail to pick the <$pocket>.");
-// Todo: Should this be playerfaceclose?
 npc_setmode(playerface);
 p_delay(0);
 // Birds above head.

--- a/src/engine/entity/Npc.ts
+++ b/src/engine/entity/Npc.ts
@@ -480,7 +480,7 @@ export default class Npc extends PathingEntity {
 
         this.updateMovement(false);
 
-        if (World.currentTick >= this.lastWanderTick + 500) {
+        if (World.currentTick > this.lastWanderTick + 500) {
             this.teleport(this.startX, this.startZ, this.startLevel);
         }
     }

--- a/src/engine/entity/Npc.ts
+++ b/src/engine/entity/Npc.ts
@@ -202,6 +202,7 @@ export default class Npc extends PathingEntity {
         const moved = this.lastTickX !== this.x || this.lastTickZ !== this.z;
         if (moved) {
             this.lastMovement = World.currentTick + 1;
+            this.lastWanderTick = World.currentTick;
         }
         return moved;
     }
@@ -418,9 +419,13 @@ export default class Npc extends PathingEntity {
         if (this.delayed) {
             return;
         }
+
         if (this.targetOp === NpcMode.NULL) {
-            this.defaultMode();
-        } else if (this.targetOp === NpcMode.NONE) {
+            const type: NpcType = NpcType.get(this.type);
+            this.targetOp = type.defaultmode;
+        }
+
+        if (this.targetOp === NpcMode.NONE) {
             this.noMode();
         } else if (this.targetOp === NpcMode.WANDER) {
             this.wanderMode();
@@ -454,7 +459,6 @@ export default class Npc extends PathingEntity {
         this.clearInteraction();
         const type: NpcType = NpcType.get(this.type);
         this.targetOp = type.defaultmode;
-        this.lastWanderTick = World.currentTick; // osrs
         this.faceEntity = -1;
         this.masks |= this.entitymask;
 
@@ -468,19 +472,17 @@ export default class Npc extends PathingEntity {
 
     wanderMode(): void {
         const type = NpcType.get(this.type);
+
+        // 1/8 chance to move every tick (even if they already have a destination)
         if (type.moverestrict !== MoveRestrict.NOMOVE && Math.random() < 0.125) {
-            // 1/8 chance to move every tick (even if they already have a destination)
             this.randomWalk(type.wanderrange);
-            const moved = this.updateMovement(false);
-            if (moved) {
-                this.lastWanderTick = World.currentTick;
-            } else if (World.currentTick > this.lastWanderTick + 500) {
-                this.teleport(this.startX, this.startZ, this.startLevel);
-                this.lastWanderTick = World.currentTick;
-            }
-            return;
         }
+
         this.updateMovement(false);
+
+        if (World.currentTick >= this.lastWanderTick + 500) {
+            this.teleport(this.startX, this.startZ, this.startLevel);
+        }
     }
 
     patrolMode(): void {
@@ -602,7 +604,6 @@ export default class Npc extends PathingEntity {
         }
 
         if (this.level !== this.target.level) {
-            this.clearWaypoints();
             this.defaultMode();
             return;
         }
@@ -626,7 +627,6 @@ export default class Npc extends PathingEntity {
         }
 
         if (this.level !== this.target.level) {
-            this.clearWaypoints();
             this.defaultMode();
             return;
         }
@@ -643,6 +643,9 @@ export default class Npc extends PathingEntity {
             this.defaultMode();
             return;
         }
+
+        // Reset 500 tick wander reset clock
+        this.lastWanderTick = World.currentTick;
 
         // Try to interact before moving, include op Obj and Loc
         if (this.tryInteract(true)) {


### PR DESCRIPTION
Fixes thieving and splashing outside of maxrange