### PR TITLE
fix(content): Arrows despawning too quickly

### DIFF
--- a/data/src/scripts/skill_combat/scripts/player/player_ranged.rs2
+++ b/data/src/scripts/skill_combat/scripts/player/player_ranged.rs2
@@ -129,6 +129,6 @@ return(~npc_projectile(coord, npc_uid, oc_param($ammo, proj_travel), 40, 36, 32,
 if (random($chance) ! 0 | $chance = ^true) {
     world_delay($delay);
     if (map_blocked(npc_coord) = false) {
-        obj_add(npc_coord, enum(obj, namedobj, ranged_ammo, $ammo), 1, 100);
+        obj_add(npc_coord, enum(obj, namedobj, ranged_ammo, $ammo), 1, 200);
     }
 }

--- a/data/src/scripts/skill_combat/scripts/pvp/pvp_ranged.rs2
+++ b/data/src/scripts/skill_combat/scripts/pvp/pvp_ranged.rs2
@@ -92,6 +92,6 @@ if (~in_duel_arena(coord) = true) {
 if (random($chance) ! 0) {
     world_delay($delay);
     if (map_blocked(.coord) = false) {
-        obj_add(.coord, enum(obj, namedobj, ranged_ammo, $ammo), 1, 100);
+        obj_add(.coord, enum(obj, namedobj, ranged_ammo, $ammo), 1, 200);
     }
 }


### PR DESCRIPTION
Reverting changes added on March 7 in this [PR](https://github.com/2004Scape/Server/commit/412eeaade9d52413d88fbb1d0a230a0864d41597) now that the engine is accounting for the additional 100 ticks.