### PR TITLE
fix(engine): Don't clearPendingAction on main modal ophelds (Puzzlebox fix)

### DIFF
--- a/data/src/scripts/minigames/game_trail/scripts/trail_puzzle.rs2
+++ b/data/src/scripts/minigames/game_trail/scripts/trail_puzzle.rs2
@@ -173,5 +173,3 @@ if($open_slot ! -1) {
     sound_synth(slide_puzzle, 0, 0);
     inv_movetoslot(trail_puzzle_inv, trail_puzzle_inv, $slot, $open_slot);
 }
-
-if_openmain(trail_puzzle); // opheld5 closes modal so this is temp workaround

--- a/src/network/rs225/client/handler/OpHeldHandler.ts
+++ b/src/network/rs225/client/handler/OpHeldHandler.ts
@@ -12,7 +12,7 @@ import Environment from '#/util/Environment.js';
 export default class OpHeldHandler extends MessageHandler<OpHeld> {
     handle(message: OpHeld, player: Player): boolean {
         const { obj: item, slot, component: comId } = message;
-        
+
         const com = Component.get(comId);
         if (typeof com === 'undefined' || !player.isComponentVisible(com) || !com.interactable) {
             player.clearPendingAction();

--- a/src/network/rs225/client/handler/OpHeldHandler.ts
+++ b/src/network/rs225/client/handler/OpHeldHandler.ts
@@ -12,7 +12,7 @@ import Environment from '#/util/Environment.js';
 export default class OpHeldHandler extends MessageHandler<OpHeld> {
     handle(message: OpHeld, player: Player): boolean {
         const { obj: item, slot, component: comId } = message;
-
+        
         const com = Component.get(comId);
         if (typeof com === 'undefined' || !player.isComponentVisible(com) || !com.interactable) {
             player.clearPendingAction();
@@ -44,7 +44,10 @@ export default class OpHeldHandler extends MessageHandler<OpHeld> {
         player.lastItem = item;
         player.lastSlot = slot;
 
-        player.clearPendingAction();
+        if(com.rootLayer != player.modalMain) {
+            player.clearPendingAction();
+        }
+
         player.moveClickRequest = false; // uses the dueling ring op to move whilst busy & queue pending: https://youtu.be/GPfN3Isl2rM
         player.faceEntity = -1;
         player.masks |= player.entitymask;


### PR DESCRIPTION
This will stop the puzzle box interface from closing and reopening on every move.

Discussed in https://github.com/2004Scape/Server/pull/1630