### PR TITLE
fix(content): dialogue fixes for tutorial island, dragon slayer

### DIFF
--- a/data/src/scripts/areas/area_edgeville/scripts/oziach.rs2
+++ b/data/src/scripts/areas/area_edgeville/scripts/oziach.rs2
@@ -15,7 +15,7 @@ if (%dragon_progress < ^dragon_complete & %dragon_progress > 0) {
     ~chatnpc("<p,quiz>So how is thy quest going?");
     @multi2("So where can I find this dragon?", oziach_find_dragon, "Where can I get an antidragon shield?", oziach_dragon_shield);
 }
-if (%dragon_progress = ^dragon_complete) {
+if (%dragon_progress >= ^dragon_complete) {
     @oziach_dragon_complete;
 }
 //default
@@ -146,7 +146,6 @@ if (inv_total(inv, melzarkey) = 0 & inv_total(bank, melzarkey) = 0) {
 // rsc
 ~chatplayer("<p,happy>I have slain the dragon!");
 ~chatnpc("<p,happy>Well done!");
-%dragon_progress = calc(^dragon_complete + 1);
 def_int $choice = ~p_choice2("Can I buy a rune plate mail body now please?", 0, "Thank you.", 1);
 if ($choice = 1) {
     ~chatplayer("<p,happy>Thank you.");

--- a/data/src/scripts/areas/area_falador/scripts/goblin_village/general_bentnoze.rs2
+++ b/data/src/scripts/areas/area_falador/scripts/goblin_village/general_bentnoze.rs2
@@ -22,7 +22,7 @@ if(map_members = true & inv_total(inv, trail_clue_hard_riddle017) > 0) {
     return;
 }
 if (~quest_dragon_getting_map_parts = true & %dragon_goblin = ^quest_dragon_knows_about_goblin) {
-    def_int $choice = ~p_choice2("I've heard that one of your number has got hold of|part of a map.", 0, "So how is life for the goblins?", 1);
+    def_int $choice = ~p_choice2("I've heard that one of your number has got hold of part of a map.", 0, "So how is life for the goblins?", 1);
     if ($choice = 0) {
         // chatnpc is neutral in osrs
         ~chatplayer("<p,neutral>I've heard that one of your number has got hold of|part of a map.");

--- a/data/src/scripts/areas/area_lumbridge/scripts/duke_horacio.rs2
+++ b/data/src/scripts/areas/area_lumbridge/scripts/duke_horacio.rs2
@@ -1,7 +1,7 @@
 [opnpc1,duke_horacio]
 ~chatnpc("<p,neutral>Greetings. Welcome to my castle.");
 
-if (%dragon_shield = ^quest_dragon_knows_about_shield & inv_total(inv, antidragonbreathshield) < 1 & inv_total(worn, antidragonbreathshield) < 1) {
+if ((%dragon_shield = ^quest_dragon_knows_about_shield | %dragon_progress >= ^dragon_complete) & inv_total(inv, antidragonbreathshield) < 1 & inv_total(worn, antidragonbreathshield) < 1) {
     @multi3("I seek a shield that will protect me from the dragon's breath.", duke_horacio_shield, "Have you any quests for me?", ~duke_handle_rune_mysteries, "Where can I find money?", duke_horacio_money);
 } else {
     @multi2("Have you any quests for me?", ~duke_handle_rune_mysteries, "Where can I find money?", duke_horacio_money);

--- a/data/src/scripts/tutorial/scripts/tut_chatbox_steps.rs2
+++ b/data/src/scripts/tutorial/scripts/tut_chatbox_steps.rs2
@@ -1,6 +1,7 @@
 [proc,tutorial_step_getting_started]
 ~set_hint_runescape_guide;
-~tutorialstep("Getting started", "To start the tutorial use your left mouse-button to click on the|'RuneScape Guide' in this room. He is indicated by a flashing|yellow arrow above his head. If you can't see him, use your|keyboard's arrow keys to rotate the view.");
+// https://web.archive.org/web/20060328131241im_/http://www.runescape.com/lang/en/aff/runescape/img/screenshots/shots/free_chardesign.jpg
+~tutorialstep("Getting started", "To start the tutorial use your left mouse-button to click|on the 'RuneScape Guide' in this room. He is indicated|by a flashing yellow arrow above his head. If you can't|see him, use your keyboard's arrow keys to rotate the view.");
 
 // Relevant in October 2006, Get Ready 435
 [proc,tutorial_step_player_controls_spanner]


### PR DESCRIPTION
- match linebreaks on initial tutorial message with https://web.archive.org/web/20060328131241/http://www.runescape.com/lang/en/aff/runescape/screenshots/free_chardesign.ws
- remove linebreak character from ~p_choice in bentnoze dialogue
- don't increase dragonslayer varp after telling oziach you've slain elvarg