### PR TITLE
fix(content): move wizard boots to level 1 clues

### DIFF
--- a/data/src/scripts/minigames/game_trail/scripts/easy/trail_clue_easy_reward.rs2
+++ b/data/src/scripts/minigames/game_trail/scripts/easy/trail_clue_easy_reward.rs2
@@ -63,7 +63,7 @@ switch_int ($random) {
 }
 
 [proc,trail_clue_easy_rare]
-def_int $random = random(12);
+def_int $random = random(13);
 
 switch_int ($random) {
     case 0 : inv_add(trail_rewardinv, black_platebody_trim, 1);
@@ -78,4 +78,5 @@ switch_int ($random) {
     case 9 : inv_add(trail_rewardinv, berret_blue, 1);
     case 10 : inv_add(trail_rewardinv, berret_black, 1);
     case 11 : inv_add(trail_rewardinv, berret_white, 1);
+    case 12 : inv_add(trail_rewardinv, boots_wizard, 1);
 }

--- a/data/src/scripts/minigames/game_trail/scripts/medium/trail_clue_medium_reward.rs2
+++ b/data/src/scripts/minigames/game_trail/scripts/medium/trail_clue_medium_reward.rs2
@@ -55,20 +55,19 @@ switch_int ($random) {
 }
 
 [proc,trail_clue_medium_rare]
-def_int $random = random(13);
+def_int $random = random(12);
 
-switch_int ($random){
-    case 0 : inv_add(trail_rewardinv, boots_wizard, 1);
-    case 1 : inv_add(trail_rewardinv, boots_ranger, 1);
-    case 2 : inv_add(trail_rewardinv, adamant_full_helm_trim, 1);
-    case 3 : inv_add(trail_rewardinv, adamant_platebody_trim, 1);
-    case 4 : inv_add(trail_rewardinv, adamant_platelegs_trim, 1);
-    case 5 : inv_add(trail_rewardinv, adamant_kiteshield_trim, 1);
-    case 6 : inv_add(trail_rewardinv, adamant_platebody_gold, 1);
-    case 7 : inv_add(trail_rewardinv, adamant_platelegs_gold, 1);
-    case 8 : inv_add(trail_rewardinv, adamant_full_helm_gold, 1);
-    case 9 : inv_add(trail_rewardinv, adamant_kiteshield_gold, 1);
-    case 10 : inv_add(trail_rewardinv, headband_red, 1);
-    case 11 : inv_add(trail_rewardinv, headband_black, 1);
-    case 12 : inv_add(trail_rewardinv, headband_brown, 1);
+switch_int ($random) {
+    case 0 : inv_add(trail_rewardinv, boots_ranger, 1);
+    case 1 : inv_add(trail_rewardinv, adamant_full_helm_trim, 1);
+    case 2 : inv_add(trail_rewardinv, adamant_platebody_trim, 1);
+    case 3 : inv_add(trail_rewardinv, adamant_platelegs_trim, 1);
+    case 4 : inv_add(trail_rewardinv, adamant_kiteshield_trim, 1);
+    case 5 : inv_add(trail_rewardinv, adamant_platebody_gold, 1);
+    case 6 : inv_add(trail_rewardinv, adamant_platelegs_gold, 1);
+    case 7 : inv_add(trail_rewardinv, adamant_full_helm_gold, 1);
+    case 8 : inv_add(trail_rewardinv, adamant_kiteshield_gold, 1);
+    case 9 : inv_add(trail_rewardinv, headband_red, 1);
+    case 10 : inv_add(trail_rewardinv, headband_black, 1);
+    case 11 : inv_add(trail_rewardinv, headband_brown, 1);
 }


### PR DESCRIPTION
- only mentioned in level 1s on official sites knowledge base https://web.archive.org/web/20060415002328/http://kbase.runescape.com:80/lang/en/aff/runescape/viewarticle.ws?article_id=1989
- moved to level 2 at some point after Oct 2006, the Dec 2006 clue expansion seems likely, costume room was updated here https://oldschool.runescape.wiki/w/Update:Game_Improvements, https://x.com/JagexAsh/status/808118338908024832
- old guides mention it in level 1, some have it in both tiers, likely a mistake since no other clue unique shares tiers
    - https://www.neoseeker.com/runescape/faqs/125252-treasure-trail.html, 
    - https://web.archive.org/web/20040813233712/http://runehq.com/viewguidedb.php?id=00350#rewards
    - https://web.archive.org/web/20050412082313/http://www.tip.it/runescape/?page=treasure_trails.htm (both tiers)