### PR TITLE
fix(content): remove "You've been frozen!" mes

### DIFF
--- a/data/src/scripts/skill_combat/scripts/npc/npc_combat_magic.rs2
+++ b/data/src/scripts/skill_combat/scripts/npc/npc_combat_magic.rs2
@@ -55,7 +55,6 @@ if (~npc_player_hit_roll(^magic_style) = true) {
 
 // todo: dunno if this should be queued but protected access lol
 [queue,npc_freeze_player](int $duration)
-mes("You've been frozen!");
 %frozen = calc(map_clock + $duration + 1);
 walktrigger(frozen);
 

--- a/data/src/scripts/skill_combat/scripts/pvp/pvp_magic.rs2
+++ b/data/src/scripts/skill_combat/scripts/pvp/pvp_magic.rs2
@@ -241,8 +241,8 @@ if (inv_total(worn, gauntlets_of_chaos) > 0 & $spell >= ^wind_bolt & $spell <= ^
 }
 return($maxhit);
 
+// https://youtu.be/1A_AITzasxE?t=431
 [queue,pvp_freeze_player](int $duration)
-mes("You've been frozen!");
 %frozen = calc(map_clock + $duration);
 walktrigger(pvp_frozen);
 


### PR DESCRIPTION
- No "You are frozen!" mes. I believe this mes comes from ancients later on

From [video](https://youtu.be/1A_AITzasxE?t=431):

https://github.com/user-attachments/assets/4645e0dd-b564-46fd-88f6-571f2bd867e2


A potential issue with our engine code though...

https://github.com/user-attachments/assets/b73c3efd-9bb5-4703-bbab-5e6aeb2a2d4a

Our walktrigger runs twice, whilst the video it runs once?

![image](https://github.com/user-attachments/assets/805ec576-2c80-400c-80b0-556c451b4623)
![image](https://github.com/user-attachments/assets/98de5d75-d647-4648-83a0-a66df31f3358)
