### PR TITLE
fix(content): change barbarians to have a 1/4 chance to scream

### DIFF
--- a/data/src/scripts/npc/scripts/barbarian.rs2
+++ b/data/src/scripts/npc/scripts/barbarian.rs2
@@ -3,5 +3,11 @@
 
 [label,barbarian_default_attack]
 if (%npc_action_delay > map_clock) return;
-npc_say("YYEEEEEAAARRRRGGHHHH!!!");
+// https://youtu.be/RdilejVd-cQ
+// total hits: 36 
+// hits with yeargh: 8
+// hits without: 28
+if (random(4) = 0) {
+    npc_say("YYEEEEEAAARRRRGGHHHH!!!");
+}
 ~npc_default_attack;


### PR DESCRIPTION
Osrs for some reason, they scream 100% of the time. This video looks like 1/4 https://youtu.be/RdilejVd-cQ

Also the barbarian women don't scream at all, unlucky? Or did only male barbarians scream