### PR TITLE
fix(content): Arrows despawning too fast from ground

### DIFF
--- a/data/src/pack/loc.pack
+++ b/data/src/pack/loc.pack
@@ -2209,7 +2209,7 @@
 2208=loc_2208
 2209=loc_2209
 2210=loc_2210
-2211=loc_2211
+2211=grave_of_scorpius
 2212=loc_2212
 2213=bankbooth
 2214=loc_2214

--- a/data/src/scripts/_unpack/all.loc
+++ b/data/src/scripts/_unpack/all.loc
@@ -11528,14 +11528,6 @@ sharelight=yes
 hillskew=yes
 op1=Squeeze-through
 
-[loc_2211]
-name=Grave of Scorpius
-desc=A weathered old gravestone.
-model=model_loc_406
-width=2
-length=2
-op1=Read
-
 [loc_2212]
 name=Sack
 desc=It's a sack!

--- a/data/src/scripts/drop tables/scripts/chaos_druid.rs2
+++ b/data/src/scripts/drop tables/scripts/chaos_druid.rs2
@@ -40,8 +40,7 @@ if ($random < 7)  {
     obj_add(npc_coord, bronze_longsword, 1, ^lootdrop_duration);
 } else if ($random < 89) {
     obj_add(npc_coord, snape_grass, 1, ^lootdrop_duration);
-} else if ($random < 90) {
-    // todo - only if Observatory Quest is complete.
+} else if ($random < 90 & %itgronigen_progress >= ^itgronigen_complete) {
     obj_add(npc_coord, unholy_mould, 1, ^lootdrop_duration);
 } else if ($random < 91) {
     obj_add(npc_coord, ~randomjewel, ^lootdrop_duration);

--- a/data/src/scripts/quests/quest_itgronigen/configs/grave_of_scorpius.loc
+++ b/data/src/scripts/quests/quest_itgronigen/configs/grave_of_scorpius.loc
@@ -1,0 +1,7 @@
+[grave_of_scorpius]
+name=Grave of Scorpius
+desc=A weathered old gravestone.
+model=model_loc_406
+width=2
+length=2
+op1=Read

--- a/data/src/scripts/quests/quest_itgronigen/scripts/grave_of_scorpius.rs2
+++ b/data/src/scripts/quests/quest_itgronigen/scripts/grave_of_scorpius.rs2
@@ -1,0 +1,2 @@
+[oploc1,grave_of_scorpius]
+~mesbox("Here lies Scorpius: Only those who have seen beyond the stars may seek his counsel.");

--- a/data/src/scripts/skill_combat/scripts/player/player_ranged.rs2
+++ b/data/src/scripts/skill_combat/scripts/player/player_ranged.rs2
@@ -119,6 +119,6 @@ return(~npc_projectile(coord, npc_uid, oc_param($ammo, proj_travel), 40, 36, 32,
 if (random($chance) ! 0 | $chance = ^true) {
     world_delay($delay);
     if (map_blocked(npc_coord) = false) {
-        obj_add(npc_coord, enum(obj, namedobj, ranged_ammo, $ammo), 1, 100);
+        obj_add(npc_coord, enum(obj, namedobj, ranged_ammo, $ammo), 1, 200);
     }
 }

--- a/data/src/scripts/skill_combat/scripts/pvp/pvp_ranged.rs2
+++ b/data/src/scripts/skill_combat/scripts/pvp/pvp_ranged.rs2
@@ -92,6 +92,6 @@ if (~in_duel_arena(coord) = true) {
 if (random($chance) ! 0) {
     world_delay($delay);
     if (map_blocked(.coord) = false) {
-        obj_add(.coord, enum(obj, namedobj, ranged_ammo, $ammo), 1, 100);
+        obj_add(.coord, enum(obj, namedobj, ranged_ammo, $ammo), 1, 200);
     }
 }


### PR DESCRIPTION
Reverting changes added on March 7 in this [PR](https://github.com/2004Scape/Server/commit/412eeaade9d52413d88fbb1d0a230a0864d41597) now that the engine is accounting for the additional 100 ticks.