### PR TITLE
fix(content): Gertrude won't override your overgrown cat

### DIFF
--- a/data/src/scripts/areas/area_varrock/scripts/gertrude.rs2
+++ b/data/src/scripts/areas/area_varrock/scripts/gertrude.rs2
@@ -74,7 +74,7 @@ switch_int (%fluffs_progress) {
             ~chatplayer("<p,neutral>Hey thanks Gertrude.");
             return;
         } //this is guessed off RSC. assuming her post-quest dialogue was changed later on.
-        if(inv_totalcat(inv, kitten) > 0 | inv_totalcat(bank, kitten) > 0 | inv_totalcat(inv, cat) > 0 | inv_totalcat(bank, cat) > 0 | %follower_obj ! null & oc_category(%follower_obj) = kitten | %follower_obj ! null & oc_category(%follower_obj) = cat) {
+        if(inv_totalcat(inv, kitten) > 0 | inv_totalcat(bank, kitten) > 0 | inv_totalcat(inv, cat) > 0 | inv_totalcat(bank, cat) > 0 | %follower_obj ! null & oc_category(%follower_obj) = kitten | %follower_obj ! null & oc_category(%follower_obj) = cat | %follower_obj ! null & oc_category(%follower_obj) = overgrown) {
             ~chatplayer("<p,neutral>Hello again Gertrude.");
             ~chatnpc("<p,neutral>Well hello adventurer, how are you?");
             ~chatplayer("<p,neutral>Pretty good, thanks. Yourself?");


### PR DESCRIPTION
Added a check to see if you have an overgrown cat following you when talking to Gertrude. 

I haven't been able to find any sources of this bug but here's some saying you can't have two cats following you at once so I'm guessing just checking your follower is correct for the time: 

https://www.neoseeker.com/forums/2410/t537652-kittens/#m8451857

https://www.neoseeker.com/forums/2410/t646414-cats-dying/#m10567110