### PR TITLE
fix(engine): prevent smaller stat_boosts from overriding bigger stat_boosts

### DIFF
--- a/data/src/scripts/player/scripts/consumption/effects/scripts/kebab.rs2
+++ b/data/src/scripts/player/scripts/consumption/effects/scripts/kebab.rs2
@@ -77,3 +77,12 @@ if ($random_stat = hitpoints) {
 } else {
     stat_sub($random_stat, $debuff, 0);
 }
+
+
+[debugproc,godbab]
+mes("Wow, that was an amazing kebab! You feel really invigorated.");
+stat_boost(attack, 2, 0);
+stat_boost(strength, 2, 0);
+stat_boost(defence, 2, 0);
+// heal 24% + 7
+stat_heal(hitpoints, 7, 24);

--- a/src/engine/script/handlers/PlayerOps.ts
+++ b/src/engine/script/handlers/PlayerOps.ts
@@ -491,7 +491,7 @@ const PlayerOps: CommandHandlers = {
         const current = player.levels[stat];
 
         const boost = (constant + (base * percent) / 100) | 0;
-        const boosted = Math.min(current + boost, base + boost);
+        const boosted = Math.max(Math.min(current + boost, base + boost), current);
         player.levels[stat] = Math.min(boosted, 255);
         if (stat === PlayerStat.HITPOINTS && player.levels[PlayerStat.HITPOINTS] >= player.baseLevels[PlayerStat.HITPOINTS]) {
             player.heroPoints.clear();


### PR DESCRIPTION
before:

https://github.com/user-attachments/assets/6637f4b8-c6bf-4af9-ae3c-081ecffdb220

after:

https://github.com/user-attachments/assets/6320a5ae-4580-4a12-82ed-26beec00ebf2

