### PR TITLE
fix(content): players shouldnt be able to duel on f2p worlds

### DIFF
--- a/data/src/scripts/minigames/game_duelarena/scripts/duel_arena.rs2
+++ b/data/src/scripts/minigames/game_duelarena/scripts/duel_arena.rs2
@@ -41,6 +41,11 @@ if (~in_duel_arena(coord) = true | ~inzone_coord_pair_table(duel_arena_zones, co
 // if the other player isnt in the duel area
 if (~inzone_coord_pair_table(duel_arena_zones, .coord) = false) {
     mes("That player is not in the duel challenge area."); // https://youtu.be/YlnPnlfgMQ4?t=51
+    return;
+}
+if (map_members = false) { // theres an area f2p worlds have access to that lets you duel other players
+    mes(^mes_members_do_that); // guess
+    return;
 }
 
 mes("Sending duel offer...");


### PR DESCRIPTION
You can duel players in this area, which are accessible in f2p. Also missing return for dueling players outside the arena

![image](https://github.com/user-attachments/assets/a59f29f5-45f2-4276-9313-628008b44ec4)
