### PR TITLE
feat(engine): prevent packet sending midi if on lowmem or have volume off

### DIFF
--- a/data/src/scripts/areas/area_karamja/scripts/captain_shanks.rs2
+++ b/data/src/scripts/areas/area_karamja/scripts/captain_shanks.rs2
@@ -47,7 +47,7 @@ inv_del(inv, shiloshipticket, 1);
 [proc,set_sail_cairn](string $arrival_mes, coord $destination, int $map_route, int $delay)
 %boat_takeoff = $map_route;
 if_openmain(ship_journey);
-midi_jingle(^sailing_journey_jingle, ^sailing_journey_jingle_millis);
+~midi_jingle(^sailing_journey_jingle, ^sailing_journey_jingle_millis);
 
 
 if_settab(null, 0);

--- a/data/src/scripts/engine.rs2
+++ b/data/src/scripts/engine.rs2
@@ -323,8 +323,6 @@
 [command,midi_song](string $song)
 // info: Play a jingle (advancing levels, completing quests, ...)
 [command,midi_jingle](string $jingle, int $length)
-// info: Play a jingle for the secondary player (advancing levels, completing quests, ...)
-[command,.midi_jingle](string $jingle, int $length)
 // info: Show the hint arrow at $coord
 [command,hint_coord](int $offset, coord $coord, int $height)
 // info: Start a softtimer on the active_player

--- a/data/src/scripts/general/scripts/quests.rs2
+++ b/data/src/scripts/general/scripts/quests.rs2
@@ -21,13 +21,13 @@ if ($progress = 0) {
 def_int $random = random(128);
 if ($random < 32) {
     // The least common music that plays when completing a quest.
-    midi_jingle(^quest_complete_3_jingle, ^quest_complete_3_millis);
+    ~midi_jingle(^quest_complete_3_jingle, ^quest_complete_3_millis);
 } else if ($random < 64) {
     // A less common music that plays when completing a quest.
-    midi_jingle(^quest_complete_2_jingle, ^quest_complete_2_millis);
+    ~midi_jingle(^quest_complete_2_jingle, ^quest_complete_2_millis);
 } else {
     // The most common music that plays when completing a quest.
-    midi_jingle(^quest_complete_1_jingle, ^quest_complete_1_millis);
+    ~midi_jingle(^quest_complete_1_jingle, ^quest_complete_1_millis);
 }
 if_settext(questscroll:com_3, $questmessage);
 if_settext(questscroll:com_9, tostring($questpoints));

--- a/data/src/scripts/interface_boat/scripts/sail.rs2
+++ b/data/src/scripts/interface_boat/scripts/sail.rs2
@@ -3,7 +3,7 @@
 
 // todo: should com_0 be set to "You sail to <$place_name>."?
 if_openmain(ship_journey);
-midi_jingle(^sailing_journey_jingle, ^sailing_journey_jingle_millis);
+~midi_jingle(^sailing_journey_jingle, ^sailing_journey_jingle_millis);
 
 // hide all tabs except friends list and ignore list
 if_settab(null, 0);
@@ -34,4 +34,4 @@ if(p_finduid(uid) = false) return;
 
 // todo: should com_0 be set to "You sail to <$place_name>."?
 if_openmain(ship_journey);
-midi_jingle(^sailing_journey_jingle, ^sailing_journey_jingle_millis);
+~midi_jingle(^sailing_journey_jingle, ^sailing_journey_jingle_millis);

--- a/data/src/scripts/levelup/scripts/levelup.rs2
+++ b/data/src/scripts/levelup/scripts/levelup.rs2
@@ -50,7 +50,7 @@ if ($has_unlocks = false) {
     $jingle = db_getfield($unlock_row, levelup:unlocks_jingle, 0);
     $jingle_millis = db_getfield($unlock_row, levelup:unlocks_jingle_millis, 0);
 }
-midi_jingle($jingle, $jingle_millis);
+~midi_jingle($jingle, $jingle_millis);
 // the level up dialogue box
 if_settext(db_getfield($unlock_row, levelup:title, 0), "@dbl@<$message>");
 if_settext(db_getfield($unlock_row, levelup:body, 0), "<db_getfield($unlock_row, levelup:level_prefix, 0)> <tostring($level)>.");

--- a/data/src/scripts/minigames/game_duelarena/scripts/duel_arena_finish.rs2
+++ b/data/src/scripts/minigames/game_duelarena/scripts/duel_arena_finish.rs2
@@ -14,7 +14,7 @@ if (.finduid(%duelpartner) = true) {
     .queue(duel_finish, 0);
 }
 // ur able to get double mes if opponent kills u with knives: https://youtu.be/KRDZJKa1whI?list=PLn23LiLYLb1bQ7Hwp77KoNBjKvpZQTfJT&t=12
-midi_jingle(^death_jingle_2, ^death_jingle_2_millis);
+~midi_jingle(^death_jingle_2, ^death_jingle_2_millis);
 // https://storage.googleapis.com/tannerdino/images/6543.jpg
 // https://youtu.be/gWmwSYxzUfo
 mes("Oh dear you are dead!");
@@ -26,7 +26,7 @@ if (.finduid(%duelpartner) = true) {
         if_settext(duel_win:com_99, "You are victorious!");
         mes("Well done! You have defeated <.displayname>!");
         session_log(^log_moderator, "Won a duel against <.name>");
-        midi_jingle(^duel_win_2_jingle, ^duel_win_2_jingle_millis);
+        ~midi_jingle(^duel_win_2_jingle, ^duel_win_2_jingle_millis);
         ~duel_reset_all;
         ~duel_spoils;
         return;
@@ -34,7 +34,7 @@ if (.finduid(%duelpartner) = true) {
         if_settext(duel_win:com_99, "You are victorious! Your opponent resigned!"); // 2006
         mes("Well done! <.displayname> resigned!"); // 2006
         session_log(^log_moderator, "Won a duel by forfeit against <.name>");
-        midi_jingle(^duel_win_2_jingle, ^duel_win_2_jingle_millis);
+        ~midi_jingle(^duel_win_2_jingle, ^duel_win_2_jingle_millis);
         ~duel_reset_all;
         ~duel_spoils;
         return;
@@ -42,7 +42,7 @@ if (.finduid(%duelpartner) = true) {
 }
 ~duel_reset_all;
 [proc,duel_spoils]
-midi_jingle(^duel_win_2_jingle, ^duel_win_2_jingle_millis);
+~midi_jingle(^duel_win_2_jingle, ^duel_win_2_jingle_millis);
 if_openmain(duel_win);
 ~duel_adjust_scoreboard(displayname, ~player_combat_level, .displayname, ~.player_combat_level);
 if_settext(duel_win:displayname, .displayname);

--- a/data/src/scripts/minigames/game_duelarena/scripts/duel_arena_start.rs2
+++ b/data/src/scripts/minigames/game_duelarena/scripts/duel_arena_start.rs2
@@ -56,7 +56,7 @@ if (.finduid(%duelpartner) = true) {
     softtimer(duel_arena_start_3, 3); // todo: confirm these timings
     softtimer(duel_arena_time_limit, 6000); // 60 minute time limit https://runescape.wiki/w/Update:Assist_System
 
-    midi_jingle(^duel_start_jingle, ^duel_start_jingle_millis);
+    ~midi_jingle(^duel_start_jingle, ^duel_start_jingle_millis);
 }
 
 

--- a/data/src/scripts/minigames/game_trail/scripts/trail_clue_helper.rs2
+++ b/data/src/scripts/minigames/game_trail/scripts/trail_clue_helper.rs2
@@ -75,7 +75,7 @@ return (false);
 [proc,trail_complete]
 ~clear_trail_progress;
 mes("Well done you've completed the Treasure Trail!");
-midi_jingle(^treasure_hunt_win_jingle, ^treasure_hunt_win_jingle_millis);
+~midi_jingle(^treasure_hunt_win_jingle, ^treasure_hunt_win_jingle_millis);
 inv_transmit(trail_rewardinv, trail_reward:inv);
 if_openmain(trail_reward);
 queue(trail_give_reward, 0);

--- a/data/src/scripts/minigames/game_trawler/scripts/trawler_start.rs2
+++ b/data/src/scripts/minigames/game_trawler/scripts/trawler_start.rs2
@@ -36,7 +36,7 @@ p_teleport(map_findsquare(^trawler_start_center_under, 0, 4, ^map_findsquare_lin
 %boat_takeoff = 11;
 %trawler = ^trawler_sailed;
 if_openmain(ship_journey);
-midi_jingle(^sailing_journey_jingle, ^sailing_journey_jingle_millis);
+~midi_jingle(^sailing_journey_jingle, ^sailing_journey_jingle_millis);
 
 p_delay(20);
 if_close;

--- a/data/src/scripts/minigames/game_trawler/scripts/trawler_win.rs2
+++ b/data/src/scripts/minigames/game_trawler/scripts/trawler_win.rs2
@@ -43,7 +43,7 @@ if (~inzone_coord_pair_table(trawler_game_zones, coord) = false) {
 mes("Murphy turns the boat towards shore.");
 %boat_takeoff = 12;
 %trawler = ^trawler_finished;
-midi_jingle(^sailing_journey_jingle, ^sailing_journey_jingle_millis);
+~midi_jingle(^sailing_journey_jingle, ^sailing_journey_jingle_millis);
 if_openmain(ship_journey);
 
 p_delay(20);

--- a/data/src/scripts/music/scripts/music.rs2
+++ b/data/src/scripts/music/scripts/music.rs2
@@ -22,6 +22,18 @@ if (p_finduid(uid) = true) {
     @please_finish;
 }
 
+[proc,midi_jingle](string $jingle, int $length)
+if (%music_volume = 0) {
+    return;
+}
+midi_jingle($jingle, $length);
+
+[proc,midi_song](string $song)
+if (%music_volume = 0) {
+    return;
+}
+midi_song($song);
+
 [proc,music_getvar](int $var)(int)
 if ($var = 1) {
     return(%music1);
@@ -75,7 +87,7 @@ if ($unlock ! null) {
 
 def_string $name = db_getfield($song, music:name, 0);
 if_settext(music:com_201, $name);
-midi_song($name);
+~midi_song($name);
 
 [label,music_playbyregion](coord $coord)
 // first, search for the song linked to this mapsquare
@@ -108,5 +120,5 @@ if ($unlock ! null) {
 if (%music_mode ! 0) {
     def_string $name = db_getfield($song, music:name, 0);
     if_settext(music:com_201, $name);
-    midi_song($name);
+    ~midi_song($name);
 }

--- a/data/src/scripts/player/scripts/death.rs2
+++ b/data/src/scripts/player/scripts/death.rs2
@@ -16,7 +16,7 @@ p_delay(3);
 
 [queue,player_death_default]
 ~player_death;
-midi_jingle(^death_jingle_2, ^death_jingle_2_millis);
+~midi_jingle(^death_jingle_2, ^death_jingle_2_millis);
 // https://storage.googleapis.com/tannerdino/images/6543.jpg
 // https://youtu.be/gWmwSYxzUfo
 mes("Oh dear you are dead!");

--- a/data/src/scripts/quests/quest_dragon/scripts/dragonslayer_ned.rs2
+++ b/data/src/scripts/quests/quest_dragon/scripts/dragonslayer_ned.rs2
@@ -26,7 +26,7 @@ if ((%dragon_progress = ^quest_dragon_ned_given_map | %dragon_progress = ^quest_
 
     if_settext(ship_journey:com_0, "You sail to Crandor Isle.");
     if_openmain(ship_journey);
-    midi_jingle(^sailing_journey_jingle, ^sailing_journey_jingle_millis);
+    ~midi_jingle(^sailing_journey_jingle, ^sailing_journey_jingle_millis);
 
     p_telejump(^crandor_tele_coord);
     %dragon_progress = ^quest_dragon_sailed_to_crandor;

--- a/data/src/scripts/quests/quest_fluffs/scripts/quest_fluffs.rs2
+++ b/data/src/scripts/quests/quest_fluffs/scripts/quest_fluffs.rs2
@@ -310,13 +310,13 @@ session_log(^log_adventure, "Quest complete: Gertrude's Cat");
 def_int $random = random(128);
 if ($random < 32) {
     // The least common music that plays when completing a quest.
-    midi_jingle(^quest_complete_3_jingle, ^quest_complete_3_millis);
+    ~midi_jingle(^quest_complete_3_jingle, ^quest_complete_3_millis);
 } else if ($random < 64) {
     // A less common music that plays when completing a quest.
-    midi_jingle(^quest_complete_2_jingle, ^quest_complete_2_millis);
+    ~midi_jingle(^quest_complete_2_jingle, ^quest_complete_2_millis);
 } else {
     // The most common music that plays when completing a quest.
-    midi_jingle(^quest_complete_1_jingle, ^quest_complete_1_millis);
+    ~midi_jingle(^quest_complete_1_jingle, ^quest_complete_1_millis);
 }
 stat_advance(cooking, 15250);
 if_openmain(questscroll_fluffs);

--- a/data/src/scripts/quests/quest_hazeelcult/scripts/quest_hazeelcult.rs2
+++ b/data/src/scripts/quests/quest_hazeelcult/scripts/quest_hazeelcult.rs2
@@ -159,7 +159,7 @@ inv_add(inv, carnilleanchestkey, 1);
 [queue,hazeelcult_fake_complete]
 inv_add(inv, coins, 5);
 %hazeelcult_progress = ^hazeelcult_given_armour_or_scroll;
-midi_jingle(^death_jingle, ^death_jingle_millis);
+~midi_jingle(^death_jingle, ^death_jingle_millis);
 if_settext(questscroll:com_3, "You have... kind of...\\ncompleted the Hazeel Cult Quest!");
 if_settext(questscroll:com_9, "5");
 if_settext(questscroll:com_10, "coins.");

--- a/data/src/scripts/quests/quest_itgronigen/scripts/quest_itgronigen.rs2
+++ b/data/src/scripts/quests/quest_itgronigen/scripts/quest_itgronigen.rs2
@@ -271,13 +271,13 @@ session_log(^log_adventure, "Quest complete: Observatory");
 def_int $random = random(128);
 if ($random < 32) {
     // The least common music that plays when completing a quest.
-    midi_jingle(^quest_complete_3_jingle, ^quest_complete_3_millis);
+    ~midi_jingle(^quest_complete_3_jingle, ^quest_complete_3_millis);
 } else if ($random < 64) {
     // A less common music that plays when completing a quest.
-    midi_jingle(^quest_complete_2_jingle, ^quest_complete_2_millis);
+    ~midi_jingle(^quest_complete_2_jingle, ^quest_complete_2_millis);
 } else {
     // The most common music that plays when completing a quest.
-    midi_jingle(^quest_complete_1_jingle, ^quest_complete_1_millis);
+    ~midi_jingle(^quest_complete_1_jingle, ^quest_complete_1_millis);
 }
 if_openmain(questscroll_itgronigen);
 if_setcolour(questlist:itgronigen, ^green_rgb);

--- a/data/src/scripts/quests/quest_itwatchtower/scripts/quest_itwatchtower.rs2
+++ b/data/src/scripts/quests/quest_itwatchtower/scripts/quest_itwatchtower.rs2
@@ -554,13 +554,13 @@ session_log(^log_adventure, "Quest complete: Watch Tower");
 def_int $random = random(128);
 if ($random < 32) {
     // The least common music that plays when completing a quest.
-    midi_jingle(^quest_complete_3_jingle, ^quest_complete_3_millis);
+    ~midi_jingle(^quest_complete_3_jingle, ^quest_complete_3_millis);
 } else if ($random < 64) {
     // A less common music that plays when completing a quest.
-    midi_jingle(^quest_complete_2_jingle, ^quest_complete_2_millis);
+    ~midi_jingle(^quest_complete_2_jingle, ^quest_complete_2_millis);
 } else {
     // The most common music that plays when completing a quest.
-    midi_jingle(^quest_complete_1_jingle, ^quest_complete_1_millis);
+    ~midi_jingle(^quest_complete_1_jingle, ^quest_complete_1_millis);
 }
 if_settext(questscroll:com_3, "You have finished the Watchtower Quest.");
 if_settext(questscroll:com_9, tostring(4));

--- a/data/src/scripts/quests/quest_seaslug/scripts/quest_seaslug.rs2
+++ b/data/src/scripts/quests/quest_seaslug/scripts/quest_seaslug.rs2
@@ -126,13 +126,13 @@ session_log(^log_adventure, "Quest complete: Sea Slug");
 def_int $random = random(128);
 if ($random < 32) {
     // The least common music that plays when completing a quest.
-    midi_jingle(^quest_complete_3_jingle, ^quest_complete_3_millis);
+    ~midi_jingle(^quest_complete_3_jingle, ^quest_complete_3_millis);
 } else if ($random < 64) {
     // A less common music that plays when completing a quest.
-    midi_jingle(^quest_complete_2_jingle, ^quest_complete_2_millis);
+    ~midi_jingle(^quest_complete_2_jingle, ^quest_complete_2_millis);
 } else {
     // The most common music that plays when completing a quest.
-    midi_jingle(^quest_complete_1_jingle, ^quest_complete_1_millis);
+    ~midi_jingle(^quest_complete_1_jingle, ^quest_complete_1_millis);
 }
 if_settext(questscroll:com_3, "You have completed the\\nSea Slug Quest!");
 if_settext(questscroll:com_9, tostring(1));

--- a/data/src/scripts/tutorial/scripts/locs/tut_organ.rs2
+++ b/data/src/scripts/tutorial/scripts/locs/tut_organ.rs2
@@ -1,6 +1,6 @@
 [oploc1,loc_416]
 if(random(2) = 0) {
-    midi_song("organ_music_1");
+    ~midi_song("organ_music_1");
 } else {
-    midi_song("organ_music_2");
+    ~midi_song("organ_music_2");
 }

--- a/src/engine/script/handlers/PlayerOps.ts
+++ b/src/engine/script/handlers/PlayerOps.ts
@@ -424,7 +424,11 @@ const PlayerOps: CommandHandlers = {
     [ScriptOpcode.SOUND_SYNTH]: checkedHandler(ActivePlayer, state => {
         const [synth, loops, delay] = state.popInts(3);
 
-        state.activePlayer.write(new SynthSound(synth, loops, delay));
+        const player = state.activePlayer;
+        if (player.lowMemory) {
+            return;
+        }
+        player.write(new SynthSound(synth, loops, delay));
     }),
 
     [ScriptOpcode.STAFFMODLEVEL]: checkedHandler(ActivePlayer, state => {
@@ -720,7 +724,7 @@ const PlayerOps: CommandHandlers = {
 
     [ScriptOpcode.TEXT_GENDER]: checkedHandler(ActivePlayer, state => {
         const [male, female] = state.popStrings(2);
-        if (state.activePlayer.gender == 0) {
+        if (state.activePlayer.gender === 0) {
             state.pushString(male);
         } else {
             state.pushString(female);
@@ -728,13 +732,24 @@ const PlayerOps: CommandHandlers = {
     }),
 
     [ScriptOpcode.MIDI_SONG]: state => {
-        state.activePlayer.playSong(check(state.popString(), StringNotNull));
+        const name = check(state.popString(), StringNotNull);
+
+        const player = state.activePlayer;
+        if (player.lowMemory) {
+            return;
+        }
+        player.playSong(name);
     },
 
     [ScriptOpcode.MIDI_JINGLE]: state => {
         const delay = check(state.popInt(), NumberNotNull);
         const name = check(state.popString(), StringNotNull);
-        state.activePlayer.playJingle(delay, name);
+
+        const player = state.activePlayer;
+        if (player.lowMemory) {
+            return;
+        }
+        player.playJingle(delay, name);
     },
 
     [ScriptOpcode.SOFTTIMER]: checkedHandler(ActivePlayer, state => {
@@ -1034,7 +1049,7 @@ const PlayerOps: CommandHandlers = {
             if (gender === 1) {
                 state.activePlayer.body[i] = Player.MALE_FEMALE_MAP.get(state.activePlayer.body[i]) ?? -1;
             } else {
-                if (i == 1) {
+                if (i === 1) {
                     state.activePlayer.body[i] = 14;
                     continue;
                 }


### PR DESCRIPTION
- Completely prevent any packets from going out to the client for music/sounds if the player is on low memory mode.
- Refactor all uses of `midi_jingle` and `midi_song` to check for music volume and prevent packets from going out if the music volume is set to 0.
- This will lower overall network/internet usage like for example being on mobile/cell data. And from the server side obv. We are causing players to unnecessarily download these files and such when they don't want to play with the midi's. 