### PR TITLE
fix(content): Skilling fixes

### DIFF
--- a/data/src/scripts/quests/quest_legends/scripts/jungle_tree.rs2
+++ b/data/src/scripts/quests/quest_legends/scripts/jungle_tree.rs2
@@ -123,8 +123,8 @@ if (%action_delay = map_clock) {
     // axe does not seem to have any effect, wc level does? (need more data)
     if (stat_random(stat(woodcutting), 70, 233) = true) { 
         // Jungle trees/bushes just silently fail to give logs/xp if no space
-        // There's also a chance to receive no logs. This is guessed at 75% here
-        if (inv_freespace(inv) > 0 & random(4) = 0) {
+        // There's also a chance to receive no logs. This seems to be about a 50% chance (tested w/100 rolls on OSRS)
+        if (inv_freespace(inv) > 0 & random(2) = 0) {
             mes("You get some <lowercase(oc_name($product))>.");
             stat_advance(woodcutting, db_getfield($data, woodcutting_trees:productexp, 0));
             inv_add(inv, $product, 1);

--- a/data/src/scripts/quests/quest_mcannon/scripts/locs/mcannon_crate.rs2
+++ b/data/src/scripts/quests/quest_mcannon/scripts/locs/mcannon_crate.rs2
@@ -1,17 +1,5 @@
 // Crate containing Lolk
 [oploc1,loc_1]
-npc_findallzone(coord);
-while (npc_findnext = true) {
-    if (npc_type = rat 
-        | npc_type = chicken 
-        | npc_type = spider 
-        | npc_type = goblin_unarmed1
-        | npc_type = goblin_unarmed2
-        ) {
-        npc_setmode(opplayer2);
-    }
-}
-
 if (%mcannon_progress = ^mcannon_tasked_with_finding_gilobs_son) {
     if (npc_find(coord, dwarf_youngster, 14, 0) = true) {
         mes("You search the crate but find nothing.");        

--- a/data/src/scripts/skill_thieving/configs/chests/trapped_chest.dbrow
+++ b/data/src/scripts/skill_thieving/configs/chests/trapped_chest.dbrow
@@ -3,7 +3,7 @@ table=trapped_chest
 data=loc,chest_10_coins
 data=level,13
 data=experience,78
-data=respawn_ticks,5
+data=respawn_ticks,15
 data=loot,coins,10,10,128
 
 [trapped_chest_chest_nature_rune]
@@ -11,7 +11,7 @@ table=trapped_chest
 data=loc,chest_nature_rune
 data=level,28
 data=experience,250
-data=respawn_ticks,13
+data=respawn_ticks,30
 data=loot,naturerune,1,1,128
 data=loot,coins,3,3,128
 
@@ -20,7 +20,7 @@ table=trapped_chest
 data=loc,chest_50_coins
 data=level,43
 data=experience,1250
-data=respawn_ticks,75
+data=respawn_ticks,150
 data=loot,coins,50,50,128
 
 [trapped_chest_chest_steel_arrowtips]
@@ -28,7 +28,7 @@ table=trapped_chest
 data=loc,chest_steel_arrowtips
 data=level,47
 data=experience,1500
-data=respawn_ticks,125
+data=respawn_ticks,250
 data=loot,steel_arrowheads,5,5,128
 data=loot,coins,20,20,128
 
@@ -37,7 +37,7 @@ table=trapped_chest
 data=loc,chest_blood_runes
 data=level,59
 data=experience,2500
-data=respawn_ticks,200
+data=respawn_ticks,400
 data=loot,bloodrune,2,2,128
 data=loot,coins,500,500,128
 data=tele_coord,0_40_52_24_9
@@ -47,7 +47,7 @@ table=trapped_chest
 data=loc,chest_ardougne_castle
 data=level,72
 data=experience,5000
-data=respawn_ticks,666
+data=respawn_ticks,800
 data=loot,coins,1000,1000,128
 data=loot,raw_shark,1,1,128
 data=loot,adamantite_ore,1,1,128

--- a/data/src/scripts/skill_thieving/scripts/chest/trapped_chest.rs2
+++ b/data/src/scripts/skill_thieving/scripts/chest/trapped_chest.rs2
@@ -36,11 +36,12 @@
 
 [oplocu,chest_steel_arrowtips]
 if (last_useitem = lockpick) {
-    ~attempt_locked_chest;
+    p_oploc(2);
+    return;
 }
+~displaymessage(^dm_default);
 
 [label,attempt_trapped_chest](loc $loc, coord $loc_coord, int $loc_angle, locshape $loc_shape)
-p_arrivedelay;
 if (map_members = false) {
     mes(^mes_members_thieving);
     return;
@@ -58,6 +59,7 @@ if (afk_event = ^true) {
 }
 
 mes("You search the chest for traps.");
+anim(human_lockedchest, 0);
 
 def_int $current_level = stat(thieving);
 def_int $thieving_level = db_getfield($data, trapped_chest:level, 0);
@@ -81,19 +83,18 @@ def_int $experience = db_getfield($data, trapped_chest:experience, 0);
 def_int $respawn_ticks = db_getfield($data, trapped_chest:respawn_ticks, 0);
 def_int $current_level = stat(thieving);
 mes("You attempt to pick the lock.");
-
 if ($current_level < $thieving_level) {
     ~mesbox("You are not a high enough level to pick this lock.");
     return;
 }
 
+sound_synth(locked, 0, 0); // after first check, but before 2nd
 if (inv_total(inv, lockpick) < 1) {
     mes("You need a lockpick for this lock.");
     return;
 }
 
 mes("You manage to pick the lock.");
-sound_synth(locked, 0, 0);
 p_delay(1);
 mes("You open the chest.");
 sound_synth(chest_open, 0, 0);
@@ -102,10 +103,8 @@ mes("You find treasure inside!");
 anim(human_openchest, 0);
 stat_advance(thieving, $experience);
 ~trapped_chest_check_for_reward($data);
-// Temp note: dur updated
 loc_change(loc_2574, 4); //opened chest
-p_delay(3);
-// Temp note: dur does not need updated ???
+p_delay(2);
 loc_change(loc_2572, $respawn_ticks); //looted chest
 
 [oploc1,loc_2572]
@@ -116,7 +115,7 @@ mes("It looks like this chest has already been looted.");
 
 [oplocu,loc_2572]
 if (last_useitem = lockpick) {
-    mes("It looks like this chest has already been looted.");
+    p_oploc(2);
 } else {
     ~displaymessage(^dm_default);
 }

--- a/data/src/scripts/skill_thieving/scripts/thieving.rs2
+++ b/data/src/scripts/skill_thieving/scripts/thieving.rs2
@@ -111,13 +111,11 @@ p_delay(0);
 def_int $hitpoints = multiply(stat(hitpoints), 12);
 def_int $damage = calc($hitpoints / 100);
 $damage = calc($damage + 3);
-// Always damage type 1.
-damage(uid, 1, $damage);
-sound_synth(human_hit4, 0, 20);
+~damage_self($damage);
 
 [proc,disarm_trapped_chest](dbrow $data, loc $loc, coord $loc_coord, int $loc_angle, locshape $loc_shape)
 // https://www.youtube.com/watch?v=5SxYEdRdiPU
-mes("You find a trap on the chest,");
+mes("You find a trap on the chest, "); // extra space matches OSRS
 p_delay(1);
 mes("You disable the trap.");
 sound_synth(locked, 0, 0);
@@ -130,16 +128,16 @@ anim(human_openchest, 0);
 ~trapped_chest_check_for_reward($data);
 def_int $experience = db_getfield($data, trapped_chest:experience, 0);
 stat_advance(thieving, $experience);
-def_int $respawn_ticks = db_getfield($data, trapped_chest:respawn_ticks, 0);
-// Temp note: dur does not need updated
-loc_change(loc_2574, $respawn_ticks);
-
+def_int $respawn_ticks = ~scale_by_playercount(db_getfield($data, trapped_chest:respawn_ticks, 0));
+loc_change(loc_2574, 4); //opened chest
+p_delay(2);
 if (db_getfieldcount($data, trapped_chest:tele_coord) > 0) {
-    p_delay(3);
     mes("Suddenly a second magical trap triggers.");
-    sound_synth(chest_open, 0, 0);
-    p_telejump(db_getfield($data, trapped_chest:tele_coord, 0));
+    sound_synth(lever, 0, 0);
+    p_teleport(db_getfield($data, trapped_chest:tele_coord, 0));
 }
+loc_change(loc_2572, $respawn_ticks); //looted chest
+
 
 [proc,pick_pocket_check_for_reward](dbrow $data)
 def_int $count = calc(db_getfieldcount($data, pickpocket:loot) - 1);

--- a/data/src/scripts/skill_woodcutting/configs/trees.dbrow
+++ b/data/src/scripts/skill_woodcutting/configs/trees.dbrow
@@ -42,7 +42,7 @@ data=tree,jungle_tree_3
 data=tree,jungle_bush_1
 data=tree,jungle_bush_2
 data=levelrequired,0
-data=productexp,100
+data=productexp,1000
 data=product,logs
 data=respawnrate,4
 


### PR DESCRIPTION
- fixes to timing, sounds, and locs used for trapped/locked thieving chests
- fix respawnrates of chests to match OSRS, and multiply all by 2 to use playercount scaling instead (old videos show longer times, e.g. https://www.youtube.com/watch?v=Mwg4q__B2Z4)
- fix jungle bushes/trees giving 10 xp instead of 100, increase odds of rolling logs on chop