### PR TITLE
fix(engine): Item stacks will no longer reverse their order if a player leaves and re-enters a zone

### DIFF
--- a/src/engine/zone/Zone.ts
+++ b/src/engine/zone/Zone.ts
@@ -132,7 +132,7 @@ export default class Zone {
         const currentTick: number = World.currentTick;
         // full update necessary to clear client zone memory
         player.write(new UpdateZoneFullFollows(this.x, this.z, player.originX, player.originZ));
-        for (const obj of this.getAllObjsUnsafe(true)) {
+        for (const obj of this.getAllObjsUnsafe()) {
             if (obj.lastLifecycleTick === currentTick || (obj.receiver64 !== Obj.NO_RECEIVER && obj.receiver64 !== player.hash64)) {
                 continue;
             }
@@ -143,7 +143,7 @@ export default class Zone {
                 player.write(new ObjAdd(CoordGrid.packZoneCoord(obj.x, obj.z), obj.type, obj.count));
             }
         }
-        for (const loc of this.getAllLocsUnsafe(true)) {
+        for (const loc of this.getAllLocsUnsafe()) {
             if (loc.lastLifecycleTick === currentTick) {
                 continue;
             }


### PR DESCRIPTION
We were sending the order of Locs and Objs in the order of newest->oldest before this PR. This was an externality of the new zone impl. rolled out a month or two ago

I tested on rsprox and the order should be oldest->newest when reloading a zone

Bug report here: https://discord.com/channels/953326730632904844/1365080774705025095/1365080774705025095