### PR TITLE
fix(content): queued quest complete changes

### DIFF
--- a/data/src/scripts/areas/area_draynor/scripts/professor_oddenstein.rs2
+++ b/data/src/scripts/areas/area_draynor/scripts/professor_oddenstein.rs2
@@ -61,7 +61,6 @@ if(inv_total(inv, pressure_gauge) > 0 & inv_total(inv, oil_can) > 0 & inv_total(
     ~chatplayer("<p,happy>I have everything!");
     ~chatnpc("<p,happy>Give 'em here then.");
     if_close;
-    // osrs has this as messages with p_delay, but based of rsc and similar scenarios in non-reworked quests, this is probably what it used to be (confirm this if possible)
     mes("You give a rubber tube, a pressure gauge, ");
     mes("and a can of oil to the professor.");
     p_delay(1);
@@ -75,6 +74,7 @@ if(inv_total(inv, pressure_gauge) > 0 & inv_total(inv, oil_can) > 0 & inv_total(
     inv_del(inv, pressure_gauge, 1);
     inv_del(inv, oil_can, 1);
     inv_del(inv, rubber_tube, 1);
+    %haunted_progress = ^haunted_complete;
     queue(haunted_quest_complete, 0); // reward is queued as soon as changetype completes in OSRS
     ~chatnpc_specific("Ernest", ernest_human, "<p,happy>Thank you <text_gender("sir", "m'lady")>.|It was dreadfully irritating being a chicken.|How can I ever thank you?");
     ~chatplayer("<p,shifty>Well a cash reward is always nice...");

--- a/data/src/scripts/general/scripts/quests.rs2
+++ b/data/src/scripts/general/scripts/quests.rs2
@@ -13,7 +13,7 @@ if ($progress = 0) {
 }
 
 [proc,send_quest_complete](component $component, namedobj $obj, int $objscale, int $questpoints, string $questmessage)
-%questpoints = add(%questpoints, $questpoints);
+~update_questpoints;
 ~quest_complete_interface($component, $obj, $objscale, $questpoints, $questmessage);
 
 [proc,quest_complete_interface](component $component, namedobj $obj, int $objscale, int $questpoints, string $questmessage)
@@ -38,7 +38,7 @@ if_setcolour($component, ^green_rgb);
 if_settab(questlist, ^tab_quest_journal);
 mes("Congratulations! Quest complete!");
 
-[proc,update_quests]
+[proc,update_questpoints]
 def_int $questpoints = 0;
 if (%runemysteries_progress = ^runemysteries_complete) {
     $questpoints = add($questpoints, ^runemysteries_questpoints);
@@ -250,6 +250,8 @@ if (%legends_progress = ^legends_complete) {
 
 %questpoints = $questpoints;
 
+[proc,update_quests]
+~update_questpoints;
 ~send_quest_progress_colour(questlist:runemysteries, %runemysteries_progress, ^runemysteries_complete);
 ~send_quest_progress_colour(questlist:doric, %doric_progress, ^doric_complete);
 ~send_quest_progress_colour(questlist:cook, %cook_progress, ^cook_complete);

--- a/data/src/scripts/quests/quest_crest/scripts/crest_dimintheis.rs2
+++ b/data/src/scripts/quests/quest_crest/scripts/crest_dimintheis.rs2
@@ -80,8 +80,10 @@ else {
 
 [label,crest_dimintheis_complete]
 ~chatplayer("<p,neutral>I have retrieved your crest.");
-// https://youtu.be/e8btuenT4nE?si=1d0Zf6EvXq90iMco&t=1169, OSRS takes all crest pieces from bank/inv, rs3 + classic doesn't though so assuming that was an OSRS change
-inv_del(inv, family_crest, 1);
+// https://youtu.be/e8btuenT4nE?si=1d0Zf6EvXq90iMco&t=1169, OSRS takes all crest pieces from bank/inv
+// confirm this was the original behaviour (it's not the case on RSC)
+inv_del(inv, family_crest, ^max_32bit_int);
+inv_del(bank, family_crest, ^max_32bit_int);
 queue(crest_complete, 0);
 ~chatnpc("<p,happy>Adventurer... I can only thank you for your kindness, although the words are insufficient to express the gratitude I feel!");
 ~chatnpc("<p,happy>You are truly a hero in every sense, and perhaps your efforts can begin to patch the wounds that have torn this family apart...");

--- a/data/src/scripts/quests/quest_haunted/scripts/quest_haunted.rs2
+++ b/data/src/scripts/quests/quest_haunted/scripts/quest_haunted.rs2
@@ -204,7 +204,6 @@ if(npc_find(coord, ernest_chicken, 8, 0) = true) {
 }
 
 [queue,haunted_quest_complete]
-%haunted_progress = ^haunted_complete;
 session_log(^log_adventure, "Quest complete: Ernest the Chicken");
 ~send_quest_complete(questlist:haunted, feather, 250, ^haunted_questpoints, "You have completed the\\nErnest The Chicken Quest!");
 inv_add(inv, coins, 300);

--- a/data/src/scripts/quests/quest_itwatchtower/scripts/quest_itwatchtower.rs2
+++ b/data/src/scripts/quests/quest_itwatchtower/scripts/quest_itwatchtower.rs2
@@ -515,11 +515,15 @@ if(~watchtower_has_all_crystals = true & %itwatchtower_progress = ^itwatchtower_
     // QUEST REWARD
     %itwatchtower_progress = ^itwatchtower_complete;
     p_teleport(2_45_73_48_43);
-    // https://youtu.be/0hkyRGQImlg?si=huZf7suXxmjXPtxN&t=1198
-    inv_del(inv, powering_crystal1, 1);
-    inv_del(inv, powering_crystal2, 1);
-    inv_del(inv, powering_crystal3, 1);
-    inv_del(inv, powering_crystal4, 1);
+    // https://youtu.be/0hkyRGQImlg?si=huZf7suXxmjXPtxN&t=1198, deletes all from bank + inv here on RS3
+    inv_del(inv, powering_crystal1, ^max_32bit_int);
+    inv_del(bank, powering_crystal1, ^max_32bit_int);
+    inv_del(inv, powering_crystal2, ^max_32bit_int);
+    inv_del(bank, powering_crystal2, ^max_32bit_int);
+    inv_del(inv, powering_crystal3, ^max_32bit_int);
+    inv_del(bank, powering_crystal3, ^max_32bit_int);
+    inv_del(inv, powering_crystal4, ^max_32bit_int);
+    inv_del(bank, powering_crystal4, ^max_32bit_int);
     p_delay(3);
     stat_advance(magic, 153000);
     inv_add(inv, coins, 5000);


### PR DESCRIPTION
- Recalculate quest points on completion instead of adding, matches https://youtu.be/v2f-IjVObLs?si=PFG7Vxrfz7b5iQhG&t=1393
- set haunted completion var when completion is queued instead of in queue
- change family crest and watchtower to delete all crest/crystals from inv/bank when completion is queued
