### PR TITLE
fix(engine): hasInteraction() to return false if targetOp is following

### DIFF
--- a/src/engine/entity/Player.ts
+++ b/src/engine/entity/Player.ts
@@ -939,7 +939,14 @@ export default class Player extends PathingEntity {
     }
 
     hasInteraction() {
-        return this.target !== null;
+        if (!this.target) {
+            return false;
+        }
+        // The follow interaction doesn't do anything
+        if (this.targetOp === ServerTriggerType.APPLAYER3 || this.targetOp === ServerTriggerType.OPPLAYER3) {
+            return false;
+        }
+        return true;
     }
 
     getOpTrigger() {
@@ -1062,17 +1069,13 @@ export default class Player extends PathingEntity {
     }
 
     tryInteract(allowOpScenery: boolean): boolean {
-        if (this.target === null || !this.canAccess()) {
+        if (!this.target || !this.hasInteraction() || !this.canAccess()) {
             return false;
         }
 
         const opTrigger = this.getOpTrigger();
         const apTrigger = this.getApTrigger();
 
-        // The follow interaction doesn't do anything, just continue
-        if (this.targetOp === ServerTriggerType.APPLAYER3 || this.targetOp === ServerTriggerType.OPPLAYER3) {
-            return false;
-        }
         // Run the opTrigger if it exists and Player is within range
         // allowOpScenery controls if Locs and Objs can be op'd
         if (opTrigger && (this.target instanceof PathingEntity || allowOpScenery) && this.inOperableDistance(this.target)) {


### PR DESCRIPTION
matches from early osrs [video](https://youtu.be/gUB1rS53IFc?t=1803):



https://github.com/user-attachments/assets/ca201831-e8a1-4158-89bc-52986ce01f21




before:

https://github.com/user-attachments/assets/a86780c6-821a-4247-b280-2160629191fc

after: 

https://github.com/user-attachments/assets/c738cd7b-a6ae-407a-8dee-a8388ba6e336

some other relevant vids:
- dont retal if moving: https://youtu.be/-zOKqWTUM40?t=77