### PR TITLE
Necromancer drop chance fix.

### DIFF
--- a/data/src/scripts/drop tables/scripts/necromancer.rs2
+++ b/data/src/scripts/drop tables/scripts/necromancer.rs2
@@ -6,7 +6,7 @@ if (npc_findhero = false) {
 
 // Default drop from config.
 obj_add(npc_coord, npc_param(death_drop), 1, ^lootdrop_duration);
-def_int $random = random(20);
+def_int $random = random(128);
 
 if ($random < 8) {
     obj_add(npc_coord, plainstaff, 1, ^lootdrop_duration);


### PR DESCRIPTION
Necromancer only rolls a 20 instead of a 128, leaving most of the drop table unattainable.
This fixes it.