### PR TITLE
fix(content): monks no longer heal and die at the same time

### DIFF
--- a/data/src/scripts/areas/monastery/scripts/monk.rs2
+++ b/data/src/scripts/areas/monastery/scripts/monk.rs2
@@ -1,7 +1,6 @@
 [ai_opplayer2,monk_edgeville]
 if (%npc_action_delay > map_clock) return;
-def_int $heal = random(4); // thanks to joe the toe!
-if ($heal = 0) {
+if (random(4) = 0) { // osrs - thanks to joe the toe!
     @monk_heal_self;
 } else {
     ~npc_default_attack;
@@ -32,3 +31,9 @@ mes("You feel a little better.");
 [label,ask_to_join_monk]
 ~chatplayer("<p,quiz>How do I get further into the monastery?");
 ~chatnpc("<p,neutral>You'll need to talk to Abbot Langley about that. He's|usually to be found walking the halls of the monastery.");
+
+[ai_queue3,monk_edgeville]
+if (npc_stat(hitpoints) ! 0) {
+    return;
+}
+~npc_default_death;


### PR DESCRIPTION
matches osrs:

- monks can self heal the same tick their hp reaches 0 and ai_queue3 is called

https://github.com/user-attachments/assets/ce1c6f2d-7720-40e8-bc95-e4fdfc7a3ee0

- monks can also naturally regenerate the same tick ai_queue3 runs. Normally the death script will still run for other npcs, but monks differ in this case


https://github.com/user-attachments/assets/5fdacef5-63dc-46a0-8922-f6ba363fa5c0

