### PR TITLE
fix(content): only scatter tradables on genie fail

### DIFF
--- a/data/src/scripts/macro events/scripts/macro_events.rs2
+++ b/data/src/scripts/macro events/scripts/macro_events.rs2
@@ -131,8 +131,9 @@ session_log(^log_adventure, "Failed random event and had their items scattered")
 p_delay(1);
 def_int $i = 0;
 while ($i < inv_size(inv)) {
-    def_coord $coord = map_findsquare(coord, 0, 5, ^map_findsquare_lineofwalk); // 11x11 for now. todo: confirm how scattering works
-    if (inv_getobj(inv, $i) ! null) {
+    def_obj $obj = inv_getobj(inv, $i);
+    if ($obj ! null & oc_tradeable($obj) = true) {
+        def_coord $coord = map_findsquare(coord, 0, 5, ^map_findsquare_lineofwalk); // 11x11 for now. todo: confirm how scattering works
         inv_dropslot(inv, $coord, $i, 200);
         spotanim_map(small_smokepuff, $coord, 124, 0);
     }


### PR DESCRIPTION
There is no proof of how this piece of content worked. But its particularly buggy if we dont check for untradeables. Lots of untradeables have custom opheld5 triggers, inv_dropslot would skip the custom behavior in these triggers.