### PR TITLE
fix(content): bool behavior for Fishing Contest & Merlin's Crystal

### DIFF
--- a/data/src/scripts/areas/area_seers/scripts/hemenster/bonzo.rs2
+++ b/data/src/scripts/areas/area_seers/scripts/hemenster/bonzo.rs2
@@ -37,7 +37,7 @@ if($option = 1) {
 
 [proc,bonzo_set_places]
 ~chatnpc("<p,neutral>Ok, nearly everyone is in their place already.|You fish in the spot by the willow tree,|and the Sinister Stranger, you fish by the pipes.");
-if(%hemenster_pipe_stashed = true) {
+if(%hemenster_pipe_stashed ! null & %hemenster_pipe_stashed = true) {
     ~move_hemenster_pipe;
     return;
 }

--- a/data/src/scripts/areas/area_white_wolf_mountain/scripts/mountain_dwarf.rs2
+++ b/data/src/scripts/areas/area_white_wolf_mountain/scripts/mountain_dwarf.rs2
@@ -67,7 +67,6 @@ if($option = 1) {
         ~chatplayer("<p,happy>Fortunately I'm alright at fishing!");
         ~chatnpc("<p,happy>Okay, I entrust you with our competition pass.|Go to Hemenster and do us proud!");
         %fishingcompo_progress = ^fishingcompo_started;
-        %hemenster_pipe_stashed = false;
         ~send_quest_progress(questlist:fishingcompo, %fishingcompo_progress, ^fishingcompo_complete);
         inv_add(inv, fishing_pass, 1);
     } else if($start = 2) {


### PR DESCRIPTION
Not an ideal fix for Fishing Contest, but trying the varp check `! true` still doesn't work properly at hemenster.

`! true` does work as expected during Merlin's to get the wax

Reported on Discord by .starkwolf & .1174i
https://discord.com/channels/953326730632904844/1358296528883679244