### PR TITLE
fix(engine): Entity searches now match RuneScape behavior. Dwarf cannon targeting is now fully authentic!

### DIFF
--- a/data/src/scripts/_test/scripts/cheats/cheat_search.rs2
+++ b/data/src/scripts/_test/scripts/cheats/cheat_search.rs2
@@ -1,0 +1,64 @@
+// This file is for testing various type of iterators and searches
+
+[debugproc,obj_findallzone1]
+if (p_finduid(uid) = true) {
+    p_telejump(0_37_55_32_30);
+    p_delay(0);
+    obj_addall(0_37_55_33_33, logs, 1, 30);
+    obj_addall(0_37_55_34_34, logs, 1, 30);
+    p_delay(1);
+    obj_findallzone(0_37_55_34_34);
+    if(obj_findnext = true){
+        obj_del;
+        return;
+    }
+}
+
+
+[debugproc,loc_findallzone1]
+if (p_finduid(uid) = true) {
+    p_telejump(0_37_55_32_30);
+    p_delay(0);
+    loc_add(0_37_55_33_33, loc_1276, 0, centrepiece_straight, 30);
+    loc_add(0_37_55_34_34, loc_1276, 0, centrepiece_straight, 30);
+    p_delay(1);
+    loc_findallzone(0_37_55_34_34);
+    if(loc_findnext = true){
+        loc_del(100);
+        return;
+    }
+}
+
+[debugproc,npc_find1]
+if (p_finduid(uid) = true) {
+    p_telejump(0_37_55_35_35);
+    p_delay(0);
+    npc_add(0_37_55_33_33, banker_man,30);
+    npc_add(0_37_55_34_33, banker_man,30);
+    npc_add(0_37_55_35_33, banker_man,30);
+    npc_add(0_37_55_36_33, banker_man,30);
+    npc_add(0_37_55_37_33, banker_man,30);
+    p_delay(1);
+
+    if(npc_find(0_37_55_35_35, banker_man, 10, 0) = true){
+        npc_say("Meeee");
+    }
+}
+
+[debugproc,npc_hunt1]
+if (p_finduid(uid) = true) {
+    p_telejump(0_37_55_35_35);
+    p_delay(0);
+    npc_add(0_37_55_33_33, goblin_unarmed1,30);
+    npc_add(0_37_55_34_33, goblin_unarmed1,30);
+    npc_add(0_37_55_35_33, goblin_unarmed1,30);
+    npc_add(0_37_55_36_33, goblin_unarmed1,30);
+    npc_add(0_37_55_37_33, goblin_unarmed1,30);
+    p_delay(1);
+
+    if(npc_hunt(0_37_55_35_35, 10, 0) = true){
+        npc_say("Meeee");
+    }
+}
+
+

--- a/data/src/scripts/engine.rs2
+++ b/data/src/scripts/engine.rs2
@@ -19,6 +19,8 @@
 [command,.huntnext]()(boolean)
 // info: Search (hunt) for one npc in a given area, prioritized by distance
 [command,npc_hunt](coord $source, int $distance, int $checkvis)(boolean)
+// info: Search (hunt) for one npc in a given area, prioritized by distance, secondary pointer
+[command,.npc_hunt](coord $source, int $distance, int $checkvis)(boolean)
 // info: Search (hunt) for npcs in a given area
 [command,npc_huntall](coord $source, int $distance, int $checkvis)
 // info: Use the next result from npc_huntall

--- a/data/src/scripts/engine.rs2
+++ b/data/src/scripts/engine.rs2
@@ -17,6 +17,8 @@
 [command,huntnext]()(boolean)
 // info: Use the next result from huntall on the secondary pointer
 [command,.huntnext]()(boolean)
+// info: Search (hunt) for one npc in a given area, prioritized by distance
+[command,npc_hunt](coord $source, int $distance, int $checkvis)(boolean)
 // info: Search (hunt) for npcs in a given area
 [command,npc_huntall](coord $source, int $distance, int $checkvis)
 // info: Use the next result from npc_huntall
@@ -699,6 +701,12 @@
 [command,obj_coord]()(coord)
 // info: Return true if a specific object exists at $coord
 [command,obj_find](coord $coord, obj $obj)(boolean)
+// info: Find all Objs around $coord (limited to the nearest 8x8 zone area)
+[command,obj_findallzone](coord $coord)
+// info: Use the next result from obj_findallzone
+[command,obj_findnext]()(boolean)
+// info: Use the next result from obj_findallzone
+[command,.obj_findnext]()(boolean)
 
 // Npc config ops (4000-4099)
 // info: Get the name from a npc config

--- a/data/src/scripts/quests/quest_mcannon/scripts/cannon_fire.rs2
+++ b/data/src/scripts/quests/quest_mcannon/scripts/cannon_fire.rs2
@@ -63,24 +63,22 @@ if ($dir = 0) {
     loc_anim(cannon_west);
 }
 
-// check close range
-npc_huntall($close_range, 1, 1);
-while (npc_huntnext = true) {
+// Check close range
+if (npc_hunt($close_range, 1, 1) = true) {
     if (lineofsight($center, npc_coord) = true) {
         jump(cannon_fire);
     }
 }
 
-// check med range
-npc_huntall($medium_range, 2, 1);
-while (npc_huntnext = true) {
+// Check med range
+if (npc_hunt($medium_range, 2, 1) = true) {
     if (lineofsight($center, npc_coord) = true) {
         jump(cannon_fire);
     }
 }
-// check long range
-npc_huntall($long_range, 5, 1);
-while (npc_huntnext = true) {
+
+// Check long range
+if (npc_hunt($long_range, 5, 1) = true) {
     if (lineofsight($center, npc_coord) = true) {
         jump(cannon_fire);
     }

--- a/src/engine/CoordGrid.ts
+++ b/src/engine/CoordGrid.ts
@@ -79,6 +79,14 @@ export const CoordGrid = {
         return Math.max(deltaX, deltaZ);
     },
 
+    // Returns the squared euclidean distance between two points (dx^2 + dz^2)
+    euclideanSquaredDistance(pos: { x: number; z: number }, other: { x: number; z: number }) {
+        const deltaX = Math.abs(pos.x - other.x);
+        const deltaZ = Math.abs(pos.z - other.z);
+
+        return deltaX * deltaX + deltaZ * deltaZ;
+    },
+
     isWithinDistanceSW(pos: { x: number; z: number }, other: { x: number; z: number }, distance: number) {
         if (Math.abs(pos.x - other.x) > distance || Math.abs(pos.z - other.z) > distance) {
             return false;

--- a/src/engine/script/ScriptIterators.ts
+++ b/src/engine/script/ScriptIterators.ts
@@ -75,7 +75,7 @@ export class HuntIterator extends ScriptIterator<Entity> {
                 const zoneZ: number = z << 3;
 
                 if (this.type === HuntModeType.PLAYER) {
-                    for (const player of World.gameMap.getZone(zoneX, zoneZ, this.level).getAllPlayersSafe()) {
+                    for (const player of World.gameMap.getZone(zoneX, zoneZ, this.level).getAllPlayersSafe(true)) {
                         if (World.currentTick > this.tick) {
                             throw new Error('[HuntIterator] tried to use an old iterator. Create a new iterator instead.');
                         }
@@ -95,7 +95,7 @@ export class HuntIterator extends ScriptIterator<Entity> {
                         yield player;
                     }
                 } else if (this.type === HuntModeType.NPC) {
-                    for (const npc of World.gameMap.getZone(zoneX, zoneZ, this.level).getAllNpcsSafe()) {
+                    for (const npc of World.gameMap.getZone(zoneX, zoneZ, this.level).getAllNpcsSafe(true)) {
                         if (World.currentTick > this.tick) {
                             throw new Error('[HuntIterator] tried to use an old iterator. Create a new iterator instead.');
                         }
@@ -119,7 +119,7 @@ export class HuntIterator extends ScriptIterator<Entity> {
                     }
                 } else if (this.type === HuntModeType.OBJ) {
                     // scripting only cares about dynamic objs??
-                    for (const obj of World.gameMap.getZone(zoneX, zoneZ, this.level).getAllObjsSafe()) {
+                    for (const obj of World.gameMap.getZone(zoneX, zoneZ, this.level).getAllObjsSafe(true)) {
                         if (World.currentTick > this.tick) {
                             throw new Error('[HuntIterator] tried to use an old iterator. Create a new iterator instead.');
                         }
@@ -142,7 +142,7 @@ export class HuntIterator extends ScriptIterator<Entity> {
                         yield obj;
                     }
                 } else if (this.type === HuntModeType.SCENERY) {
-                    for (const loc of World.gameMap.getZone(zoneX, zoneZ, this.level).getAllLocsSafe()) {
+                    for (const loc of World.gameMap.getZone(zoneX, zoneZ, this.level).getAllLocsSafe(true)) {
                         if (World.currentTick > this.tick) {
                             throw new Error('[HuntIterator] tried to use an old iterator. Create a new iterator instead.');
                         }
@@ -173,7 +173,7 @@ export class HuntIterator extends ScriptIterator<Entity> {
 /**
  * This iterator powers the `npc_huntall` RuneScript command.
  */
-export class NpcHuntAllCommandIterator extends ScriptIterator<Entity> {
+export class NpcHuntAllCommandIterator extends ScriptIterator<Npc> {
     // a radius of 1 will loop 9 zones
     // a radius of 2 will loop 25 zones
     // a radius of 3 will loop 49 zones
@@ -203,7 +203,7 @@ export class NpcHuntAllCommandIterator extends ScriptIterator<Entity> {
         this.checkVis = checkVis;
     }
 
-    protected *generator(): IterableIterator<Entity> {
+    protected *generator(): IterableIterator<Npc> {
         for (let x: number = this.maxX; x >= this.minX; x--) {
             const zoneX: number = x << 3;
             for (let z: number = this.maxZ; z >= this.minZ; z--) {

--- a/src/engine/script/ScriptIterators.ts
+++ b/src/engine/script/ScriptIterators.ts
@@ -8,6 +8,7 @@ import HuntVis from '#/engine/entity/hunt/HuntVis.js';
 import Loc from '#/engine/entity/Loc.js';
 import Npc from '#/engine/entity/Npc.js';
 import NpcIteratorType from '#/engine/entity/NpcIteratorType.js';
+import Obj from '#/engine/entity/Obj.js';
 import { isLineOfSight, isLineOfWalk } from '#/engine/GameMap.js';
 import World from '#/engine/World.js';
 
@@ -208,7 +209,7 @@ export class NpcHuntAllCommandIterator extends ScriptIterator<Entity> {
             for (let z: number = this.maxZ; z >= this.minZ; z--) {
                 const zoneZ: number = z << 3;
 
-                for (const npc of World.gameMap.getZone(zoneX, zoneZ, this.level).getAllNpcsSafe()) {
+                for (const npc of World.gameMap.getZone(zoneX, zoneZ, this.level).getAllNpcsSafe(true)) {
                     if (World.currentTick > this.tick) {
                         throw new Error('[HuntIterator] tried to use an old iterator. Create a new iterator instead.');
                     }
@@ -268,7 +269,7 @@ export class NpcIterator extends ScriptIterator<Npc> {
 
     protected *generator(): IterableIterator<Npc> {
         if (this.type === NpcIteratorType.ZONE) {
-            for (const npc of World.gameMap.getZone(this.x, this.z, this.level).getAllNpcsSafe()) {
+            for (const npc of World.gameMap.getZone(this.x, this.z, this.level).getAllNpcsSafe(true)) {
                 if (World.currentTick > this.tick) {
                     throw new Error('[NpcIterator] tried to use an old iterator. Create a new iterator instead.');
                 }
@@ -279,7 +280,7 @@ export class NpcIterator extends ScriptIterator<Npc> {
                 const zoneX: number = x << 3;
                 for (let z: number = this.maxZ; z >= this.minZ; z--) {
                     const zoneZ: number = z << 3;
-                    for (const npc of World.gameMap.getZone(zoneX, zoneZ, this.level).getAllNpcsSafe()) {
+                    for (const npc of World.gameMap.getZone(zoneX, zoneZ, this.level).getAllNpcsSafe(true)) {
                         if (World.currentTick > this.tick) {
                             throw new Error('[NpcIterator] tried to use an old iterator. Create a new iterator instead.');
                         }
@@ -316,11 +317,33 @@ export class LocIterator extends ScriptIterator<Loc> {
     }
 
     protected *generator(): IterableIterator<Loc> {
-        for (const loc of World.gameMap.getZone(this.x, this.z, this.level).getAllLocsSafe()) {
+        for (const loc of World.gameMap.getZone(this.x, this.z, this.level).getAllLocsSafe(true)) {
             if (World.currentTick > this.tick) {
                 throw new Error('[LocIterator] tried to use an old iterator. Create a new iterator instead.');
             }
             yield loc;
+        }
+    }
+}
+
+export class ObjIterator extends ScriptIterator<Obj> {
+    private readonly level: number;
+    private readonly x: number;
+    private readonly z: number;
+
+    constructor(tick: number, level: number, x: number, z: number) {
+        super(tick);
+        this.level = level;
+        this.x = x;
+        this.z = z;
+    }
+
+    protected *generator(): IterableIterator<Obj> {
+        for (const Obj of World.gameMap.getZone(this.x, this.z, this.level).getAllObjsSafe(true)) {
+            if (World.currentTick > this.tick) {
+                throw new Error('[ObjIterator] tried to use an old iterator. Create a new iterator instead.');
+            }
+            yield Obj;
         }
     }
 }

--- a/src/engine/script/ScriptOpcode.ts
+++ b/src/engine/script/ScriptOpcode.ts
@@ -280,6 +280,8 @@ enum ScriptOpcode {
     OBJ_TAKEITEM,
     OBJ_TYPE,
     OBJ_FIND,
+    OBJ_FINDALLZONE,
+    OBJ_FINDNEXT,
 
     // Npc config ops (4000-4099)
     NC_CATEGORY = 4000,

--- a/src/engine/script/ScriptOpcode.ts
+++ b/src/engine/script/ScriptOpcode.ts
@@ -233,6 +233,7 @@ enum ScriptOpcode {
     NPC_QUEUE, // official
     NPC_RANGE, // official
     NPC_SAY, // official
+    NPC_HUNT,
     NPC_HUNTALL, // official
     NPC_HUNTNEXT,
     NPC_SETHUNT, // official

--- a/src/engine/script/ScriptOpcodePointers.ts
+++ b/src/engine/script/ScriptOpcodePointers.ts
@@ -797,6 +797,17 @@ const ScriptOpcodePointers: {
         set: ['active_obj'],
         set2: ['active_obj2']
     },
+    [ScriptOpcode.OBJ_FINDALLZONE]: {
+        set: ['find_obj'],
+        set2: ['find_obj']
+    },
+    [ScriptOpcode.OBJ_FINDNEXT]: {
+        require: ['find_obj'],
+        set: ['active_obj'],
+        require2: ['find_obj'],
+        set2: ['active_obj2'],
+        conditional: true
+    },
 
     // Inventory ops
     [ScriptOpcode.INV_ADD]: {

--- a/src/engine/script/ScriptOpcodePointers.ts
+++ b/src/engine/script/ScriptOpcodePointers.ts
@@ -150,6 +150,10 @@ const ScriptOpcodePointers: {
         set2: ['active_player2'],
         conditional: true
     },
+    [ScriptOpcode.NPC_HUNT]: {
+        set: ['active_npc'],
+        set2: ['active_npc2']
+    },
     [ScriptOpcode.NPC_HUNTALL]: {
         set: ['find_npc']
     },

--- a/src/engine/script/ScriptState.ts
+++ b/src/engine/script/ScriptState.ts
@@ -125,6 +125,7 @@ export default class ScriptState {
     huntIterator: IterableIterator<Entity> | null = null;
     npcIterator: IterableIterator<Npc> | null = null;
     locIterator: IterableIterator<Loc> | null = null;
+    objIterator: IterableIterator<Obj> | null = null;
 
     lastInt: number = 0;
 

--- a/src/engine/script/handlers/LocOps.ts
+++ b/src/engine/script/handlers/LocOps.ts
@@ -9,7 +9,7 @@ import EntityLifeCycle from '#/engine/entity/EntityLifeCycle.js';
 import Loc from '#/engine/entity/Loc.js';
 import { LocIterator } from '#/engine/script/ScriptIterators.js';
 import ScriptOpcode from '#/engine/script/ScriptOpcode.js';
-import ScriptPointer, { ActiveLoc, checkedHandler } from '#/engine/script/ScriptPointer.js';
+import { ActiveLoc, checkedHandler } from '#/engine/script/ScriptPointer.js';
 import { CommandHandlers } from '#/engine/script/ScriptRunner.js';
 import { check, CoordValid, DurationValid, LocAngleValid, LocShapeValid, LocTypeValid, ParamTypeValid, SeqTypeValid } from '#/engine/script/ScriptValidators.js';
 import World from '#/engine/World.js';
@@ -97,11 +97,6 @@ const LocOps: CommandHandlers = {
         const coord: CoordGrid = check(state.popInt(), CoordValid);
 
         state.locIterator = new LocIterator(World.currentTick, coord.level, coord.x, coord.z);
-        // not necessary but if we want to refer to the original loc again, we can
-        if (state._activeLoc) {
-            state._activeLoc2 = state._activeLoc;
-            state.pointerAdd(ScriptPointer.ActiveLoc2);
-        }
     },
 
     [ScriptOpcode.LOC_FINDNEXT]: state => {

--- a/src/engine/script/handlers/NpcOps.ts
+++ b/src/engine/script/handlers/NpcOps.ts
@@ -289,13 +289,14 @@ const NpcOps: CommandHandlers = {
         const huntvis: HuntVis = check(checkVis, HuntVisValid);
 
         let closestNpc;
-        let closestDistance = distance;
+        let closestDistance = Number.MAX_SAFE_INTEGER;
 
         const npcs = new NpcIterator(World.currentTick, position.level, position.x, position.z, distance, huntvis, NpcIteratorType.DISTANCE);
 
         for (const npc of npcs) {
             if (npc && npc.type === npcType.id) {
-                const npcDistance = CoordGrid.distanceToSW(position, npc);
+                // Picks the smallest euclidean distance
+                const npcDistance = CoordGrid.euclideanSquaredDistance(position, npc);
                 if (npcDistance <= closestDistance) {
                     closestNpc = npc;
                     closestDistance = npcDistance;
@@ -306,7 +307,7 @@ const NpcOps: CommandHandlers = {
             state.pushInt(0);
             return;
         }
-        // not necessary but if we want to refer to the original npc again, we can
+
         state.activeNpc = closestNpc;
         state.pointerAdd(ActiveNpc[state.intOperand]);
         state.pushInt(1);
@@ -321,11 +322,6 @@ const NpcOps: CommandHandlers = {
         const huntvis: HuntVis = check(checkVis, HuntVisValid);
 
         state.npcIterator = new NpcIterator(World.currentTick, position.level, position.x, position.z, distance, huntvis, NpcIteratorType.DISTANCE);
-        // not necessary but if we want to refer to the original npc again, we can
-        if (state._activeNpc) {
-            state._activeNpc2 = state._activeNpc;
-            state.pointerAdd(ScriptPointer.ActiveNpc2);
-        }
     },
 
     [ScriptOpcode.NPC_FINDALL]: state => {
@@ -337,22 +333,12 @@ const NpcOps: CommandHandlers = {
         const huntvis: HuntVis = check(checkVis, HuntVisValid);
 
         state.npcIterator = new NpcIterator(World.currentTick, position.level, position.x, position.z, distance, huntvis, NpcIteratorType.DISTANCE, npcType);
-        // not necessary but if we want to refer to the original npc again, we can
-        if (state._activeNpc) {
-            state._activeNpc2 = state._activeNpc;
-            state.pointerAdd(ScriptPointer.ActiveNpc2);
-        }
     },
 
     [ScriptOpcode.NPC_FINDALLZONE]: state => {
         const coord: CoordGrid = check(state.popInt(), CoordValid);
 
         state.npcIterator = new NpcIterator(World.currentTick, coord.level, coord.x, coord.z, 0, 0, NpcIteratorType.ZONE);
-        // not necessary but if we want to refer to the original npc again, we can
-        if (state._activeNpc) {
-            state._activeNpc2 = state._activeNpc;
-            state.pointerAdd(ScriptPointer.ActiveNpc2);
-        }
     },
 
     [ScriptOpcode.NPC_FINDNEXT]: state => {

--- a/src/engine/script/handlers/ObjOps.ts
+++ b/src/engine/script/handlers/ObjOps.ts
@@ -5,6 +5,7 @@ import ParamType from '#/cache/config/ParamType.js';
 import { CoordGrid } from '#/engine/CoordGrid.js';
 import EntityLifeCycle from '#/engine/entity/EntityLifeCycle.js';
 import Obj from '#/engine/entity/Obj.js';
+import { ObjIterator } from '#/engine/script/ScriptIterators.js';
 import ScriptOpcode from '#/engine/script/ScriptOpcode.js';
 import { ActiveObj, ActivePlayer } from '#/engine/script/ScriptPointer.js';
 import { CommandHandlers } from '#/engine/script/ScriptRunner.js';
@@ -171,6 +172,24 @@ const ObjOps: CommandHandlers = {
         }
 
         state.activeObj = obj;
+        state.pointerAdd(ActiveObj[state.intOperand]);
+        state.pushInt(1);
+    },
+
+    [ScriptOpcode.OBJ_FINDALLZONE]: state => {
+        const coord: CoordGrid = check(state.popInt(), CoordValid);
+
+        state.objIterator = new ObjIterator(World.currentTick, coord.level, coord.x, coord.z);
+    },
+
+    [ScriptOpcode.OBJ_FINDNEXT]: state => {
+        const result = state.objIterator?.next();
+        if (!result || result.done) {
+            state.pushInt(0);
+            return;
+        }
+
+        state.activeObj = result.value;
         state.pointerAdd(ActiveObj[state.intOperand]);
         state.pushInt(1);
     }

--- a/src/engine/zone/Zone.ts
+++ b/src/engine/zone/Zone.ts
@@ -385,8 +385,8 @@ export default class Zone {
      * Generates npcs that are currently "visible" in this zone.
      * "visible" meaning they are active on the server and available to the client.
      */
-    *getAllNpcsSafe(): IterableIterator<Npc> {
-        for (const npc of this.npcs.all()) {
+    *getAllNpcsSafe(reverse: boolean = false): IterableIterator<Npc> {
+        for (const npc of this.npcs.all(reverse)) {
             if (npc.isValid()) {
                 yield npc;
             }
@@ -397,8 +397,8 @@ export default class Zone {
      * Generates all objs that are currently "visible" in this zone.
      * "visible" meaning they are active on the server and available to the client.
      */
-    *getAllObjsSafe(): IterableIterator<Obj> {
-        for (const obj of this.objs.all()) {
+    *getAllObjsSafe(reverse: boolean = false): IterableIterator<Obj> {
+        for (const obj of this.objs.all(reverse)) {
             if (obj.isValid()) {
                 yield obj;
             }
@@ -445,8 +445,8 @@ export default class Zone {
      * Generates all locs that are currently "visible" in this zone.
      * "visible" meaning they are active on the server and available to the client.
      */
-    *getAllLocsSafe(): IterableIterator<Loc> {
-        for (const loc of this.locs.all()) {
+    *getAllLocsSafe(reverse: boolean = false): IterableIterator<Loc> {
+        for (const loc of this.locs.all(reverse)) {
             if (loc.isValid()) {
                 yield loc;
             }
@@ -494,8 +494,8 @@ export default class Zone {
      * Does not guarantee that the npcs are currently "visible".
      * "visible" meaning they are active on the server and available to the client.
      */
-    *getAllNpcsUnsafe(): IterableIterator<Npc> {
-        for (const npc of this.npcs.all()) {
+    *getAllNpcsUnsafe(reverse: boolean = false): IterableIterator<Npc> {
+        for (const npc of this.npcs.all(reverse)) {
             yield npc;
         }
     }
@@ -505,8 +505,8 @@ export default class Zone {
      * Does not guarantee that the players are currently "visible".
      * "visible" meaning they are active on the server and available to the client.
      */
-    *getAllPlayersUnsafe(): IterableIterator<Player> {
-        for (const player of this.players.all()) {
+    *getAllPlayersUnsafe(reverse: boolean = false): IterableIterator<Player> {
+        for (const player of this.players.all(reverse)) {
             yield player;
         }
     }

--- a/src/engine/zone/Zone.ts
+++ b/src/engine/zone/Zone.ts
@@ -373,8 +373,8 @@ export default class Zone {
      * Generates players that are currently "visible" in this zone.
      * "visible" meaning they are active on the server and available to the client.
      */
-    *getAllPlayersSafe(): IterableIterator<Player> {
-        for (const player of this.players.all()) {
+    *getAllPlayersSafe(reverse: boolean = false): IterableIterator<Player> {
+        for (const player of this.players.all(reverse)) {
             if (player.isValid()) {
                 yield player;
             }


### PR DESCRIPTION
So a few things here:
- All entity lookups now iterate in 'reverse' order. This matches OSRS targeting
- There are two new commands: 
  - `obj_findallzone` mirrors `loc_findallzone` behavior but for `Obj`s
  - `npc_hunt` mirrors `npc_find` but it checks if the `Npc` is attackable
- `npc_hunt` and `npc_find` now will return the `Npc` with the shortest Euclidean distance, which matches osrs behavior
- Dwarf multicannon now uses `npc_hunt` to do its targeting. This allows the cannon to fully match osrs behavior for targeting

Here's some stuff from osrs:

### OSRS stuff

Dwarf cannon priority map showing Euclidean distance
![image](https://github.com/user-attachments/assets/038d22fd-069d-4dba-804b-ec917c13ce15)

Barb assault cannon priority map showing Euclidean distance
![image](https://github.com/user-attachments/assets/38260c19-2878-43ac-aa6b-2b3749e68bf7)

A fun osrs clip that you can make sense of if you want (04 will match this behavior and others)
https://github.com/user-attachments/assets/9f978491-596d-429c-9f32-849b9d9d407e






