### PR TITLE
fix(content): no longer pass gnomeballs if equipping something in your right hand

### DIFF
--- a/data/src/scripts/minigames/game_gnomeball/scripts/gnomeball_pass.rs2
+++ b/data/src/scripts/minigames/game_gnomeball/scripts/gnomeball_pass.rs2
@@ -10,7 +10,7 @@ if (inv_total(worn, ball_gnomeball_game) < 1 & $player1_ingame = true) {
     mes("You need a ball in your hand to throw.");
     return;
 }
-if (inv_getobj(worn, ^wearpos_rhand) ! null) {
+if (inv_getobj(worn, ^wearpos_rhand) ! null & $player1_ingame = false) {
     mes("You need your right hand free to pass a ball."); // osrs
     return;
 }

--- a/data/src/scripts/minigames/game_gnomeball/scripts/gnomeball_pass.rs2
+++ b/data/src/scripts/minigames/game_gnomeball/scripts/gnomeball_pass.rs2
@@ -10,6 +10,10 @@ if (inv_total(worn, ball_gnomeball_game) < 1 & $player1_ingame = true) {
     mes("You need a ball in your hand to throw.");
     return;
 }
+if (inv_getobj(worn, ^wearpos_rhand) ! null) {
+    mes("You need your right hand free to pass a ball."); // osrs
+    return;
+}
 // https://oldschool.runescape.wiki/w/Update:Patch_Notes_(3_October_2013)
 // if close early: "Players can no longer use a gnomeball to interrupt other players' Make-X actions without the gnomeball being thrown."
 .if_close;


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/3ba99aee-d87b-4dcd-b8a0-33141937d61b)
