### PR TITLE
fix(content): remove run energy restore on tutorial island completion

### DIFF
--- a/data/src/scripts/tutorial/scripts/tutorial.rs2
+++ b/data/src/scripts/tutorial/scripts/tutorial.rs2
@@ -328,7 +328,6 @@ inv_clear(bank);
 inv_add(bank, coins, 25);
 
 ~stat_reset_all;
-healenergy(10000);
 
 ~initalltabs;
 ~update_all(inv_getobj(worn, ^wearpos_rhand));


### PR DESCRIPTION
from [blog](https://oldschool.runescape.wiki/w/Update:Calling_Pets_%26_Deadman_Death):
`Run energy is now restored at the end of the tutorial.`