### PR TITLE
fix(content): Fix grammar on magic tab.

### DIFF
--- a/data/src/scripts/skill_magic/interfaces/magic.if
+++ b/data/src/scripts/skill_magic/interfaces/magic.if
@@ -5920,7 +5920,7 @@ height=54
 center=yes
 font=p11
 shadowed=yes
-text=A high level Fire mssile
+text=A high level Fire missile
 colour=0x6B6F33
 
 [com_404]


### PR DESCRIPTION
This PR fixes the wrong grammar in the Fire wave mage spell description.