### PR TITLE
fix(content): some levelup unlock messages

### DIFF
--- a/data/src/scripts/levelup/scripts/levelup_unlocks_fishing.rs2
+++ b/data/src/scripts/levelup/scripts/levelup_unlocks_fishing.rs2
@@ -5,10 +5,10 @@ switch_int(stat_base(fishing)) {
     case 10 : ~objbox(raw_herring,"You can now try fishing for @dbl@Herring.", 250, 0, 0);
     case 15 : ~doubleobjbox(raw_anchovies,net,"You can now try to net @dbl@Anchovies.", 200);
     case 16 : ~doubleobjbox(raw_mackerel,casket,"You can now try fishing for @dbl@Mackerel@bla@,|@dbl@Oysters@bla@ and @bdl@Caskets@bla@ with a large net.", 200);
-    case 20 : ~doubleobjbox(raw_trout,fly_fishing_rod,"You can now try fishing for @dbl@Trout.", 200);
+    case 20 : ~doubleobjbox(raw_trout,fly_fishing_rod,"You can now try fly fishing for @dbl@Trout.", 200);
     case 23 : ~doubleobjbox(raw_cod,net,"Members can now try fishing for @dbl@Cod with a large net.", 200);
     case 25 : ~doubleobjbox(raw_pike,fishing_rod,"You can now try fishing for @dbl@Pike.", 200);
-    case 30 : ~doubleobjbox(raw_salmon,fly_fishing_rod,"You can now try fishing for @dbl@Salmon.", 200);
+    case 30 : ~doubleobjbox(raw_salmon,fly_fishing_rod,"You can now try fly fishing for @dbl@Salmon.", 200);
     case 35 : ~doubleobjbox(raw_tuna,harpoon,"You can now try harpooning @dbl@Tuna.", 200);
     case 40 : ~doubleobjbox(raw_lobster,lobster_pot,"You can now try to catch @dbl@Lobsters.", 200);
     case 46 : ~doubleobjbox(raw_bass,big_net,"Members can now try fishing for @dbl@Sea Bass with a large net.", 200);

--- a/data/src/scripts/levelup/scripts/levelup_unlocks_smithing.rs2
+++ b/data/src/scripts/levelup/scripts/levelup_unlocks_smithing.rs2
@@ -13,7 +13,7 @@ switch_int(stat_base(smithing)) {
     case 11 : ~objbox(bronze_chainbody,"You can now make @dbl@Bronze Chainmail Bodies.", 250, 0, 0);
     case 12 : ~objbox(bronze_kiteshield,"You can now make @dbl@Bronze Kite Shields.", 250, 0, 0);
     case 14 : ~objbox(bronze_2h_sword,"You can now make @dbl@Bronze Two Handed Swords.", 250, 0, 0);
-    case 15 : ~doubleobjbox(iron_ore,iron_dagger,"You can now smelt @dbl@Iron Ore@bla@ and make @dbl@Iron|@dbl@Daggers.", 200);
+    case 15 : ~objbox(iron_dagger,"You can now make @dbl@Iron Daggers.", 250, 0, 0);
     case 16 : ~doubleobjbox(bronze_platelegs,iron_axe,"You can now make @dbl@Bronze Plate Legs@bla@, @dbl@Bronze|@dbl@Plate Skirts@bla@ and @dbl@Iron Axes.", 200);
     case 17 : ~objbox(iron_mace,"You can now make @dbl@Iron Maces.", 250, 0, divide(^objbox_height, 2));
     case 18 : ~doubleobjbox(bronze_platebody,iron_med_helm," You can now make @dbl@Bronze Plate Bodies and Iron||@dbl@Medium Helms. ||", 200);
@@ -27,7 +27,7 @@ switch_int(stat_base(smithing)) {
     case 26 : ~objbox(iron_chainbody,"You can now make @dbl@Iron Chainmail Bodies.", 250, 0, 0);
     case 27 : ~objbox(iron_kiteshield,"You can now make @dbl@Iron Kite Shields.", 250, 0, 0);
     case 29 : ~objbox(iron_2h_sword,"You can now make @dbl@Iron Two Handed Swords.", 250, 0, 0);
-    case 30 : ~doubleobjbox(iron_ore,steel_dagger,"You can now smelt @dbl@Steel@bla@ and make @dbl@Steel Daggers.", 200);
+    case 30 : ~objbox(steel_dagger,"You can now make @dbl@Steel Daggers.", 250, 0, 0);
     case 31 : ~doubleobjbox(iron_platelegs,steel_axe,"You can now make @dbl@Iron Plate Legs@bla@, @dbl@Iron Plate Skirts|@bla@and @dbl@Steel Axes.", 200);
     case 32 : ~objbox(steel_mace,"You can now make @dbl@Steel Maces.", 250, 0, divide(^objbox_height, 2));
     case 33 : ~doubleobjbox(iron_platebody,steel_med_helm," You can now make @dbl@Iron Plate Bodies and Steel||@dbl@Medium Helms. ||", 200);


### PR DESCRIPTION
![you can now try fly fishing for trout (2014)](https://github.com/user-attachments/assets/b765d684-0bf7-438c-8e11-ec31250a7580)
![you can now try fly fishing for salmon  members can catch leckish fish (2023)](https://github.com/user-attachments/assets/af824e88-4b69-4b52-862b-cec4031870ed)
----
You can see that Smithing had a change in these dagger messages where smelting was a newer addition:
![you can now make steel daggers (2014)](https://github.com/user-attachments/assets/3449a300-12d4-41a2-8b6b-3943d281dfb2)
![you can now make mithril daggers (2006)](https://github.com/user-attachments/assets/6b593d77-44aa-4605-894e-e53f3979ab7b)
![you can now make adamant daggers (2007)](https://github.com/user-attachments/assets/7843098a-007d-4b85-b65b-b8a59c4017f1)
![you can now smelt iron ore and make iron daggers (2024)](https://github.com/user-attachments/assets/0da5ceb8-04bb-418c-8514-43496ca47f8f)
![you can now smelt steel and make steel daggers (2023)](https://github.com/user-attachments/assets/4ebce9cc-f2c3-4725-8b61-8ff56f60f2b0)

