### PR TITLE
fix(content): Alog message once per clue opening, not once per item inside the clue reward

### DIFF
--- a/data/src/scripts/minigames/game_trail/scripts/easy/trail_clue_easy_reward.rs2
+++ b/data/src/scripts/minigames/game_trail/scripts/easy/trail_clue_easy_reward.rs2
@@ -2,6 +2,7 @@
 // Rolls math verification: https://www.youtube.com/watch?v=Er4RAFnmTvs
 def_int $rolls = calc(2 + random(3));
 def_int $roll = 0;
+def_int $rare = 0;
 
 while ($roll < $rolls) {
     // Rare drop chance was 1/12 in OSRS in 2019. @https://twitter.com/JagexTide/status/1131933683714330624
@@ -14,13 +15,17 @@ while ($roll < $rolls) {
     // Assuming the rarity of any given object from the rare drop tables, have stayed consistent throughout
     // the years, this lands our chance to land on the rare drop table at 1/117.
     if(random(117) = 0) {
-        session_log(^log_adventure, "Completed an Easy Clue Scroll and received a Rare Reward!");
+        $rare = calc($rare + 1);
         gosub(trail_clue_easy_rare);
     } else {
-        session_log(^log_adventure, "Completed an Easy Clue Scroll!");
         gosub(trail_clue_easy_normal);
     }
     $roll = calc($roll + 1);
+}
+if ($rare > 0) {
+    session_log(^log_adventure, "Completed an Easy Clue Scroll and received <tostring($rare)> Rare Reward(s)!");
+} else {
+    session_log(^log_adventure, "Completed an Easy Clue Scroll.");
 }
 ~trail_complete;
 

--- a/data/src/scripts/minigames/game_trail/scripts/easy/trail_clue_easy_reward.rs2
+++ b/data/src/scripts/minigames/game_trail/scripts/easy/trail_clue_easy_reward.rs2
@@ -56,7 +56,6 @@ switch_int ($random) {
     case 24 : inv_add(reward, amulet_of_magic, 1);
     case 25 : inv_add(reward, willow_longbow, 1);
 }
-session_log(^log_adventure, "Completed an Easy Clue Scroll!");
 
 [proc,trail_clue_easy_rare]
 def_int $random = random(12);

--- a/data/src/scripts/minigames/game_trail/scripts/easy/trail_clue_easy_reward.rs2
+++ b/data/src/scripts/minigames/game_trail/scripts/easy/trail_clue_easy_reward.rs2
@@ -14,13 +14,14 @@ while ($roll < $rolls) {
     // Assuming the rarity of any given object from the rare drop tables, have stayed consistent throughout
     // the years, this lands our chance to land on the rare drop table at 1/117.
     if(random(117) = 0) {
+        session_log(^log_adventure, "Completed an Easy Clue Scroll and received a Rare Reward!");
         gosub(trail_clue_easy_rare);
     } else {
+        session_log(^log_adventure, "Completed an Easy Clue Scroll!");
         gosub(trail_clue_easy_normal);
     }
     $roll = calc($roll + 1);
 }
-
 ~trail_complete;
 
 [proc,trail_clue_easy_normal]
@@ -55,6 +56,7 @@ switch_int ($random) {
     case 24 : inv_add(reward, amulet_of_magic, 1);
     case 25 : inv_add(reward, willow_longbow, 1);
 }
+session_log(^log_adventure, "Completed an Easy Clue Scroll!");
 
 [proc,trail_clue_easy_rare]
 def_int $random = random(12);

--- a/data/src/scripts/minigames/game_trail/scripts/hard/trail_clue_hard_reward.rs2
+++ b/data/src/scripts/minigames/game_trail/scripts/hard/trail_clue_hard_reward.rs2
@@ -1,20 +1,24 @@
 [proc,trail_clue_hard_reward]
 def_int $rolls = calc(4 + random(3));
-
 def_int $roll = 0;
+def_int $rare = 0;
 
 while ($roll < $rolls) {
     // Rare drop chance was 1/13 in OSRS in 2019. @https://twitter.com/JagexTide/status/1131933683714330624
     // the chances have been scaled down over time to accomodate for more uniques being in the list, there are 25 uniques in May 2004
     // 133 by 2019, which is 5.32x more, 13 * 5.32 ~= 69
     if(random(69) = 0) {
-        session_log(^log_adventure, "Completed a Hard Clue Scroll and received a Rare Reward!");
+        $rare = calc($rare + 1);
         gosub(trail_clue_hard_rare);
     } else {
-        session_log(^log_adventure, "Completed a Hard Clue Scroll!");
         gosub(trail_clue_hard_normal);
     }
     $roll = calc($roll + 1);
+}
+if ($rare > 0) {
+    session_log(^log_adventure, "Completed a Hard Clue Scroll and received <tostring($rare)> Rare Reward(s)!");
+} else {
+    session_log(^log_adventure, "Completed a Hard Clue Scroll.");
 }
 ~trail_complete;
 

--- a/data/src/scripts/minigames/game_trail/scripts/hard/trail_clue_hard_reward.rs2
+++ b/data/src/scripts/minigames/game_trail/scripts/hard/trail_clue_hard_reward.rs2
@@ -8,13 +8,14 @@ while ($roll < $rolls) {
     // the chances have been scaled down over time to accomodate for more uniques being in the list, there are 25 uniques in May 2004
     // 133 by 2019, which is 5.32x more, 13 * 5.32 ~= 69
     if(random(69) = 0) {
+        session_log(^log_adventure, "Completed a Hard Clue Scroll and received a Rare Reward!");
         gosub(trail_clue_hard_rare);
     } else {
+        session_log(^log_adventure, "Completed a Hard Clue Scroll!");
         gosub(trail_clue_hard_normal);
     }
     $roll = calc($roll + 1);
 }
-
 ~trail_complete;
 
 [proc,trail_clue_hard_normal]
@@ -60,7 +61,6 @@ switch_int ($random) {
     case 10 : inv_add(reward, trail_cavalier_tan, 1);
     case 11 : inv_add(reward, trail_cavalier_brown, 1);
     case 12 : inv_add(reward, trail_cavalier_black, 1);
-
     case 13 : inv_add(reward, rune_full_helm_zamorak, 1);
     case 14 : inv_add(reward, rune_platebody_zamorak, 1);
     case 15 : inv_add(reward, rune_platelegs_zamorak, 1);

--- a/data/src/scripts/minigames/game_trail/scripts/medium/trail_clue_medium_reward.rs2
+++ b/data/src/scripts/minigames/game_trail/scripts/medium/trail_clue_medium_reward.rs2
@@ -1,19 +1,24 @@
 [proc,trail_clue_medium_reward]
 def_int $rolls = calc(3 + random(3));
 def_int $roll = 0;
+def_int $rare = 0;
 
 while ($roll < $rolls) {
     // Rare drop chance was 1/11 in OSRS in 2019. @https://twitter.com/JagexTide/status/1131933683714330624, 112 items in 2019, there are 13 in May 04
     // so the chance is 1/95 ((112/13) * 11)
     if(random(95) = 0) {
-        session_log(^log_adventure, "Completed a Medium Clue Scroll and received a Rare Reward!");
+        $rare = calc($rare + 1);
         gosub(trail_clue_medium_rare);
     } else {
-        session_log(^log_adventure, "Completed a Medium Clue Scroll!");
         gosub(trail_clue_medium_normal);
     }
 
     $roll = calc($roll + 1);
+}
+if ($rare > 0) {
+    session_log(^log_adventure, "Completed a Medium Clue Scroll and received <tostring($rare)> Rare Reward(s)!");
+} else {
+    session_log(^log_adventure, "Completed a Medium Clue Scroll.");
 }
 ~trail_complete;
 

--- a/data/src/scripts/minigames/game_trail/scripts/medium/trail_clue_medium_reward.rs2
+++ b/data/src/scripts/minigames/game_trail/scripts/medium/trail_clue_medium_reward.rs2
@@ -6,14 +6,15 @@ while ($roll < $rolls) {
     // Rare drop chance was 1/11 in OSRS in 2019. @https://twitter.com/JagexTide/status/1131933683714330624, 112 items in 2019, there are 13 in May 04
     // so the chance is 1/95 ((112/13) * 11)
     if(random(95) = 0) {
+        session_log(^log_adventure, "Completed a Medium Clue Scroll and received a Rare Reward!");
         gosub(trail_clue_medium_rare);
     } else {
+        session_log(^log_adventure, "Completed a Medium Clue Scroll!");
         gosub(trail_clue_medium_normal);
     }
 
     $roll = calc($roll + 1);
 }
-
 ~trail_complete;
 
 [proc,trail_clue_medium_normal]

--- a/data/src/scripts/skill_agility/scripts/shortcuts.rs2
+++ b/data/src/scripts/skill_agility/scripts/shortcuts.rs2
@@ -44,7 +44,7 @@ def_int $z_dist = -4;
 if(coordx(coord) < 2602) {
     $z_dist = 4;
 }
-~agility_force_move(80, human_walk_logbalance, movecoord(coord, $z_dist, 0, 0));
+~agility_force_move(85, human_walk_logbalance, movecoord(coord, $z_dist, 0, 0));
 mes("...You make it safely to the other side.");
 
 [oploc1,loc_2332]


### PR DESCRIPTION
Fixes ( original #1607 ) reported by _heart. on discord
![image](https://github.com/user-attachments/assets/926b693d-5563-4ef8-821f-f5ac63555a23)
![image](https://github.com/user-attachments/assets/0e24a9c6-26c4-400c-b10e-896d43a3b58b)

