### PR TITLE
chore(engine): Housekeeping for reset defaults

### DIFF
--- a/src/engine/entity/Npc.ts
+++ b/src/engine/entity/Npc.ts
@@ -146,7 +146,7 @@ export default class Npc extends PathingEntity {
             }
 
             this.varsString.fill(undefined);
-            this.defaultMode();
+            this.resetDefaults();
 
             const npcType: NpcType = NpcType.get(this.type);
             this.huntrange = npcType.huntrange;
@@ -421,6 +421,7 @@ export default class Npc extends PathingEntity {
             return;
         }
 
+        // Fail safe
         if (this.targetOp === NpcMode.NULL) {
             const type: NpcType = NpcType.get(this.type);
             this.targetOp = type.defaultmode;
@@ -456,7 +457,7 @@ export default class Npc extends PathingEntity {
         this.masks |= NpcInfoProt.FACE_ENTITY;
     }
 
-    defaultMode(): void {
+    resetDefaults(): void {
         this.clearInteraction();
         const type: NpcType = NpcType.get(this.type);
         this.targetOp = type.defaultmode;
@@ -522,7 +523,7 @@ export default class Npc extends PathingEntity {
 
     playerEscapeMode(): void {
         if (!this.validateTarget() || !this.targetWithinMaxRange()) {
-            this.defaultMode();
+            this.resetDefaults();
             return;
         }
 
@@ -531,7 +532,7 @@ export default class Npc extends PathingEntity {
         }
 
         if (CoordGrid.distanceToSW(this, this.target) > 25) {
-            this.defaultMode();
+            this.resetDefaults();
             return;
         }
 
@@ -555,7 +556,7 @@ export default class Npc extends PathingEntity {
         const mz: number = CoordGrid.moveZ(this.z, direction);
 
         if (isFlagged(mx, mz, this.level, flags)) {
-            this.defaultMode();
+            this.resetDefaults();
             return;
         }
 
@@ -582,7 +583,7 @@ export default class Npc extends PathingEntity {
 
     playerFollowMode(): void {
         if (!this.validateTarget() || !this.targetWithinMaxRange()) {
-            this.defaultMode();
+            this.resetDefaults();
             return;
         }
         const player = this.target;
@@ -601,7 +602,7 @@ export default class Npc extends PathingEntity {
 
     playerFaceMode(): void {
         if (!this.validateTarget()) {
-            this.defaultMode();
+            this.resetDefaults();
             return;
         }
 
@@ -610,21 +611,21 @@ export default class Npc extends PathingEntity {
         }
 
         if (this.level !== this.target.level) {
-            this.defaultMode();
+            this.resetDefaults();
             return;
         }
 
         const type = NpcType.get(this.type);
 
         if (CoordGrid.distanceTo(this, this.target) > type.maxrange) {
-            this.defaultMode();
+            this.resetDefaults();
             return;
         }
     }
 
     playerFaceCloseMode(): void {
         if (!this.validateTarget()) {
-            this.defaultMode();
+            this.resetDefaults();
             return;
         }
 
@@ -633,12 +634,12 @@ export default class Npc extends PathingEntity {
         }
 
         if (this.level !== this.target.level) {
-            this.defaultMode();
+            this.resetDefaults();
             return;
         }
 
         if (CoordGrid.distanceTo(this, this.target) > 1) {
-            this.defaultMode();
+            this.resetDefaults();
             return;
         }
     }
@@ -646,7 +647,7 @@ export default class Npc extends PathingEntity {
     aiMode(): void {
         const type: NpcType = NpcType.get(this.type);
         if (!this.target || !this.target.isValid() || this.target.level !== this.level || !this.targetWithinMaxRange()) {
-            this.defaultMode();
+            this.resetDefaults();
             return;
         }
 
@@ -659,7 +660,7 @@ export default class Npc extends PathingEntity {
 
         // Clear target if givechase=no
         if (moved && !type.givechase) {
-            this.defaultMode();
+            this.resetDefaults();
             return;
         }
 
@@ -693,7 +694,7 @@ export default class Npc extends PathingEntity {
         }
         if (this.inOperableDistance(this.target)) {
             // this.target = null;
-            this.defaultMode();
+            this.resetDefaults();
             return true;
         }
         return false;

--- a/src/engine/entity/Npc.ts
+++ b/src/engine/entity/Npc.ts
@@ -466,6 +466,7 @@ export default class Npc extends PathingEntity {
 
         const npcType: NpcType = NpcType.get(this.type);
         this.huntMode = npcType.huntmode;
+        this.huntrange = npcType.huntrange;
         this.huntClock = 0;
         this.huntTarget = null;
         // Reset timer interval

--- a/src/engine/script/handlers/NpcOps.ts
+++ b/src/engine/script/handlers/NpcOps.ts
@@ -191,9 +191,12 @@ const NpcOps: CommandHandlers = {
     [ScriptOpcode.NPC_SETMODE]: checkedHandler(ActiveNpc, state => {
         const mode = check(state.popInt(), NpcModeValid);
 
-        if (mode === NpcMode.NULL || mode === NpcMode.NONE || mode === NpcMode.WANDER || mode === NpcMode.PATROL) {
+        if (mode === NpcMode.NONE || mode === NpcMode.WANDER || mode === NpcMode.PATROL) {
             state.activeNpc.clearInteraction();
             state.activeNpc.targetOp = mode;
+            return;
+        } else if (mode === NpcMode.NULL) {
+            state.activeNpc.resetDefaults();
             return;
         }
         state.activeNpc.targetOp = mode;


### PR DESCRIPTION
Reverts a small change from https://github.com/2004Scape/Server/pull/1613 . Some content was relying on `npc_setmode(null)` to clean up a bunch of npc variables. The previous PR took that behavior away, but this PR adds it back

We might revisit this in the future and flesh it out a bit more. It's a little unintuitive that `npc_setmode(null)`  should have a bunch of side effects. It's possible that jagex uses a command like `npc_reset()` to achieve this behavior instead. Further, there's a few examples where we *do not* want this side effect, like failing a pickpocket, which is why the side effect was removed in the first place

For now, failing a pickpocket will reset a bunch of Npc state (inauthentically) until we can revisit this. This PR is essentially a temporary solution for tomorrow's update, because some content like gnomeball was relying on this behavior

I took this opportunity to rename `defaultMode` to `resetDefaults` also