### PR TITLE
fix(content): Misc context fixes

### DIFF
--- a/data/src/scripts/areas/area_seers/scripts/mcgrubors_wood.rs2
+++ b/data/src/scripts/areas/area_seers/scripts/mcgrubors_wood.rs2
@@ -41,7 +41,7 @@ mes("You use your spade with the vine.");
 p_delay(0);
 mes("You dig in amoungst the vines.");
 mes("You find a red vine worm.");
-if(inv_freespace(inv) = 0) {
+if(inv_freespace(inv) = 0 & inv_total(inv, red_vine_worm) = 0) {
     mes("You do not have enough space to carry this.");
     return;
 }

--- a/data/src/scripts/levelrequire/scripts/levelrequire.rs2
+++ b/data/src/scripts/levelrequire/scripts/levelrequire.rs2
@@ -139,8 +139,14 @@ return(true);
 [label,levelrequire_iban_staff](int $slot)
 // https://oldschool.runescape.wiki/w/Update:Various_tweaks_to_the_game
 // > Fixed a bug which meant the Iban-staff could be wielded at level 49, despite stating a requirement of 50.
-if (stat_base(magic) < 49 & stat_base(attack) < 49) {
-    // todo: messages and additional quest requirements
+if (stat(magic) < 50) {
+    mes("You are not a high enough level to use this item.");
+    mes("You need to have a Magic level of 50.");
+    return;
+}
+if (stat(attack) < 50) {
+    mes("You are not a high enough level to use this item.");
+    mes("You need to have an Attack level of 50.");
     return;
 }
 // https://youtu.be/n_ip_vEDbCA?si=0uESoOC98Fvl7HqS&t=2333

--- a/data/src/scripts/quests/quest_chompybird/scripts/chompy_bird.rs2
+++ b/data/src/scripts/quests/quest_chompybird/scripts/chompy_bird.rs2
@@ -61,39 +61,19 @@ npc_del;
 [label,player_combat_chompybird_start]
 def_obj $rhand = inv_getobj(worn, ^wearpos_rhand);
 
-if ($rhand = null)
-{
+if ($rhand = null) {
     // todo confirm for 2004
     mes("You'll need a weapon to try and attack this beast.");
     return;
 }
 
-def_category $rhand_cat = oc_category($rhand);
-
-if ($rhand_cat = weapon_slash
-    | $rhand_cat = weapon_stab
-    | $rhand_cat = weapon_axe
-    | $rhand_cat = weapon_pickaxe
-    | $rhand_cat = weapon_blunt
-    | $rhand_cat = weapon_spear
-    | $rhand_cat = weapon_spiked
-    | $rhand_cat = weapon_2h_sword
-    | $rhand_cat = weapon_staff
-    | $rhand_cat = weapon_scythe)
-{
+if (%damagetype ! ^ranged_style) {
     // todo confirm for 2004
     mes("The Chompy Bird is too quick for your melee weapon.");
     return;
 }
 
-if (
-    $rhand ! ogre_bow
-    & (
-        $rhand_cat = weapon_bow
-        | $rhand_cat = weapon_crossbow
-        | $rhand_cat = weapon_thrown
-        | $rhand_cat = weapon_javelin))
-{
+if ($rhand ! ogre_bow) {
     // todo confirm for 2004
     mes("Your ranged weapon isn't powerful enough to hurt the Chompy bird.");
     return;
@@ -113,6 +93,11 @@ if ($ammo ! ogre_arrow) {
     return;
 }
 
+def_int $attackrange = ~player_attackrange($rhand);
+if (npc_range(coord) > $attackrange) {
+    p_aprange($attackrange);
+    return;
+}
 ~player_combat_chompybird($rhand, $ammo);
 
 // is this right?  it's basically a replica of the existing combat logic,

--- a/data/src/scripts/quests/quest_murder/configs/quest_murder.loc
+++ b/data/src/scripts/quests/quest_murder/configs/quest_murder.loc
@@ -34,6 +34,7 @@ width=2
 length=2
 mapscene=8
 op2=Investigate
+category=watersource
 
 [loc_2655]
 name=Sinclair family crest

--- a/data/src/scripts/quests/quest_murder/scripts/murder_guard.rs2
+++ b/data/src/scripts/quests/quest_murder/scripts/murder_guard.rs2
@@ -142,7 +142,7 @@ switch_int(%murder_murderer_id) {
 ~mesbox("You prove to the guard <~murder_get_murderer_name> did not use poison on the <~murder_get_poisoned_loc_name>.");
 ~chatnpc("<p,neutral>Excellent work - have you considered a career as a detective? But I'm afraid it's still not quite enough...");
 ~mesbox("You match <~murder_get_murderer_name>'s finger prints with those on the dagger found in the body of Lord Sinclair.");
-~chatnpc("<p,happy>Yes. There's no doubt about it. It must have been <~murder_get_murderer_name> who killed <~murder_get_murderer_pronoun> father. All of the guards must congratulate you on your excellent work in helping us to solve this case.");
+~chatnpc("<p,happy>Yes. There's no doubt about it. It must have been <~murder_get_murderer_name> who killed <~murder_get_murderer_pronoun2> father. All of the guards must congratulate you on your excellent work in helping us to solve this case.");
 ~chatnpc("<p,neutral>We don't have many murders here in RuneScape and I'm afraid we wouldn't have been able to solve it by ourselves. We will hold <~murder_get_murderer_pronoun> here under house arrest until such time as we bring <~murder_get_murderer_pronoun> to trial.");
 ~chatnpc("<p,neutral>You have our gratitude, and I'm sure the rest of the family's as well, in helping to apprehend the murderer. I'll just take the evidence from you now.");
 ~mesbox("You hand over all the evidence.");
@@ -164,5 +164,11 @@ switch_int(%murder_murderer_id) {
 [proc,murder_get_murderer_pronoun]()(string)
 switch_int(%murder_murderer_id) {
     case 2,4,6 : return ("him");
+    case default : return ("her");
+}
+
+[proc,murder_get_murderer_pronoun2]()(string)
+switch_int(%murder_murderer_id) {
+    case 2,4,6 : return ("his");
     case default : return ("her");
 }


### PR DESCRIPTION
- correct freespace check on vine worms
- change sinclair fountain to work as a water source
- fix typo in murder guard dialogue
- aprange check for chompy bird hunting
- Fixed bug where Iban's staff would only check against either stat instead of both, also add the requirement messages, and change it to use `stat` instead of `stat_base`, as this was more likely to be the original cause of the bug (having a check < 49 doesn't make much sense)