### PR TITLE
fix(content): clear pending action when unequipping items

### DIFF
--- a/data/src/scripts/player/scripts/equip.rs2
+++ b/data/src/scripts/player/scripts/equip.rs2
@@ -2,6 +2,7 @@
 
 [inv_button1,wornitems:wear]
 if_close;
+p_clearpendingaction;
 ~unequip(last_slot);
 
 [proc,equip](int $slot)


### PR DESCRIPTION
From [video](https://youtu.be/AVpqoWjsT1E?t=34):

https://github.com/user-attachments/assets/8a7d7268-e964-4f50-8fdb-a04d3533377b



Makes me question... Did every protected if_button/inv_button in the engine clear pending action and close interface?