### PR TITLE
fix(content): Typo in level up message

### DIFF
--- a/data/src/scripts/levelup/scripts/levelup_unlocks_herblore.rs2
+++ b/data/src/scripts/levelup/scripts/levelup_unlocks_herblore.rs2
@@ -7,7 +7,7 @@ switch_int(stat_base(herblore)) {
     case 12 : ~objbox(3dose1strength,"You can now make @dbl@Strength Potions@bla@.", 250, 0, ^objbox_height);
     case 20 : ~objbox(harralander,"You can now identify @dbl@Harralander@bla@.", 250, 0, 0);
     case 22 : ~objbox(3dose1restore,"You can now make @dbl@Stat Restore Potions@bla@.", 250, 0, ^objbox_height);
-    case 25 : ~objbox(ranarr_weed,"You can now identify @dbl@Rannar Weed@bla@.", 250, 0, 0);
+    case 25 : ~objbox(ranarr_weed,"You can now identify @dbl@Ranarr Weed@bla@.", 250, 0, 0);
     case 30 : ~objbox(3dose1defense,"You can now make @dbl@Defence Potions@bla@.", 250, 0, ^objbox_height);
     case 38 : ~objbox(3doseprayerrestore,"You can now make @dbl@Prayer Restore Potions@bla@.", 250, 0, ^objbox_height);
     case 40 : ~objbox(irit_leaf,"You can now identify @dbl@Irit Leaf@bla@.", 250, 0, 0);


### PR DESCRIPTION
No source showing incorrect spelling, assuming just a typo

Reported by clayton_c on discord: https://discord.com/channels/953326730632904844/1358519718088278036