### PR TITLE
fix(content): Ranged ammo poison fix

### DIFF
--- a/data/src/scripts/skill_combat/scripts/pvp/pvp_ranged.rs2
+++ b/data/src/scripts/skill_combat/scripts/pvp/pvp_ranged.rs2
@@ -50,7 +50,7 @@ if ($rhand = null) {
     %action_delay = add(map_clock, 4);
 } else {
     %action_delay = add(map_clock, oc_param($rhand, attackrate));
-    def_int $poison_severity = oc_param($rhand, poison_severity);
+    def_int $poison_severity = oc_param($ammo, poison_severity);
     if ($damage > 0 & $poison_severity > 0 & random(4) = 0) { // 1/4 chance to poison
         .queue(poison_player, 0, $poison_severity);
     }


### PR DESCRIPTION
It was originally only checking the equipped weapon for poison instead of both like it does in npc ranged combat. 