### PR TITLE
fix(content): clear movement and interactions when you use your last dart/knife/jav

### DIFF
--- a/data/src/scripts/skill_combat/scripts/player/player_ranged.rs2
+++ b/data/src/scripts/skill_combat/scripts/player/player_ranged.rs2
@@ -60,6 +60,8 @@ if ($damage > 0 & $poison_severity > 0 & random(8) = 0) { // 1/8 chance to poiso
     ~npc_poison_start(max(sub($poison_severity, 14), 0)); // lowered by 14 if ranged attack
 }
 
+p_opnpc(2);
+
 //mes("attackstyle: <tostring(%attackstyle)>, damagestyle: <tostring(%damagestyle)>, damage: <tostring($damage)>, damagetype: <tostring(%damagetype)>");
 anim(%com_attackanim, 0);
 sound_synth(%com_attacksound, 0, 0);
@@ -70,8 +72,6 @@ npc_anim(npc_param(defend_anim), sub($delay, 30)); // delay npc this tick
 if (npc_param(defend_sound) ! null) {
     sound_synth(npc_param(defend_sound), 0, sub($delay, 30)); // delay 1 client tick for the hit queue
 }
-
-p_opnpc(2);
 
 if ($ammo = holy_water) {
     ~ranged_dropammo_npc($ammo, ^true, sub(divide($delay, 30), 2)); // 100% chance to drop ammo
@@ -122,6 +122,7 @@ spotanim_pl(oc_param($ammo, proj_launch), 96, 0);
 inv_del(worn, $ammo, 1);
 if (inv_total(worn, $ammo) = 0) {
     mes("That was your last one!");
+    p_stopaction;
     ~update_all(inv_getobj(worn, ^wearpos_rhand));
 }
 return(~npc_projectile(coord, npc_uid, oc_param($ammo, proj_travel), 40, 36, 32, 15, 0, 11, 5));


### PR DESCRIPTION
osrs:

https://github.com/user-attachments/assets/d22ceda6-4e5b-49af-af7a-e9b2f9946830


before:

https://github.com/user-attachments/assets/e12d5c79-51c8-4e34-bc4a-8f64fab7df93


after:

https://github.com/user-attachments/assets/98ba7e47-84e7-45c3-9f95-0f88643ccfc2

