### PR TITLE
fix(content): no longer delay the player when stealing from thieving stalls

### DIFF
--- a/data/src/scripts/skill_thieving/scripts/thieving.rs2
+++ b/data/src/scripts/skill_thieving/scripts/thieving.rs2
@@ -66,7 +66,8 @@ def_int $experience = db_getfield($data, stealing:experience, 0);
 def_int $respawn_ticks = ~scale_by_playercount(db_getfield($data, stealing:respawn_ticks, 0));
 anim(human_pickuptable, 0);
 sound_synth(pick, 0, 0);
-p_delay(0);
+// p_delay here was added with this update: https://oldschool.runescape.wiki/w/Update:Special_Attacks
+// p_delay(0); 
 switch_loc (loc_type) {
     case bakers_stall_stealing : 
         longqueue(stolen_from_stall_baker, ^baker_stall_timer, ^discard);


### PR DESCRIPTION
Similar to https://github.com/2004Scape/Server/pull/1368

They added a 1t p_delay to produce this behavior described in the [blog post](https://oldschool.runescape.wiki/w/Update:Special_Attacks):
`The new RuneScape launch inadventantly made it harder to gain resources from these in competative situations (where two or more people are trying to get the resource at once), since only one person could ever get the resource at a time. We have now fixed it back to the old behaviour where if both people are successful at the exact same instant, they will both get the resource.`