### PR TITLE
fix(engine): INV_DROPALL crash due to misplaced brace

### DIFF
--- a/src/engine/script/handlers/InvOps.ts
+++ b/src/engine/script/handlers/InvOps.ts
@@ -759,7 +759,7 @@ const InvOps: CommandHandlers = {
         }
 
         if (wealthLog.size > 0) {
-            const items = Array.from(wealthLog.values().map(item => (({ cost: _cost, ...event }) => event)(item)));
+            const items = Array.from(wealthLog.values()).map(item => (({ cost: _cost, ...event }) => event)(item));
             state.activePlayer.addWealthEvent({
                 event_type: WealthEventType.DEATH,
                 account_items: items,


### PR DESCRIPTION
Bug:
Players who die while meeting the condition `wealthLog.size > 0` fail to die "correctly". Instead they are logged out. When they log back in they are in the same place as they died, they have 0 hitpoints and they have lost _all_ of their items.

Error message:
```
script error: inv_dropall wealthLog.values(...).map is not a function
file: death.rs2

stack backtrace:
    1: [proc,player_death_lose_items] - death.rs2:91
    2: [proc,player_death_lose_items] - death.rs2:63
```

Fix:
Re-arrange brackets to prevent the script from crashing.