### PR TITLE
fix(content): remove members check from lava eel fishing to match osrs

### DIFF
--- a/data/src/scripts/general/configs/free_to_play.constant
+++ b/data/src/scripts/general/configs/free_to_play.constant
@@ -10,6 +10,3 @@
 
 // this exists in osrs mesbox, not sure if it actually exists though. for trying to enter chaos altar on f2p worlds
 ^mes_members_do_that = "You must be on a members' world to do that."
-
-// unconfirmed
-^mes_members_fish_here = "You need to be on a members world to fish here."

--- a/data/src/scripts/skill_fishing/scripts/fishing_spots/lavafish.rs2
+++ b/data/src/scripts/skill_fishing/scripts/fishing_spots/lavafish.rs2
@@ -80,11 +80,6 @@ if (%action_delay < map_clock) {
 p_opnpc(3);
 
 [proc,oil_rod_fishing_check_requirements]()(boolean)
-if (map_members = false) {
-    anim(null, 0);
-    ~mesbox(^mes_members_fish_here);
-    return(false);
-}
 // check level
 if (stat(fishing) < 53) {
     anim(null, 0);


### PR DESCRIPTION
In osrs it just lets you fish in f2p, no members check at all

https://github.com/user-attachments/assets/18e874c2-1716-442d-879c-8a1445486b63

