### PR TITLE
fix(content): extra stage check on orb of protection chest

### DIFF
--- a/data/src/scripts/quests/quest_tree/scripts/quest_tree.rs2
+++ b/data/src/scripts/quests/quest_tree/scripts/quest_tree.rs2
@@ -75,7 +75,7 @@ if(npc_find(coord, khazard_commander, 5, 0) = true) {
 }
 
 [oploc1,loc_2182]
-if(%tree_progress > ^tree_retrieved_orb | inv_total(inv, orb_of_protection) > 0 | inv_total(bank, orb_of_protection) > 0) {
+if(%tree_progress < ^tree_ballista_fired | %tree_progress > ^tree_retrieved_orb | inv_total(inv, orb_of_protection) > 0 | inv_total(bank, orb_of_protection) > 0) {
     mes("You search the chest, but find nothing.");
     return;
 }


### PR DESCRIPTION
This chest is also placed in west ardougne and can be accessed before firing the ballista during the quest, and you can still get the orb from it (confirmed on RS3)