### PR TITLE
fix(content): Missing ophelds

### DIFF
--- a/data/src/scripts/areas/area_alkharid/scripts/shantay.rs2
+++ b/data/src/scripts/areas/area_alkharid/scripts/shantay.rs2
@@ -1,4 +1,10 @@
 [opnpc1,shantay]
+//guess based on osrs. Averaged about 100 talks between each drop.
+if(random(100) = 0) {
+    mes("Something drops out of Shantay's pocket onto the floor.");
+    mes("It looks like a piece of paper.");
+    obj_add(npc_coord, thkebabinstructs, 1, ^lootdrop_duration);
+}
 if (%shantay_jail_progress = ^not_talked_to_shantay) {
     ~chatnpc("<p,neutral>Hello effendi, I am Shantay.");
     ~chatnpc("<p,neutral>I see you're new. Please read the billboard poster|before going into the desert. It'll give yer details on the|dangers you can face.");

--- a/data/src/scripts/areas/area_alkharid/scripts/shantay_pass.rs2
+++ b/data/src/scripts/areas/area_alkharid/scripts/shantay_pass.rs2
@@ -122,3 +122,9 @@ p_telejump(movecoord(coord, 0, 0, -3));
 // todo: Find a screenshot of this
 [opheld1,thshantaydisc]
 ~mesbox("The Desert is a VERY Dangerous place. Do not enter if|you are scared of dying. Beware of high temperatures,|sand storms, robbers, and slavers."); // complete guess
+
+//guess, matches osrs dialogue
+[opheld1,thkebabinstructs]
+~objbox(thkebabinstructs, "*** Delicious Ugthanki Kebab *** Ingredients: Cooked Ugthanki meat, Flour, Water, Onion, Tomato. The Ugthanki meat should be nicely grilled.", 200, 0, 0);
+~objbox(thkebabinstructs, "Next take the flour and water and make some Pitta Bread. You'll need a range to do this.Take an onion and chop it into a bowl. Take a tomato and chop it into the onion mixture.", 200, 0, 0);
+~objbox(thkebabinstructs, "Chop the meat into the Onion and Tomato mixture. Finally fill the pitta bread with the Ugthanki, Onion and Tomato mixture to make your delicious Ugthanki Kebab.", 200, 0, 0);

--- a/data/src/scripts/skill_cooking/scripts/cooking_inv/scripts/stew/stew.rs2
+++ b/data/src/scripts/skill_cooking/scripts/cooking_inv/scripts/stew/stew.rs2
@@ -72,3 +72,8 @@ inv_del(inv, spicespot, 1);
 
 inv_add(inv, uncooked_curry, 1);
 mes("You add the spice to the stew and make a curry.");
+
+[opheld1,burnt_curry]
+inv_del(inv, burnt_curry, 1);
+inv_add(inv, bowl_empty, 1);
+mes("You empty the burnt curry from the bowl.");


### PR DESCRIPTION
This covers the rest of the ophelds we are missing. Some guessing based on osrs.

Doesn't include the following:
display_tea (unobtainable)
tray_gold, (unobtainable? I couldn't find anything about this obj)
obj_2715, obj_2718, obj_2721 (not used)

![image](https://github.com/user-attachments/assets/688a2a91-b0aa-48b5-bed7-dd6755ebb2d9)
