### PR TITLE
fix(engine): send tabs on reconnect

### DIFF
--- a/src/engine/entity/Player.ts
+++ b/src/engine/entity/Player.ts
@@ -530,6 +530,10 @@ export default class Player extends PathingEntity {
             this.write(new UpdateRebootTimer(ticksBeforeShutdown));
         }
         this.closeModal();
+        // tabs could have been updated while reconnecting, make sure we sync them now
+        for (let i = 0; i < this.tabs.length; i++) {
+            this.write(new IfSetTab(i, this.tabs[i]));
+        }
         this.refreshInvs();
         for (let i = 0; i < this.stats.length; i++) {
             this.write(new UpdateStat(i, this.stats[i], this.levels[i]));


### PR DESCRIPTION
Tabs could have been updated while reconnecting, leaving clients in a broken tab state upon login

ie: disconnected while travelling to Entrana
![image](https://github.com/user-attachments/assets/87dd255a-510e-420d-bf58-0a4d653a5875)