### PR TITLE
fix(content): monkeybars changes

### DIFF
--- a/data/src/scripts/player/scripts/appearance.rs2
+++ b/data/src/scripts/player/scripts/appearance.rs2
@@ -49,13 +49,16 @@ if ($weapon = null) {
 .buildappearance(worn);
 
 [proc,bas_set_all](seq $seq)
-bas_readyanim($seq);
-bas_turnonspot($seq);
-bas_walk_f($seq);
-bas_walk_b($seq);
-bas_walk_l($seq);
-bas_walk_r($seq);
-bas_running($seq);
+~bas_set($seq, $seq, $seq, $seq, $seq, $seq, $seq);
+
+[proc,bas_set](seq $ready, seq $turn, seq $walkf, seq $walkb, seq $walkl, seq $walkr, seq $run)
+bas_readyanim($ready);
+bas_turnonspot($turn);
+bas_walk_f($walkf);
+bas_walk_b($walkb);
+bas_walk_l($walkl);
+bas_walk_r($walkr);
+bas_running($run);
 buildappearance(worn);
 
 [proc,headicon_add](int $icon)

--- a/data/src/scripts/skill_agility/scripts/agility.rs2
+++ b/data/src/scripts/skill_agility/scripts/agility.rs2
@@ -139,34 +139,13 @@ p_telejump($fail_coord);
 mes($message);
 
 [proc,set_walkbas](seq $walk_seq)
-bas_readyanim($walk_seq);
-bas_turnonspot($walk_seq);
-bas_walk_f($walk_seq);
-bas_walk_b($walk_seq);
-bas_walk_l($walk_seq);
-bas_walk_r($walk_seq);
-bas_running(null);
-buildappearance(worn);
+~bas_set($walk_seq, $walk_seq, $walk_seq, $walk_seq, $walk_seq, $walk_seq, null);
 
 [proc,set_readywalk_bas](seq $ready_seq, seq $walk_seq)
-bas_readyanim($ready_seq);
-bas_turnonspot($walk_seq);
-bas_walk_f($walk_seq);
-bas_walk_b($walk_seq);
-bas_walk_l($walk_seq);
-bas_walk_r($walk_seq);
-bas_running(null);
-buildappearance(worn);
+~bas_set($ready_seq, $walk_seq, $walk_seq, $walk_seq, $walk_seq, $walk_seq, null);
 
 [proc,set_readywalkturn_bas](seq $ready_seq, seq $turn_seq, seq $walk_seq)
-bas_readyanim($ready_seq);
-bas_turnonspot($turn_seq);
-bas_walk_f($walk_seq);
-bas_walk_b($walk_seq);
-bas_walk_l($walk_seq);
-bas_walk_r($walk_seq);
-bas_running(null);
-buildappearance(worn);
+~bas_set($ready_seq, $turn_seq, $walk_seq, $walk_seq, $walk_seq, $walk_seq, null);
 
 // Finds an identical loc on the $merge_pos coord to switch active_loc to
 [proc,change_merged_loc](coord $merge_pos)

--- a/data/src/scripts/skill_agility/scripts/shortcuts.rs2
+++ b/data/src/scripts/skill_agility/scripts/shortcuts.rs2
@@ -151,9 +151,12 @@ if(coordz(loc_coord) > coordz(loc_param(start_coord))) {
 // teleport to the end of the spikes and walk 1 tile to the end of the bars
 ~forcewalk2($start_coord);
 facesquare(movecoord(coord, 0, 0, calc($dist_mod)));
+~bas_set(human_monkeybars_ready, human_monkeybars_ready, human_monkeybars_walk, 
+         human_monkeybars_ready, human_monkeybars_ready, human_monkeybars_ready, null);
 anim(human_monkeybars_on, 0);
 p_delay(0);
-~agility_force_move(0, human_monkeybars_walk, movecoord(coord, 0, 0, calc($dist_mod * 2)));
+~forcemove(movecoord(coord, 0, 0, calc($dist_mod * 1)));
+p_delay(0);
 // You can only fail the monkeybars in the agility dungeon
 if(stat_random(stat(agility), loc_param(obstacle_low_fail), loc_param(obstacle_high_fail)) = false) {
     def_coord $fall_pos = 0_40_149_39_19; 
@@ -162,13 +165,16 @@ if(stat_random(stat(agility), loc_param(obstacle_low_fail), loc_param(obstacle_h
     }
     ~agility_instant_fail($fall_pos, calc(((stat(hitpoints) * 15) / 100) + 1), "You miss the hand hold and fall to the level below.");
     anim(human_monkeybars_off, 0);
+    ~update_bas;
     p_delay(0);
     return;
 
 }
-p_telejump(movecoord(coord, 0, 0, calc($dist_mod * 2)));
+p_teleport(movecoord(coord, 0, 0, calc($dist_mod * 3)));
 p_delay(0);
-~agility_force_move(200, human_monkeybars_walk, movecoord(coord, 0, 0, calc($dist_mod * 1)));
+~forcemove(movecoord(coord, 0, 0, calc($dist_mod * 1)));
+~update_bas;
+stat_advance(agility, 200);
 anim(human_monkeybars_off, 0);
 p_delay(0);
 


### PR DESCRIPTION
- update monkeybars to closer match this 2006 video https://www.youtube.com/watch?v=jdcT9ogpMwE&t=166s, also now correctly sets bas which prevents the wrong stand animation being used when delayed for the tick after the teleport
- Create a proc for updating each bas, update existing procs to call this