### PR TITLE
fix(content): add authentic line breaks in random event dialogue

### DIFF
--- a/data/src/scripts/macro events/scripts/general/macro_event_drunken_dwarf.rs2
+++ b/data/src/scripts/macro events/scripts/general/macro_event_drunken_dwarf.rs2
@@ -74,7 +74,7 @@ inv_add(inv, beer, 1);
 
 npc_queue(6, 0, 0); // say good bye
 npc_settimer(0);
-~chatnpc("<p,drunk>I 'new it were you matey! 'Ere, have some ob the good stuff!"); // osrs
+~chatnpc("<p,drunk>I 'new it were you matey!|'Ere, have some ob the good stuff!"); // 2004
 
 // https://youtu.be/8wJZmDwcBKs?t=108
 [ai_opplayer2,macro_event_drunken_dwarf]

--- a/data/src/scripts/macro events/scripts/general/macro_event_genie.rs2
+++ b/data/src/scripts/macro events/scripts/general/macro_event_genie.rs2
@@ -59,7 +59,7 @@ npc_delay(2);
 if (uid ! %npc_macro_event_target) {
     // https://youtu.be/qNQYgiNMBes?t=134
     if (.finduid(%npc_macro_event_target) = true) {
-        ~chatnpc("<p,sad>Sorry, but I'm trying to talk to <.displayname>. However, <.text_gender("he", "she")> appears to be ignoring me..."); 
+        ~chatnpc("<p,sad>Sorry, but I'm trying to talk to <.displayname>.|However, <.text_gender("he", "she")> appears to be ignoring me..."); 
         return;
     }
     ~chatnpc("<p,sad>Sorry, but I'm trying to talk to another player.|However, they appear to be ignoring me...");

--- a/data/src/scripts/macro events/scripts/general/macro_event_mysterious_old_man.rs2
+++ b/data/src/scripts/macro events/scripts/general/macro_event_mysterious_old_man.rs2
@@ -59,7 +59,7 @@ npc_delay(2);
 if (uid ! %npc_macro_event_target) {
     // https://youtu.be/U_TRFGTfIY0?t=276
     if (.finduid(%npc_macro_event_target) = true) {
-        ~chatnpc("<p,sad>Sorry, but I'm trying to talk to <.displayname>. However, <.text_gender("he", "she")> appears to be ignoring me..."); // same as genie
+        ~chatnpc("<p,sad>Sorry, but I'm trying to talk to <.displayname>.|However, <.text_gender("he", "she")> appears to be ignoring me..."); // same as genie
         return;
     }
     ~chatnpc("<p,sad>Sorry, but I'm trying to talk to another player.|However, they appear to be ignoring me...");

--- a/data/src/scripts/macro events/scripts/general/macro_event_mysterious_old_man.rs2
+++ b/data/src/scripts/macro events/scripts/general/macro_event_mysterious_old_man.rs2
@@ -58,8 +58,9 @@ npc_delay(2);
 [opnpc1,macro_event_mysterious_old_man_general]
 if (uid ! %npc_macro_event_target) {
     // https://youtu.be/U_TRFGTfIY0?t=276
+    // no comma and 'ignorning' is authentic
     if (.finduid(%npc_macro_event_target) = true) {
-        ~chatnpc("<p,sad>Sorry, but I'm trying to talk to <.displayname>.|However, <.text_gender("he", "she")> appears to be ignoring me..."); // same as genie
+        ~chatnpc("<p,sad>Sorry, but I'm trying to talk to <.displayname>.|However <.text_gender("he", "she")> appears to be ignorning me...");
         return;
     }
     ~chatnpc("<p,sad>Sorry, but I'm trying to talk to another player.|However, they appear to be ignoring me...");


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/a766f311-7f01-49c2-bbfe-a840d8551d77)
![image](https://github.com/user-attachments/assets/bce8ad52-c242-4b3e-b8ba-e462bf4c8305)
