### PR TITLE
fix(content): last knife/dart does unarmed animation

### DIFF
--- a/data/src/scripts/skill_combat/scripts/player/player_ranged.rs2
+++ b/data/src/scripts/skill_combat/scripts/player/player_ranged.rs2
@@ -60,9 +60,9 @@ if ($damage > 0 & $poison_severity > 0 & random(8) = 0) { // 1/8 chance to poiso
 }
 
 //mes("attackstyle: <tostring(%attackstyle)>, damagestyle: <tostring(%damagestyle)>, damage: <tostring($damage)>, damagetype: <tostring(%damagetype)>");
-def_int $delay = add(~player_ranged_use_weapon($rhand, $ammo), 30); // osrs it seems to be delayed an extra tick
 anim(%com_attackanim, 0);
 sound_synth(%com_attacksound, 0, 0);
+def_int $delay = add(~player_ranged_use_weapon($rhand, $ammo), 30); // osrs it seems to be delayed an extra tick
 ~npc_retaliate(calc($delay / 30));
 npc_queue(2, $damage, calc($delay / 30));
 npc_anim(npc_param(defend_anim), sub($delay, 30)); // delay npc this tick


### PR DESCRIPTION
The ~update_all proc in:

https://github.com/2004Scape/Server/blob/728267a226bdefb858a153660b16d3706a2b4824/data/src/scripts/skill_combat/scripts/player/player_ranged.rs2#L122-L125

Sets the %com values to unarmed... so anim() and sound_synth need to go before this