### PR TITLE
fix(content): lucien door and death, kangai mau dialogue typo

### DIFF
--- a/data/src/scripts/areas/area_brimhaven/scripts/kangai_mau.rs2
+++ b/data/src/scripts/areas/area_brimhaven/scripts/kangai_mau.rs2
@@ -54,7 +54,7 @@ if($option = 1) {
 
 [label,kangai_mau_house]
 ~chatplayer("<p,neutral>How can I find Handelmort's house? Ardougne IS a big place...");
-~chatnpc("<p,neutral>I dont know Ardougne. You tell me.");
+~chatnpc("<p,neutral>I don't know Ardougne. You tell me.");
 @multi2("Ok, I will get it back.", kangai_mau_start_totem, "Why does he have it?", kangai_mau_why);
 
 [label,kangai_mau_totem_back]

--- a/data/src/scripts/quests/quest_ikov/scripts/lucien.rs2
+++ b/data/src/scripts/quests/quest_ikov/scripts/lucien.rs2
@@ -106,10 +106,13 @@ if(%ikov_progress <= ^ikov_helping_armadyl) { // guessing...
 ~chatnpc("<p,neutral>Well if you see any be sure to point them in my direction.");
 
 [ai_queue3,lucien_edge]
-if(npc_findhero = true) {
+if(npc_findhero = true & %ikov_progress = ^ikov_helping_armadyl) {
     if_close;
+    npc_setmode(none);
     queue(queue_defeat_lucien, 0, npc_uid);
+    return;
 }
+gosub(npc_death);
 
 [queue,queue_defeat_lucien](npc_uid $npc)
 if (npc_finduid($npc) = true) {

--- a/data/src/scripts/quests/quest_ikov/scripts/quest_ikov.rs2
+++ b/data/src/scripts/quests/quest_ikov/scripts/quest_ikov.rs2
@@ -1,6 +1,6 @@
 [oploc1,loc_102]
 if(%ikov_progress >= ^ikov_started) {
-    ~open_and_close_door2(loc_1532, ~check_axis_locactive(coord), door_open);
+    ~open_and_close_door2(loc_1538, ~check_axis_locactive(coord), door_open);
     return;
 }
 // https://www.youtube.com/watch?v=-tsHE3OEuYk&t=126s
@@ -74,15 +74,3 @@ stat_advance(ranged, 105000);
 stat_advance(fletching, 80000);
 session_log(^log_adventure, "Quest complete: Temple of Ikov (Lucien)");
 ~send_quest_complete(questlist:ikov, yew_longbow, 250, ^ikov_questpoints, "You have completed the\\nTemple of Ikov Quest for Lucien!");
-
-[debugproc,ikov_reset]
-if(p_finduid(uid) = false) {
-    return;
-}
-mes("Resetting all varps affected by ikov update");
-%ikov_dungeon = 0;
-%ikov_icearrowchest_coord = null;
-%haunted_lever = 0;
-%haunted_manor_fountain_poisoned = 0;
-%cog_cooled = 0;
-

--- a/data/src/scripts/skill_herblore/configs/brewing/potions.obj
+++ b/data/src/scripts/skill_herblore/configs/brewing/potions.obj
@@ -855,7 +855,7 @@ category=category_69
 members=yes
 param=next_obj_stage,3dose1restore
 param=decant_potion_enum,potion_1restore
-param=dose_count,1
+param=dose_count,4
 // jagex name
 
 [4dose1defense]


### PR DESCRIPTION
- fix incorrect open door being used for luciens house
- stop lucien from attacking you after ai_queue3 runs, also add another check to the queue for safety
- fix typo in kangai mau's dialogue