### PR TITLE
fix(content): add self combat check to ai_opplayer2, and match npc retal edgecases

### DIFF
--- a/data/src/scripts/areas/area_alkharid/scripts/al_kharid_warrior.rs2
+++ b/data/src/scripts/areas/area_alkharid/scripts/al_kharid_warrior.rs2
@@ -5,7 +5,7 @@
 [ai_queue1,alkharid_warrior]
 def_npc_mode $npc_mode = npc_getmode;
 ~npc_default_retaliate;
-if (finduid(%npc_attacking_uid) = true & $npc_mode ! opplayer2) { // in osrs it checks mode rather than ~npc_out_of_combat
+if (finduid(%npc_attacking_uid) = true & $npc_mode ! opplayer2) { // in osrs it checks mode rather than ~npc_retal_ready
     npc_huntall(npc_coord, 5, 0);
     while (npc_huntnext = true) {
         if (npc_type = alkharid_warrior & npc_getmode ! opplayer2) {

--- a/data/src/scripts/areas/area_alkharid/scripts/al_kharid_warrior.rs2
+++ b/data/src/scripts/areas/area_alkharid/scripts/al_kharid_warrior.rs2
@@ -3,15 +3,20 @@
 // https://youtu.be/D8VG03tRR1w?t=60
 // https://youtu.be/cjmEFliibGI
 [ai_queue1,alkharid_warrior]
-def_npc_mode $npc_mode = npc_getmode;
+if (finduid(%npc_aggressive_player) = false) {
+    return;
+}
+if (npc_getmode = opplayer2) {
+    ~npc_default_retaliate;
+    return;
+}
 ~npc_default_retaliate;
-if (finduid(%npc_attacking_uid) = true & $npc_mode ! opplayer2) { // in osrs it checks mode rather than ~npc_retal_ready
-    npc_huntall(npc_coord, 5, 0);
-    while (npc_huntnext = true) {
-        if (npc_type = alkharid_warrior & npc_getmode ! opplayer2) {
-            npc_say("Brother, I will help thee with this infidel!");
-            %npc_aggressive_player = uid;
-            ~npc_default_retaliate;
-        }
+npc_huntall(npc_coord, 5, 0);
+while (npc_huntnext = true) {
+    if (npc_type = alkharid_warrior & npc_getmode ! opplayer2) {
+        npc_say("Brother, I will help thee with this infidel!");
+        %npc_aggressive_player = uid;
+        npc_setmode(opplayer2);
     }
 }
+

--- a/data/src/scripts/areas/area_barbarian_village/scripts/beer_barrels.rs2
+++ b/data/src/scripts/areas/area_barbarian_village/scripts/beer_barrels.rs2
@@ -1,8 +1,8 @@
 [label,beer_barrel_beatdown]
 mes("The barbarians probably don't like people messing with their barrels.");
-npc_findallany(coord, 10, ^vis_lineofsight);
-while (npc_findnext = true) {
-    if (npc_category = barbarian) {
+npc_huntall(coord, 10, ^vis_lineofsight);
+while (npc_huntnext = true) {
+    if (npc_category = barbarian & npc_getmode ! opplayer2) {
         npc_say("Oi - that's ours!");
         npc_setmode(opplayer2);
     }

--- a/data/src/scripts/areas/area_draynor/scripts/witch.rs2
+++ b/data/src/scripts/areas/area_draynor/scripts/witch.rs2
@@ -8,8 +8,11 @@ if (%npc_action_delay > map_clock) {
     npc_setmode(applayer2);
     return;
 }
-if (~npc_can_attack_player = false) {
+if (~npc_check_notcombat = false) {
     npc_setmode(null);
+    return;
+}
+if (~npc_check_notcombat_self = false) {
     return;
 }
 if (stat_base(strength) <= stat(strength) & random(2) = 0) { // guessed from dark wizards

--- a/data/src/scripts/areas/area_mage_arena/scripts/battle_mage.rs2
+++ b/data/src/scripts/areas/area_mage_arena/scripts/battle_mage.rs2
@@ -41,7 +41,7 @@ if (random(10) = 0 & inv_total(worn, saradomin_staff) > 0 & inv_total(worn, sara
     return;
 }
 ~npc_cast_spell(^saradomin_strike, 5);
-if (~npc_can_attack_player = true) {
+if (~npc_check_notcombat = true & ~npc_check_notcombat_self = true) {
     npc_say("Feel the wrath of Saradomin.");
 }
 
@@ -51,7 +51,7 @@ if (random(10) = 0 & inv_total(worn, guthix_staff) > 0 & inv_total(worn, guthix_
     return;
 }
 ~npc_cast_spell(^claws_of_guthix, 5);
-if (~npc_can_attack_player = true) {
+if (~npc_check_notcombat = true & ~npc_check_notcombat_self = true) {
     npc_say("Feel the wrath of Guthix.");
 }
 
@@ -61,6 +61,6 @@ if (random(10) = 0 & inv_total(worn, zamorak_staff) > 0 & inv_total(worn, zamora
     return;
 }
 ~npc_cast_spell(^flames_of_zamorak, 5);
-if (~npc_can_attack_player = true) {
+if (~npc_check_notcombat = true & ~npc_check_notcombat_self = true) {
     npc_say("Feel the wrath of Zamorak.");
 }

--- a/data/src/scripts/areas/area_wilderness/scripts/king_black_dragon.rs2
+++ b/data/src/scripts/areas/area_wilderness/scripts/king_black_dragon.rs2
@@ -76,8 +76,11 @@ if ($random < 10) { // osrs
 if (%npc_action_delay > map_clock) {
     return;
 }
-if (~npc_can_attack_player = false) {
+if (~npc_check_notcombat = false) {
     npc_setmode(null);
+    return;
+}
+if (~npc_check_notcombat_self = false) {
     return;
 }
 // kbd can attack from a distance but can also be safespoted
@@ -95,8 +98,11 @@ npc_setmode(opplayer2);
 if (%npc_action_delay > map_clock) {
     return;
 }
-if (~npc_can_attack_player = false) {
+if (~npc_check_notcombat = false) {
     npc_setmode(null);
+    return;
+}
+if (~npc_check_notcombat_self = false) {
     return;
 }
 ~kbd_random_attack;

--- a/data/src/scripts/macro events/scripts/general/macro_event_drunken_dwarf.rs2
+++ b/data/src/scripts/macro events/scripts/general/macro_event_drunken_dwarf.rs2
@@ -79,8 +79,11 @@ npc_settimer(0);
 // https://youtu.be/8wJZmDwcBKs?t=108
 [ai_opplayer2,macro_event_drunken_dwarf]
 if (%npc_action_delay > map_clock) return;
-if (~npc_can_attack_player = false) {
+if (~npc_check_notcombat = false) {
     npc_setmode(null);
+    return;
+}
+if (~npc_check_notcombat_self = false) {
     return;
 }
 

--- a/data/src/scripts/macro events/scripts/mining/macro_event_rock_golem.rs2
+++ b/data/src/scripts/macro events/scripts/mining/macro_event_rock_golem.rs2
@@ -26,8 +26,11 @@ npc_setmode(opplayer2);
 if (%npc_action_delay > map_clock) {
     return;
 }
-if (~npc_can_attack_player = false) {
+if (~npc_check_notcombat = false) {
     npc_setmode(null);
+    return;
+}
+if (~npc_check_notcombat_self = false) {
     return;
 }
 if (npc_range(coord) < 2) {

--- a/data/src/scripts/npc/scripts/chaos_druid.rs2
+++ b/data/src/scripts/npc/scripts/chaos_druid.rs2
@@ -2,8 +2,11 @@
 if (%npc_action_delay > map_clock) {
     return;
 }
-if (~npc_can_attack_player = false) {
+if (~npc_check_notcombat = false) {
     npc_setmode(null);
+    return;
+}
+if (~npc_check_notcombat_self = false) {
     return;
 }
 ~chaos_druid_spell;
@@ -13,8 +16,11 @@ if(random(4) ! 0) npc_setmode(opplayer2);
 if (%npc_action_delay > map_clock) {
     return;
 }
-if (~npc_can_attack_player = false) {
+if (~npc_check_notcombat = false) {
     npc_setmode(null);
+    return;
+}
+if (~npc_check_notcombat_self = false) {
     return;
 }
 // ~1/4 based off 100 attacks in osrs

--- a/data/src/scripts/npc/scripts/dark_wizard.rs2
+++ b/data/src/scripts/npc/scripts/dark_wizard.rs2
@@ -11,8 +11,11 @@ if (%npc_action_delay > map_clock) {
     npc_setmode(applayer2);
     return;
 }
-if (~npc_can_attack_player = false) {
+if (~npc_check_notcombat = false) {
     npc_setmode(null);
+    return;
+}
+if (~npc_check_notcombat_self = false) {
     return;
 }
 
@@ -35,8 +38,11 @@ if (%npc_action_delay > map_clock) {
     npc_setmode(applayer2);
     return;
 }
-if (~npc_can_attack_player = false) {
+if (~npc_check_notcombat = false) {
     npc_setmode(null);
+    return;
+}
+if (~npc_check_notcombat_self = false) {
     return;
 }
 

--- a/data/src/scripts/npc/scripts/dragon.rs2
+++ b/data/src/scripts/npc/scripts/dragon.rs2
@@ -25,8 +25,11 @@
 // if (%npc_action_delay > map_clock) {
 //     return;
 // }
-// if (~npc_can_attack_player = false) {
+// if (~npc_check_notcombat = false) {
 //     npc_setmode(null);
+//     return;
+// }
+// if (~npc_check_notcombat_self = false) {
 //     return;
 // }
 // // 1/2 chance to switch to op, with line of walk check (same as elvarg for now)
@@ -41,8 +44,11 @@
 if (%npc_action_delay > map_clock) {
     return;
 }
-if (~npc_can_attack_player = false) {
+if (~npc_check_notcombat = false) {
     npc_setmode(null);
+    return;
+}
+if (~npc_check_notcombat_self = false) {
     return;
 }
 // edit: elvarg was reworked after the dragon slayer rework.
@@ -63,8 +69,11 @@ if (stat(hitpoints) = 0) {
     return;
 }
 if (%npc_action_delay > map_clock) return;
-if (~npc_can_attack_player = false) {
+if (~npc_check_notcombat = false) {
     npc_setmode(null);
+    return;
+}
+if (~npc_check_notcombat_self = false) {
     return;
 }
 anim(%com_defendanim, 0);

--- a/data/src/scripts/npc/scripts/shadow_spider.rs2
+++ b/data/src/scripts/npc/scripts/shadow_spider.rs2
@@ -6,12 +6,15 @@ if (stat(hitpoints) = 0) {
 if (%npc_action_delay > map_clock) {
     return;
 }
-if (~npc_can_attack_player = false) {
+if (~npc_check_notcombat = false) {
     npc_setmode(null);
     return;
 }
+if (~npc_check_notcombat_self = false) {
+    return;
+}
 // https://www.youtube.com/watch?v=qCuX19-3SHc&t=185s
-if (~npc_out_of_combat = true) {
+if (~npc_retal_ready = true) {
     ~shadow_spider_drain;
 }
 ~npc_meleeattack;
@@ -22,7 +25,7 @@ sound_synth(prayer_drain, 0, 0);
 stat_sub(prayer, divide(stat(prayer), 2), 0); // division by 2 round up, thats why percent isn't being used 
 
 [ai_queue2,shadow_spider]
-if (~npc_out_of_combat = true & finduid(%npc_aggressive_player) = true) {
+if (~npc_retal_ready = true & finduid(%npc_aggressive_player) = true) {
     ~shadow_spider_drain;
 }
 ~npc_default_damage(last_int);

--- a/data/src/scripts/quests/quest_arena/scripts/bouncer.rs2
+++ b/data/src/scripts/quests/quest_arena/scripts/bouncer.rs2
@@ -15,7 +15,7 @@ if (inzone(^arena_lower_coord, ^arena_upper_coord, coord) = true) @defeat_bounce
 if(%arena_progress = ^arena_defeated_scorpion) {
     %arena_progress = ^arena_defeated_bouncer;
     // https://youtu.be/mz82tzr4fJw?si=zkEYpF66XpLEbUjK&t=321, npc_add's another if the general is already in combat
-    if (npc_find(movecoord(coord, 8, 0, 0), general_khazard, 15, 0) = false | ~npc_out_of_combat = false) {
+    if (npc_find(movecoord(coord, 8, 0, 0), general_khazard, 15, 0) = false | ~npc_retal_ready = false) {
         npc_add(0_40_49_46_18, general_khazard, 500); // ticks guessed
     }
     @general_khazard_bouncer_killed;

--- a/data/src/scripts/quests/quest_arena/scripts/general_khazard.rs2
+++ b/data/src/scripts/quests/quest_arena/scripts/general_khazard.rs2
@@ -91,7 +91,7 @@ cam_reset;
 @general_khazard_attack;
 
 [label,general_khazard_agreement]
-if (npc_find(movecoord(coord, 8, 0, 0), general_khazard, 15, 0) = false | ~npc_out_of_combat = false) {
+if (npc_find(movecoord(coord, 8, 0, 0), general_khazard, 15, 0) = false | ~npc_retal_ready = false) {
     npc_add(0_40_49_46_18, general_khazard, 500); // ticks guessed
 }
 ~chatnpc("<p,skull>The agreement was that the Servils may leave if you won a few fights, and indeed they are now free to do so.");

--- a/data/src/scripts/quests/quest_dragon/scripts/elvarg.rs2
+++ b/data/src/scripts/quests/quest_dragon/scripts/elvarg.rs2
@@ -24,8 +24,11 @@ if (%dragon_progress < ^dragon_complete) {
 if (%npc_action_delay > map_clock) {
     return;
 }
-if (~npc_can_attack_player = false) {
+if (~npc_check_notcombat = false) {
     npc_setmode(null);
+    return;
+}
+if (~npc_check_notcombat_self = false) {
     return;
 }
 // 1/2 chance to switch to op, with line of walk check
@@ -40,8 +43,11 @@ if (random(2) = 0 & lineofwalk(npc_coord, coord) = true) {
 if (%npc_action_delay > map_clock) {
     return;
 }
-if (~npc_can_attack_player = false) {
+if (~npc_check_notcombat = false) {
     npc_setmode(null);
+    return;
+}
+if (~npc_check_notcombat_self = false) {
     return;
 }
 // 1/8 chance to switch back to ap

--- a/data/src/scripts/quests/quest_dragon/scripts/melzar_the_mad.rs2
+++ b/data/src/scripts/quests/quest_dragon/scripts/melzar_the_mad.rs2
@@ -8,8 +8,11 @@
 if (%npc_action_delay > map_clock) {
     return;
 }
-if (~npc_can_attack_player = false) {
+if (~npc_check_notcombat = false) {
     npc_setmode(null);
+    return;
+}
+if (~npc_check_notcombat_self = false) {
     return;
 }
 // data based off of 200 or so attacks
@@ -37,8 +40,11 @@ if ($random_attack < 8 & stat(strength) >= stat_base(strength)) { // dont cast i
 if (%npc_action_delay > map_clock) {
     return;
 }
-if (~npc_can_attack_player = false) {
+if (~npc_check_notcombat = false) {
     npc_setmode(null);
+    return;
+}
+if (~npc_check_notcombat_self = false) {
     return;
 }
 // mes("Op");

--- a/data/src/scripts/quests/quest_vampire/scripts/count_draynor.rs2
+++ b/data/src/scripts/quests/quest_vampire/scripts/count_draynor.rs2
@@ -24,8 +24,11 @@ if (stat(hitpoints) = 0) {
 if (%npc_action_delay > map_clock) {
     return;
 }
-if (~npc_can_attack_player = false) {
+if (~npc_check_notcombat = false) {
     npc_setmode(null);
+    return;
+}
+if (~npc_check_notcombat_self = false) {
     return;
 }
 anim(%com_defendanim, 0);

--- a/data/src/scripts/skill_combat/scripts/npc/npc_combat.rs2
+++ b/data/src/scripts/skill_combat/scripts/npc/npc_combat.rs2
@@ -6,10 +6,9 @@
 // a default melee retaliate script.
 [proc,npc_default_retaliate]
 // npc flinch
-if (~npc_out_of_combat = true) {
+if (~npc_retal_ready = true) {
     %npc_action_delay = add(map_clock, divide(npc_param(attackrate), 2));
     %npc_attacking_uid = %npc_aggressive_player;
-    %npc_lastattack = map_clock;
 }
 if (finduid(%npc_attacking_uid) = true) {
     if (npc_stat(hitpoints) <= npc_param(retreat)) {
@@ -22,10 +21,9 @@ if (finduid(%npc_attacking_uid) = true) {
 // mostly used for ranged and magic npc's
 [proc,npc_default_retaliate_ap]
 // set npc to ap if its out of combat
-if (~npc_out_of_combat = true) {
+if (~npc_retal_ready = true) {
     %npc_action_delay = add(map_clock, divide(npc_param(attackrate), 2));
     %npc_attacking_uid = %npc_aggressive_player;
-    %npc_lastattack = map_clock;
     if (finduid(%npc_attacking_uid) = true) {
         npc_setmode(applayer2);
     }
@@ -47,8 +45,11 @@ if (stat(hitpoints) = 0) {
     return;
 }
 if (%npc_action_delay > map_clock) return;
-if (~npc_can_attack_player = false) {
+if (~npc_check_notcombat = false) {
     npc_setmode(null);
+    return;
+}
+if (~npc_check_notcombat_self = false) { // Doesnt change mode! Keeps trying!
     return;
 }
 anim(%com_defendanim, 0);
@@ -262,8 +263,8 @@ mes("You can't attack this npc.");
 return (false);
 
 
-[proc,npc_out_of_combat]()(boolean)
-if ((add(%npc_lastattack, 8) < map_clock) | (npc_getmode ! applayer2 & npc_getmode ! opplayer2 & npc_getmode ! playerescape)) {
+[proc,npc_retal_ready]()(boolean)
+if ((add(%npc_action_delay, 8) < map_clock) | (npc_getmode ! applayer2 & npc_getmode ! opplayer2 & npc_getmode ! playerescape)) {
     return (true);
 }
 return (false);
@@ -314,38 +315,34 @@ p_preventlogout("You can't log out until 10 seconds after the end of combat.", 1
 
 [proc,npc_retaliate](int $queue_delay)
 npc_queue(1, 0, $queue_delay);
-// if in singles and attacking another player, then delay npc action by 8 ticks
-if (map_multiway(npc_coord) = false & %npc_attacking_uid ! uid & %npc_attacking_uid ! null) {
-    %npc_action_delay = add(map_clock, 8);
-}
 %npc_aggressive_player = uid;
 if(%npc_lastcombat < map_clock) %npc_lastcombat = map_clock;
 
 [proc,.npc_retaliate](int $queue_delay)
 .npc_queue(1, 0, $queue_delay);
-// if in singles and attacking another player, then delay npc action by 8 ticks
-if (map_multiway(.npc_coord) = false & .%npc_attacking_uid ! uid & .%npc_attacking_uid ! null) {
-    .%npc_action_delay = add(map_clock, 8);
-}
 .%npc_aggressive_player = uid;
 if(.%npc_lastcombat < map_clock) .%npc_lastcombat = map_clock;
 
 [proc,npc_set_attack_vars]
 %lastcombat = map_clock;
-%npc_lastattack = map_clock;
 %npc_attacking_uid = uid;
 %aggressive_npc = npc_uid;
 
-[proc,npc_can_attack_player]()(boolean)
-if (map_multiway(npc_coord) = false) {
+[proc,npc_check_notcombat]()(boolean)
+if (map_multiway(npc_coord) = false) { // checks npc coord ALWAYS!
     if (add(%lastcombat_pvp, 8) > map_clock) {
         return(false);
     }
-    if (add(%lastcombat, 8) > map_clock & %aggressive_npc ! npc_uid & %aggressive_npc ! null) {
+    if (add(%lastcombat, 8) > map_clock & %aggressive_npc ! null & %aggressive_npc ! npc_uid) {
         return(false);
     }
 }
-if (~inzone_coord_pair_table(gnomeball_zones, coord) = true) {
-    return(false); // osrs
+return(true);
+
+[proc,npc_check_notcombat_self]()(boolean)
+if (map_multiway(npc_coord) = false) {
+    if (add(%npc_lastcombat, 8) > map_clock & %npc_aggressive_player ! null & %npc_aggressive_player ! uid) {
+        return(false);
+    }
 }
 return(true);

--- a/data/src/scripts/skill_combat/scripts/npc/npc_combat.rs2
+++ b/data/src/scripts/skill_combat/scripts/npc/npc_combat.rs2
@@ -5,36 +5,29 @@
 
 // a default melee retaliate script.
 [proc,npc_default_retaliate]
-// npc flinch
-if (~npc_retal_ready = true) {
-    %npc_action_delay = add(map_clock, divide(npc_param(attackrate), 2));
-    %npc_attacking_uid = %npc_aggressive_player;
+if (finduid(%npc_aggressive_player) = false | ~npc_retal_ready = false) {
+    return;
 }
-if (finduid(%npc_attacking_uid) = true) {
-    if (npc_stat(hitpoints) <= npc_param(retreat)) {
-        npc_setmode(playerescape);
-    } else {
-        npc_setmode(opplayer2);
-    }
+%npc_action_delay = add(map_clock, divide(npc_param(attackrate), 2)); // flinch
+%npc_attacking_uid = %npc_aggressive_player;
+if (npc_stat(hitpoints) <= npc_param(retreat)) {
+    npc_setmode(playerescape);
+} else {
+    npc_setmode(opplayer2);
 }
 
 // mostly used for ranged and magic npc's
 [proc,npc_default_retaliate_ap]
-// set npc to ap if its out of combat
-if (~npc_retal_ready = true) {
-    %npc_action_delay = add(map_clock, divide(npc_param(attackrate), 2));
-    %npc_attacking_uid = %npc_aggressive_player;
-    if (finduid(%npc_attacking_uid) = true) {
-        npc_setmode(applayer2);
-    }
+if (finduid(%npc_aggressive_player) = false | ~npc_retal_ready = false) {
     return;
 }
-if (finduid(%npc_attacking_uid) = true & npc_getmode ! applayer2) {
-    if (npc_stat(hitpoints) <= npc_param(retreat)) {
-        npc_setmode(playerescape);
-    } else {
-        npc_setmode(opplayer2); // only set mode to op if the npc is not currently ap
-    }
+%npc_action_delay = add(map_clock, divide(npc_param(attackrate), 2));
+%npc_attacking_uid = %npc_aggressive_player;
+// default to ap
+if (npc_stat(hitpoints) <= npc_param(retreat)) {
+    npc_setmode(playerescape);
+} else {
+    npc_setmode(applayer2);
 }
 
 

--- a/data/src/scripts/skill_combat/scripts/npc/npc_combat_magic.rs2
+++ b/data/src/scripts/skill_combat/scripts/npc/npc_combat_magic.rs2
@@ -66,8 +66,11 @@ if (%npc_action_delay > map_clock) {
     npc_setmode(applayer2);
     return(false);
 }
-if (~npc_can_attack_player = false) {
+if (~npc_check_notcombat = false) {
     npc_setmode(null);
+    return(false);
+}
+if (~npc_check_notcombat_self = false) {
     return(false);
 }
 return(true);

--- a/data/src/scripts/skill_combat/scripts/npc/npc_combat_ranged.rs2
+++ b/data/src/scripts/skill_combat/scripts/npc/npc_combat_ranged.rs2
@@ -20,8 +20,11 @@ if (%npc_action_delay > map_clock) {
     npc_setmode(applayer2);
     return;
 }
-if (~npc_can_attack_player = false) {
+if (~npc_check_notcombat = false) {
     npc_setmode(null);
+    return;
+}
+if (~npc_check_notcombat_self = false) {
     return;
 }
 

--- a/data/src/scripts/tutorial/scripts/npcs/tut_giant_rat.rs2
+++ b/data/src/scripts/tutorial/scripts/npcs/tut_giant_rat.rs2
@@ -21,8 +21,11 @@ if (map_clock < %npc_action_delay) {
     return;
 }
 
-if (~npc_can_attack_player = false) {
+if (~npc_check_notcombat = false) {
     npc_setmode(null);
+    return;
+}
+if (~npc_check_notcombat_self = false) {
     return;
 }
 anim(%com_defendanim, 0);


### PR DESCRIPTION
- renames `~npc_can_attack_player` to `~npc_check_notcombat`
- adds new proc to check if the npc itself is in combat, `~npc_check_notcombat_self` (amazing how our combat managed to work as well as it did without this!)
- Partially removes %npc_lastattack, unnecessary varn.
- Refactors retal code to account for osrs edgecases
- adds opplayer2 mode check before aggroing barbarians when stealing their beer
- removes the flinching from al kharid warriors to match https://youtu.be/D8VG03tRR1w?t=60

Some edge cases that match osrs:
- ragging someones guard in singles

https://github.com/user-attachments/assets/f8ea75ca-f8f3-47e3-805f-6ff963664ff9

https://github.com/user-attachments/assets/edf29a91-86eb-44b5-b22a-807944df3592


- ranging highwayman defaults to ap

https://github.com/user-attachments/assets/9349d619-d932-4d46-8dcf-ee2519784733


https://github.com/user-attachments/assets/eef772c4-9ece-4095-b0b5-fab6479bd39c

- logging out on alt before the npc's retal code runs, %npc_action_delay unaffected. (this didnt match with the previous code!)

https://github.com/user-attachments/assets/b6a1787c-eef6-472d-ac71-c530dc8ad6cf


https://github.com/user-attachments/assets/856cde1b-6703-4a64-97c7-a355e5a53db6

