### PR TITLE
fix(content): put pies and cakes into first inv slot after eating

### DIFF
--- a/data/src/scripts/player/scripts/consumption/consume.rs2
+++ b/data/src/scripts/player/scripts/consumption/consume.rs2
@@ -53,7 +53,7 @@ def_int $eat_delay = 0;
 if (oc_param(last_item, next_obj_stage) = piedish) {
     $eat_delay = 1;
 }
-@player_consume_item(consume_effect_stat, $eat_delay, 3);
+@player_consume_item(consume_effect_stat2, $eat_delay, 3);
 
 // cakes
 [opheld1,_category_130]
@@ -61,15 +61,15 @@ def_int $eat_delay = 1;
 if (oc_param(last_item, next_obj_stage) = null) {
     $eat_delay = 2;
 }
-@player_consume_item(consume_effect_stat, $eat_delay, 3);
+@player_consume_item(consume_effect_stat2, $eat_delay, 3);
 
 // pizzas
 [opheld1,_category_132]
+def_int $eat_delay = 0;
 if (oc_param(last_item, next_obj_stage) = null) {
-    @player_consume_item(consume_effect_stat, 1, 3);
-    return;
+    $eat_delay = 1;
 }
-@player_consume_item(consume_effect_stat2, 0, 3); // uses consume_effect_stat2: https://oldschool.runescape.wiki/w/Update:Zoom_%26_The_Herb_Sack
+@player_consume_item(consume_effect_stat2, $eat_delay, 3); // uses consume_effect_stat2: https://oldschool.runescape.wiki/w/Update:Zoom_%26_The_Herb_Sack
 
 // potions
 [opheld1,jangerberries]@player_consume_item(consume_effect_stat, 2, 3);

--- a/data/src/scripts/player/scripts/consumption/effects/scripts/consume_effects.rs2
+++ b/data/src/scripts/player/scripts/consumption/effects/scripts/consume_effects.rs2
@@ -17,7 +17,9 @@ anim(human_eat, 0);
 def_obj $consumable = last_item;
 
 inv_delslot(inv, last_slot);
-inv_add(inv, oc_param($consumable, next_obj_stage), 1);
+if (oc_param($consumable, next_obj_stage) ! null) {
+    inv_add(inv, oc_param($consumable, next_obj_stage), 1);
+}
 anim(human_eat, 0);
 ~consume_effect_apply($consumable, false);
 


### PR DESCRIPTION
- matches osrs's curry, stew, and some cocktails...


Old videos:

https://github.com/user-attachments/assets/368606b5-88dd-4c30-bf7f-bce877d90994


https://github.com/user-attachments/assets/b1966761-3335-495e-a82f-bf85d1ff8923

