### PR TITLE
fix(content): static flax times, tourist trap typo, fight arena changes

### DIFF
--- a/data/src/pack/npc.pack
+++ b/data/src/pack/npc.pack
@@ -841,7 +841,7 @@
 840=ugthanki
 841=mine_cart_driver
 842=rowdy_guard
-843=rdpt_employee
+843=rpdt_employee
 844=wizard_cromperty
 845=horacio
 846=kangai_mau

--- a/data/src/scripts/areas/area_ardougne_east/configs/ardougne_east.npc
+++ b/data/src/scripts/areas/area_ardougne_east/configs/ardougne_east.npc
@@ -521,7 +521,7 @@ head3=model_80_idk_head
 wanderrange=0
 moverestrict=nomove
 
-[rdpt_employee]
+[rpdt_employee]
 vislevel=hide
 name=RPDT employee
 desc=Inefficient looking.

--- a/data/src/scripts/areas/area_ardougne_east/scripts/rdpt_employee.rs2
+++ b/data/src/scripts/areas/area_ardougne_east/scripts/rdpt_employee.rs2
@@ -1,5 +1,5 @@
-[opnpc1,rdpt_employee]
-~chatnpc("<p,neutral>Welcome to RDPT!");
+[opnpc1,rpdt_employee]
+~chatnpc("<p,neutral>Welcome to RPDT!");
 if(%totem_progress = ^totem_crate_marked) {
     def_int $option = ~p_choice2("So, when are you going to deliver this crate?", 1, "Thank you, it's interesting in here.", 2);
     if($option = 1) {

--- a/data/src/scripts/areas/area_ardougne_east/scripts/wizard_cromperty.rs2
+++ b/data/src/scripts/areas/area_ardougne_east/scripts/wizard_cromperty.rs2
@@ -52,7 +52,7 @@ if($option = 1) {
     ~chatplayer("<p,neutral>Yes, that sounds good. Teleport me!");
     ~chatnpc("<p,happy>Okey dokey! Ready?");
     if(%totem_progress < ^totem_complete) {
-        @rdpt_teleport;
+        @rpdt_teleport;
     }
     ~chatnpc("<p,confused>Hmm.... that's odd... I can't seem to get a signal...");
 } else if($option = 2) {
@@ -60,7 +60,7 @@ if($option = 1) {
     ~chatnpc("<p,neutral>As you wish.");
 }
 
-[label,rdpt_teleport]
+[label,rpdt_teleport]
 if_close;
 npc_say("Dipsolum sententa sententi!");
 spotanim_pl(curse_impact, 124, 70);

--- a/data/src/scripts/general_use/scripts/pickables.rs2
+++ b/data/src/scripts/general_use/scripts/pickables.rs2
@@ -62,8 +62,5 @@ if(inv_freespace(inv) = 0) {
     sound_synth(pick, 0, 0);
     mes("You pick some flax.");
     inv_add(inv, flax, 1);
-
-    def_int $respawnrate = 20;
-    $respawnrate = ~scale_by_playercount($respawnrate);
-    loc_del($respawnrate);
+    loc_del(25); // 10t after update
 }

--- a/data/src/scripts/quests/quest_arena/scripts/fightslave.rs2
+++ b/data/src/scripts/quests/quest_arena/scripts/fightslave.rs2
@@ -26,13 +26,13 @@ switch_int(%arena_progress) {
     case ^arena_obtained_armour, ^arena_spoken_drunkguard, ^arena_given_khali_brew, ^arena_entered_ogre_fight :
         if(~wearing_khazard_armour = true) {
             if (.npc_find(coord, $partner, 3, 0) = true) { // uses other set if greater than 2 away in RS3
-                ~chatplayer("<p,quiz>Do either of you know a Justin or Sammy Servil?");
+                ~chatplayer("<p,quiz>Do either of you know a Justin or Jeremy Servil?");
                 ~chatnpc("<p,angry>If we did, why would we tell you guard?");
                 ~.chatnpc("<p,angry>Until our last breath, our every action will be against Khazard. Never will we help you.");
                 ~chatnpc("<p,angry>I spit on Khazard's grave, and all who do his bidding.");
                 return;
             }
-            ~chatplayer("<p,quiz>Do you know a Justin or Sammy Servil?");
+            ~chatplayer("<p,quiz>Do you know a Justin or Jeremy Servil?");
             ~chatnpc("<p,angry>If I did, why would I tell you guard?");
         } else {
             if (.npc_find(coord, $partner, 3, 0) = true) { // uses other set if greater than 2 away in RS3
@@ -42,7 +42,7 @@ switch_int(%arena_progress) {
                 ~chatnpc("<p,bored>You're a brave <text_gender("man", "woman")>. If the guards get you, you'll be in here next.");
                 return;
             }
-            ~chatplayer("<p,quiz>Do you know a Justin or Sammy Servil?");
+            ~chatplayer("<p,quiz>Do you know a Justin or Jeremy Servil?");
             ~chatnpc("<p,bored>I have heard of those of whom you speak. But I fear it may be too late.");
         }
 }

--- a/data/src/scripts/quests/quest_arena/scripts/jeremy_servil.rs2
+++ b/data/src/scripts/quests/quest_arena/scripts/jeremy_servil.rs2
@@ -94,19 +94,19 @@ npc_del;
 [label,ogre_attack_justin]
 if_close;
 def_coord $ogre_to = 0_40_49_46_29;
-if (npc_find(movecoord(coord, 0, 0, 8), khazard_ogre, 14, 0) = true) {
+if (npc_find($ogre_to, khazard_ogre, 14, 0) = true) {
     if(npc_getmode = none) { // npc in cutscene already, do nothing
         return;
     } else if(inzone(0_40_49_47_29, 0_40_49_49_30, npc_coord) = false) {
-        if(add(%npc_lastcombat, 8) > map_clock) {
+        if(add(%npc_lastcombat, 8) <= map_clock) {
             // out of combat and out of cage so attack player, otherwise we'll just set ptr and start cutscene
             ~npc_retaliate(0);
             return;
         }
-        npc_add($ogre_to, khazard_ogre, 500);
+        npc_add(movecoord($ogre_to, 1, 0, 0), khazard_ogre, 500);
     }
 } else {
-    npc_add($ogre_to, khazard_ogre, 500);
+    npc_add(movecoord($ogre_to, 1, 0, 0), khazard_ogre, 500);
 }
 def_int $delay = distance(npc_coord, movecoord($ogre_to, 2, 0, 0));
 if (.npc_find(movecoord(coord, 0, 0, 8), justin_servil, 14, 0) = true) {
@@ -128,29 +128,21 @@ if(loc_find(0_40_49_46_29, loc_78) = true & .loc_find(0_40_49_46_30, loc_77) = t
     .loc_del(6);
     .loc_add(movecoord(.loc_coord, 1, 0, 0), .loc_type, 1, .loc_shape, 6);
 }
-npc_tele($ogre_to);
-npc_queue(10, 0, 1);
+npc_walk(0_40_49_44_32);
 p_delay(2);
 cam_reset;
 cam_lookat(0_40_49_40_32, 270, 2, 1);
-p_delay(6);
-cam_reset;
-
-[ai_queue10,khazard_ogre]
-npc_walk(0_40_49_44_32);
-npc_queue(11, 0, 4);
-
-[ai_queue11,khazard_ogre]
+p_delay(1);
 npc_walk(0_40_49_41_32);
-npc_queue(12, 0, 3);
-
-[ai_queue12,khazard_ogre]
+p_delay(3);
 npc_anim(npc_param(attack_anim), 0);
 npc_setmode(null);
-if (.npc_find(npc_coord, justin_servil, 1, 0) = true) {
+if (.npc_findexact(0_40_49_40_32, justin_servil) = true) {
     .npc_anim(human_defend_cowardly, 0);
     .npc_setmode(null);
 }
+p_delay(0);
+cam_reset;
 
 [ai_queue10,jeremy_servil]
 npc_walk(0_40_49_56_31);

--- a/data/src/scripts/quests/quest_arena/scripts/quest_arena.rs2
+++ b/data/src/scripts/quests/quest_arena/scripts/quest_arena.rs2
@@ -194,25 +194,26 @@ if (%arena_progress = ^arena_defeated_ogre & npc_find(coord, general_khazard, 8,
 // again, guessed numbers
 if_close;
 def_coord $cam_coord = 0_40_49_39_23;
+def_coord $scorp_spawn = 0_40_49_47_23;
 if (npc_find(movecoord(coord, 0, 0, 8), khazard_scorpion, 14, 0) = true) {
     if(npc_getmode = none) { // npc in cutscene already, do nothing
         return;
-    } else if(inzone(0_40_49_47_23, 0_40_49_49_24, npc_coord) = false) {
-        if(add(%npc_lastcombat, 8) > map_clock) {
+    } else if(inzone($scorp_spawn, 0_40_49_49_24, npc_coord) = false) {
+        if(add(%npc_lastcombat, 8) <= map_clock) {
             // out of combat and out of cage so attack player, otherwise we'll just set ptr and start cutscene
             ~npc_retaliate(0);
             return;
         }
-        npc_add(0_40_49_47_23, khazard_scorpion, 500);
+        npc_add($scorp_spawn, khazard_scorpion, 500);
     }
 } else {
-    npc_add(0_40_49_47_23, khazard_scorpion, 500);
+    npc_add($scorp_spawn, khazard_scorpion, 500);
 }
 npc_setmode(none);
 cam_moveto(0_40_49_35_23, 700, 0, 100);
-cam_lookat(0_40_49_47_23, 100, 0, 100);
+cam_lookat($scorp_spawn, 100, 0, 100);
 cam_moveto(0_40_49_41_23, 450, 4, 2);
-npc_walk(0_40_49_47_23);
+npc_walk($scorp_spawn);
 p_delay(2);
 if(loc_find(0_40_49_46_23, loc_78) = true & .loc_find(0_40_49_46_24, loc_77) = true) {
     // Temp note: dur updated
@@ -230,25 +231,26 @@ cam_reset;
 // again, guessed numbers
 if_close;
 def_coord $cam_coord = 0_40_49_39_23;
-if (npc_find(movecoord(coord, 0, 0, 8), bouncer, 14, 0) = true) {
+def_coord $bouncer_spawn = 0_40_49_47_26;
+if (npc_find($bouncer_spawn, bouncer, 14, 0) = true) {
     if(npc_getmode = none) { // npc in cutscene already, do nothing
         return;
-    } else if(inzone(0_40_49_47_26, 0_40_49_49_27, npc_coord) = false) {
-        if(add(%npc_lastcombat, 8) > map_clock) {
+    } else if(inzone($bouncer_spawn, 0_40_49_49_27, npc_coord) = false) {
+        if(add(%npc_lastcombat, 8) <= map_clock) {
             // out of combat and out of cage so attack player, otherwise we'll just set ptr and start cutscene
             ~npc_retaliate(0);
             return;
         }
-        npc_add(0_40_49_47_26, bouncer, 500);
+        npc_add($bouncer_spawn, bouncer, 500);
     }
 } else {
-    npc_add(0_40_49_47_26, bouncer, 500);
+    npc_add($bouncer_spawn, bouncer, 500);
 }
 npc_setmode(none);
 cam_moveto(0_40_49_35_26, 700, 0, 100);
-cam_lookat(0_40_49_47_26, 100, 0, 100);
+cam_lookat($bouncer_spawn, 100, 0, 100);
 cam_moveto(0_40_49_41_26, 450, 4, 2);
-npc_walk(0_40_49_47_26);
+npc_walk($bouncer_spawn);
 p_delay(2);
 if(loc_find(0_40_49_46_26, loc_78) = true & .loc_find(0_40_49_46_27, loc_77) = true) {
     // Temp note: dur updated

--- a/data/src/scripts/quests/quest_arena/scripts/quest_arena.rs2
+++ b/data/src/scripts/quests/quest_arena/scripts/quest_arena.rs2
@@ -195,7 +195,7 @@ if (%arena_progress = ^arena_defeated_ogre & npc_find(coord, general_khazard, 8,
 if_close;
 def_coord $cam_coord = 0_40_49_39_23;
 def_coord $scorp_spawn = 0_40_49_47_23;
-if (npc_find(movecoord(coord, 0, 0, 8), khazard_scorpion, 14, 0) = true) {
+if (npc_find($scorp_spawn, khazard_scorpion, 14, 0) = true) {
     if(npc_getmode = none) { // npc in cutscene already, do nothing
         return;
     } else if(inzone($scorp_spawn, 0_40_49_49_24, npc_coord) = false) {

--- a/data/src/scripts/quests/quest_desertrescue/scripts/camp_guard.rs2
+++ b/data/src/scripts/quests/quest_desertrescue/scripts/camp_guard.rs2
@@ -104,7 +104,7 @@ if_close;
 
 [label,camp_merc_minearea]
 ~chatplayer("<p,neutral>I'd like to mine in a different area.");
-~chatnpc("<p,happy>Oh, you want to work in another area of the mine eh? @dbl@--The guard seems pleased with his rhetorical @dbl@question.-- @bla@Well, I can understand that! A change is as good as a@bla@rest they say.");
+~chatnpc("<p,happy>Oh, you want to work in another area of the mine eh? @dbl@--The guard seems pleased with his rhetorical @dbl@question.-- @bla@Well, I can understand that! A change is as good as a @bla@rest they say.");
 switch_int(~p_choice2("Huh, fat chance of a rest for me.", 1, "Yes sir, you're quite right sir.", 2)) {
     case 1 :
         ~chatplayer("<p,neutral>Huh, fat chance of a rest for me.");

--- a/data/src/scripts/quests/quest_ikov/scripts/guardian_of_armadyl.rs2
+++ b/data/src/scripts/quests/quest_ikov/scripts/guardian_of_armadyl.rs2
@@ -66,7 +66,7 @@ switch_int(~p_choice3("What is the Armadyl?", 1, "Who are the Mahjarrat?", 2, "W
     case 1 :
         ~chatplayer("<p,confused>What is the Armadyl?");
         ~chatnpc("<p,happy>Armadyl is the god we serve. We have been charged with guarding his sacred arctifacts until he requires them.");
-        switch_int(~p_choice2("Ah ok, thanks.", 2, "Someone told me there were only three gods.", 2)) {
+        switch_int(~p_choice2("Ah ok, thanks.", 1, "Someone told me there were only three gods.", 2)) {
             case 1 :
                 ~chatplayer("<p,confused>Ah ok, thanks.");
                 ~chatnpc("<p,happy>Go in peace.");


### PR DESCRIPTION
- change flax respawn times to be static (matches OSRS and old videos)
- fix a typo in the tourist trap quest
- change the ogre cutscene in fight arena to stop using npc_queue, fix the reversed conditions used for checking if the npcs are out of combat