### PR TITLE
refactor(content): npc_findallzone, climb_ladder, adds npc_findcat() command

### DIFF
--- a/data/src/scripts/areas/area_alkharid/scripts/border_gate.rs2
+++ b/data/src/scripts/areas/area_alkharid/scripts/border_gate.rs2
@@ -8,12 +8,13 @@
 // searches for a nearby border guard
 // then starts dialogue with them
 [label,find_and_talk_to_border_guard]
-npc_findallzone(coord);
-while (npc_findnext = true) {
-    if (npc_type = border_guard_lumby | npc_type = border_guard_alkharid) {
-        if ((npc_coord = 0_51_50_4_26 | npc_coord = 0_51_50_3_26) & coordx(coord) = coordx(npc_coord)) {
-            @talk_to_border_guard(loc_coord);
-        }
+if (coordx(coord) < coordx(loc_coord)) { // in lumby
+    if (npc_find(coord, border_guard_lumby, 1, 0) = true) {
+        @talk_to_border_guard(loc_coord);
+    }
+} else { // in al kharid
+    if (npc_find(coord, border_guard_alkharid, 1, 0) = true) {
+        @talk_to_border_guard(loc_coord);
     }
 }
 

--- a/data/src/scripts/areas/area_entrana/scripts/entrana_dungeon.rs2
+++ b/data/src/scripts/areas/area_entrana/scripts/entrana_dungeon.rs2
@@ -1,9 +1,6 @@
-[oploc1,loc_2408] 
-npc_findallzone(coord);
-while (npc_findnext = true) {
-    if (npc_type = cave_monk) {
-        @cave_monk_chat;
-    }
+[oploc1,loc_2408]
+if (npc_findexact(movecoord(loc_coord, 2, 0, 0), cave_monk) = true) {
+    @cave_monk_chat;
 }
 
 [oploc1,loc_2407]

--- a/data/src/scripts/areas/area_falador/scripts/mining_guild.rs2
+++ b/data/src/scripts/areas/area_falador/scripts/mining_guild.rs2
@@ -5,7 +5,7 @@ if (stat(mining) < 60) {
     return;
 }
 p_arrivedelay;
-@climb_ladder(movecoord(coord, 0, 0, 6400), true);
+~climb_ladder(movecoord(coord, 0, 0, 6400), true);
 
 [oploc1,loc_2112]
 if (stat(mining) < 60) {

--- a/data/src/scripts/areas/area_gnome/scripts/brimstail_cave.rs2
+++ b/data/src/scripts/areas/area_gnome/scripts/brimstail_cave.rs2
@@ -2,4 +2,4 @@
 p_telejump(0_37_153_41_27);
 
 [oploc1,brimstail_ladder]
-@climb_ladder(0_37_53_42_29, true);
+~climb_ladder(0_37_53_42_29, true);

--- a/data/src/scripts/areas/area_gnome/scripts/king_bolren.rs2
+++ b/data/src/scripts/areas/area_gnome/scripts/king_bolren.rs2
@@ -105,10 +105,10 @@ switch_int(%tree_progress) {
         npc_setmode(none); // no mode because we don't want bolren to start moving
         facesquare(movecoord(coord, 8, 0, 0));
         npc_facesquare(movecoord(coord, 8, 0, 0));
-        ~gnome_chant("Su tana.");
-        ~gnome_chant("En tania.");
-        ~gnome_chant("Su tana.");
-        ~gnome_chant("En tania.");
+        ~gnome_chant(0_39_49_45_32, 0_39_49_46_31, "Su tana.");
+        ~gnome_chant(0_39_49_46_36, 0_39_49_45_35, "En tania.");
+        ~gnome_chant(0_39_49_45_32, 0_39_49_46_31, "Su tana.");
+        ~gnome_chant(0_39_49_46_36, 0_39_49_45_35, "En tania.");
         if(npc_find(coord, king_bolren, 4, 0) = false) { 
             return; // should never happen, just switching active npc
         }
@@ -133,25 +133,16 @@ switch_int(%tree_progress) {
         }
 }
 
-[proc,gnome_chant](string $message)
-npc_findallzone(coord);
-while(npc_findnext = true) {
-    if(npc_type = local_gnome) {
-        npc_facesquare(movecoord(coord, 2, 0, 0));
-        if((compare($message, "Su tana.") = 0 & coordz(coord) > coordz(npc_coord)) | (compare($message, "En tania.") = 0 & coordz(coord) < coordz(npc_coord))) {
-            npc_say($message);
-            npc_anim(midget_chanting, 0);
-        }
-    }
+[proc,gnome_chant](coord $coord1, coord $coord2, string $message)
+if (npc_findexact($coord1, local_gnome) = true) {
+    npc_facesquare(movecoord(coord, 2, 0, 0));
+    npc_say($message);
+    npc_anim(midget_chanting, 0);
 }
-npc_findallzone(movecoord(coord, 0, 0, -8));
-while(npc_findnext = true) {
-    if(npc_type = local_gnome) {
-        npc_facesquare(movecoord(coord, 2, 0, 0));
-        if((compare($message, "Su tana.") = 0 & coordz(coord) > coordz(npc_coord)) | (compare($message, "En tania.") = 0 & coordz(coord) < coordz(npc_coord))) {
-            npc_say($message);
-            npc_anim(midget_chanting, 0);
-        }
-    }
+
+if (npc_findexact($coord2, local_gnome) = true) {
+    npc_facesquare(movecoord(coord, 2, 0, 0));
+    npc_say($message);
+    npc_anim(midget_chanting, 0);
 }
 p_delay(1);

--- a/data/src/scripts/areas/area_lostcity/scripts/doorman.rs2
+++ b/data/src/scripts/areas/area_lostcity/scripts/doorman.rs2
@@ -30,16 +30,16 @@ if(loc_coord = 0_50_149_38_22) {
         ~open_and_close_door(loc_1535, ~check_axis(coord, loc_coord, loc_angle), false);
         return;
     }
+    if (npc_find(0_50_149_35_22, door_man, 2, 0) = true) {
+        @door_man_chat;
+    }
 } else if(loc_coord = 0_50_149_33_18) {
     // southern door
     if(coordz(coord) < coordz(loc_coord)) {
         ~open_and_close_door(loc_1535, ~check_axis(coord, loc_coord, loc_angle), false);
         return;
     }
-}
-npc_findallzone(coord);
-while (npc_findnext = true) {
-    if (npc_type = door_man) {
+    if (npc_find(0_50_149_33_20, door_man, 2, 0) = true) {
         @door_man_chat;
     }
 }

--- a/data/src/scripts/areas/area_lostcity/scripts/ladder_fairy.rs2
+++ b/data/src/scripts/areas/area_lostcity/scripts/ladder_fairy.rs2
@@ -1,11 +1,8 @@
 [opnpc1,ladder_fairy] @ladder_fairy_talk;
 
 [oploc1,loc_2410]
-npc_findallzone(coord);
-while (npc_findnext = true) {
-    if (npc_type = ladder_fairy) {
-        @ladder_fairy_talk;
-    }
+if (npc_findexact(0_50_149_54_54, ladder_fairy) = true) {
+    @ladder_fairy_talk;
 }
 
 [label,ladder_fairy_talk]

--- a/data/src/scripts/areas/area_mage_arena/scripts/mage_arena.rs2
+++ b/data/src/scripts/areas/area_mage_arena/scripts/mage_arena.rs2
@@ -8,7 +8,7 @@ mes("You climb down the ladder.");
 
 [oploc1,loc_2872]
 p_arrivedelay;
-@climb_ladder(movecoord(coord, 549, 0, -756), true);
+~climb_ladder(movecoord(coord, 549, 0, -756), true);
 
 
 [oploc1,loc_2878] @jump_in_sparkling_pool(^sparkling_pool_chamber_coord);

--- a/data/src/scripts/areas/area_shilo/scripts/kaleb_paramaya.rs2
+++ b/data/src/scripts/areas/area_shilo/scripts/kaleb_paramaya.rs2
@@ -7,11 +7,11 @@ if(inv_total(inv, paramayaticket) = 0) {
 inv_del(inv, paramayaticket, 1);
 if_close;
 p_delay(0);
-@climb_ladder(movecoord(coord, 0, 1, 0), true);
+~climb_ladder(movecoord(coord, 0, 1, 0), true);
 
 [oploc1,loc_2269]
 mes("You climb down the ladder.");
-@climb_ladder(1_44_46_45_51, false);
+~climb_ladder(1_44_46_45_51, false);
 
 [opnpc1,kaleb_paramaya]
 ~chatplayer("<p,neutral>Hello.");

--- a/data/src/scripts/areas/monastery/scripts/prayer_guild.rs2
+++ b/data/src/scripts/areas/monastery/scripts/prayer_guild.rs2
@@ -16,7 +16,7 @@ if (%prayer_guild < 1) {
     ~mesbox("A nearby monk glares at you. Maybe you should talk to him before climbing the ladder.");
     return;
 }
-@climb_ladder(movecoord(coord, 0, 1, 0), true);
+~climb_ladder(movecoord(coord, 0, 1, 0), true);
 
 [label,ask_to_join_abbot_langley2]
 def_int $choice = ~p_choice2("Well can I join your order?", 1, "Oh, sorry.", 2);

--- a/data/src/scripts/engine.rs2
+++ b/data/src/scripts/engine.rs2
@@ -529,6 +529,10 @@
 [command,npc_find](coord $coord, npc $npc, int $distance, int $checkvis)(boolean)
 // info: Return true if a specific secondary npc exists at $coord and passes a visibility check
 [command,.npc_find](coord $coord, npc $npc, int $distance, int $checkvis)(boolean)
+// info: Return true if a specific npc_category exists at $coord and passes a visibility check
+[command,npc_findcat](coord $coord, category $category, int $distance, int $checkvis)(boolean)
+// info: Return true if a specific secondary npc_category exists at $coord and passes a visibility check
+[command,.npc_findcat](coord $coord, category $category, int $distance, int $checkvis)(boolean)
 // info: Search for npcs in a given area
 [command,npc_findall](coord $coord, npc $npc, int $distance, int $checkvis)
 // info: Search for secondary npcs in a given area

--- a/data/src/scripts/general/scripts/misc/wine_of_zamorak.rs2
+++ b/data/src/scripts/general/scripts/misc/wine_of_zamorak.rs2
@@ -1,16 +1,10 @@
 // Sources
 // https://www.youtube.com/watch?v=U3NUBXGV1SY&t=78s
 // https://www.youtube.com/watch?v=9WB1kF-IBro&t=230s
+// https://youtu.be/sGcGQLV1Lf4
 // https://oldschool.runescape.wiki/w/Wine_of_zamorak
 [opobj3,wine_of_zamorak]
-if (~wine_of_zamorak_attack(obj_type, obj_coord) = true) {
-    return;
-}
-@pickup_obj;
-
-
-[proc,wine_of_zamorak_attack](obj $obj, coord $coord)(boolean)
-if ($obj = wine_of_zamorak & $coord = 0_45_54_50_59) {
+if (obj_coord = 0_45_54_50_59) {
     mes("STOP STEALING MY WINE! GAH!");
     spotanim_pl(zamorak_flame, 0, 0);
     sound_synth(flames_of_zamorak, 0, 0);
@@ -20,23 +14,21 @@ if ($obj = wine_of_zamorak & $coord = 0_45_54_50_59) {
     stat_drain(defence, 1, 5);
     stat_drain(ranged, 1, 5);
     stat_drain(magic, 1, 5);
-
-    def_boolean $has_spoken = false;
-
-    $has_spoken = ~set_monk_aggro(0_45_54_50_59, $has_spoken);
-    $has_spoken = ~set_monk_aggro(0_45_54_57_61, $has_spoken);
-    return($has_spoken);
-}
-
-[proc,set_monk_aggro](coord $coord, boolean $has_spoken)(boolean)
-npc_findallzone($coord);
-while (npc_findnext = true) {
-    if (npc_category = monk_of_zamorak) {
-        if ($has_spoken = false) {
-            npc_say("Hands off Zamorak's wine!");
-            $has_spoken = true;
+    if (npc_find(0_45_54_54_60, monk_of_zamorak_17, 5, 0) = true | npc_find(0_45_54_54_60, monk_of_zamorak_22, 5, 0) = true) {
+        npc_say("Hands off Zamorak's wine!");
+        npc_findall(0_45_54_54_60, monk_of_zamorak_17, 5, 0);
+        while (npc_findnext = true) {
+            if (npc_getmode ! opplayer2) {
+                npc_setmode(opplayer2);
+            }
         }
-        npc_setmode(opplayer2);
+        npc_findall(0_45_54_54_60, monk_of_zamorak_22, 5, 0);
+        while (npc_findnext = true) {
+            if (npc_getmode ! opplayer2) {
+                npc_setmode(opplayer2);
+            }
+        }
+        return;
     }
 }
-return($has_spoken);
+@pickup_obj;

--- a/data/src/scripts/interface_bank/scripts/bank_booth.rs2
+++ b/data/src/scripts/interface_bank/scripts/bank_booth.rs2
@@ -1,5 +1,5 @@
 [oploc1,bankbooth]
-if (npc_findcat(loc_coord, bank_teller, 1, 0) = true) {
+if (npc_findcat(loc_coord, bank_teller, 2, 0) = true) {
     @talk_to_banker;
 }
 @openbank; // default to just open bank if a bank teller was not found to start dialogue.

--- a/data/src/scripts/interface_bank/scripts/bank_booth.rs2
+++ b/data/src/scripts/interface_bank/scripts/bank_booth.rs2
@@ -1,31 +1,6 @@
 [oploc1,bankbooth]
-npc_findallzone(movecoord(loc_coord, 1, 0, 0));
-while (npc_findnext = true) {
-    // find a banker on 4 different axis from the booth.
-    if (npc_category = bank_teller & (npc_coord = movecoord(loc_coord, 1, 0, 0) | npc_coord = movecoord(loc_coord, -1, 0, 0) | npc_coord = movecoord(loc_coord, 0, 0, 1) | npc_coord = movecoord(loc_coord, 0, 0, -1))) {
-        @talk_to_banker;
-    }
-}
-npc_findallzone(movecoord(loc_coord, -1, 0, 0));
-while (npc_findnext = true) {
-    // find a banker on 4 different axis from the booth.
-    if (npc_category = bank_teller & (npc_coord = movecoord(loc_coord, 1, 0, 0) | npc_coord = movecoord(loc_coord, -1, 0, 0) | npc_coord = movecoord(loc_coord, 0, 0, 1) | npc_coord = movecoord(loc_coord, 0, 0, -1))) {
-        @talk_to_banker;
-    }
-}
-npc_findallzone(movecoord(loc_coord, 0, 0, 1));
-while (npc_findnext = true) {
-    // find a banker on 4 different axis from the booth.
-    if (npc_category = bank_teller & (npc_coord = movecoord(loc_coord, 1, 0, 0) | npc_coord = movecoord(loc_coord, -1, 0, 0) | npc_coord = movecoord(loc_coord, 0, 0, 1) | npc_coord = movecoord(loc_coord, 0, 0, -1))) {
-        @talk_to_banker;
-    }
-}
-npc_findallzone(movecoord(loc_coord, 0, 0, -1));
-while (npc_findnext = true) {
-    // find a banker on 4 different axis from the booth.
-    if (npc_category = bank_teller & (npc_coord = movecoord(loc_coord, 1, 0, 0) | npc_coord = movecoord(loc_coord, -1, 0, 0) | npc_coord = movecoord(loc_coord, 0, 0, 1) | npc_coord = movecoord(loc_coord, 0, 0, -1))) {
-        @talk_to_banker;
-    }
+if (npc_findcat(loc_coord, bank_teller, 1, 0) = true) {
+    @talk_to_banker;
 }
 @openbank; // default to just open bank if a bank teller was not found to start dialogue.
 

--- a/data/src/scripts/ladders+stairs/scripts/ladders.rs2
+++ b/data/src/scripts/ladders+stairs/scripts/ladders.rs2
@@ -69,8 +69,12 @@ p_arrivedelay;
 p_arrivedelay;
 switch_coord (loc_coord) {
     case 1_47_54_14_62 : 
-
         ~climb_ladder(movecoord(coord(), 0, -1, 0), false); // black knights
+        if (npc_find(coord, black_knight_aggre, 5, 0) = true) { // checks from player coord! - osrs
+            npc_say("Die intruder!!!");
+            npc_setmode(opplayer2);
+        }
+        return;
 }
 ~climb_ladder(movecoord(coord(), 0, -1, 0), false);
 

--- a/data/src/scripts/ladders+stairs/scripts/ladders.rs2
+++ b/data/src/scripts/ladders+stairs/scripts/ladders.rs2
@@ -21,12 +21,12 @@ switch_int (loc_angle) {
 // Climb Up
 [oploc1,loc_272]
 p_arrivedelay;
-@climb_ladder(movecoord(coord(), 0, 1, 0), true);
+~climb_ladder(movecoord(coord(), 0, 1, 0), true);
 
 // Climb Down
 [oploc1,loc_273]
 p_arrivedelay;
-@climb_ladder(movecoord(coord(), 0, -1, 0), false);
+~climb_ladder(movecoord(coord(), 0, -1, 0), false);
 
 // Climb-down op
 [oploc1,loc_2147]
@@ -34,7 +34,7 @@ def_coord $coord = loc_coord();
 
 // wizard tower level 0
 if ($coord = 0_48_49_32_26) {
-    @climb_ladder(0_48_149_32_40, false);
+    ~climb_ladder(0_48_149_32_40, false);
 } else {
     mes("unhandled ladder <~coord_tostring($coord)>");
 }
@@ -42,15 +42,15 @@ if ($coord = 0_48_49_32_26) {
 [oploc1,loc_1746]
 p_arrivedelay;
 switch_coord (loc_coord) {
-    case 2_47_54_17_57 : @climb_ladder(1_47_54_17_58, false); // black knights fortress ladder
-    case default : @climb_ladder(movecoord(coord(), 0, -1, 0), false);   
+    case 2_47_54_17_57 : ~climb_ladder(1_47_54_17_58, false); // black knights fortress ladder
+    case default : ~climb_ladder(movecoord(coord(), 0, -1, 0), false);   
 }
 
 [oploc1,loc_1747]
 p_arrivedelay;
 switch_coord (loc_coord) {
     case 0_40_53_10_49 : @ladder_to_dwarf_remains; // Ladder to Dwarf Guard Tower
-    case default : @climb_ladder(movecoord(coord(), 0, 1, 0), true);
+    case default : ~climb_ladder(movecoord(coord(), 0, 1, 0), true);
 }
 
 [oploc1,loc_1748]
@@ -59,45 +59,51 @@ p_arrivedelay;
 
 [oploc2,loc_1748]
 p_arrivedelay;
-@climb_ladder(movecoord(coord(), 0, 1, 0), true);
+~climb_ladder(movecoord(coord(), 0, 1, 0), true);
 
 [oploc3,loc_1748]
 p_arrivedelay;
-@climb_ladder(movecoord(coord(), 0, -1, 0), true);
+~climb_ladder(movecoord(coord(), 0, -1, 0), true);
 
 [oploc1,loc_1749]
 p_arrivedelay;
-@climb_ladder(movecoord(coord(), 0, -1, 0), false);
+switch_coord (loc_coord) {
+    case 1_47_54_14_62 : 
+
+        ~climb_ladder(movecoord(coord(), 0, -1, 0), false); // black knights
+}
+~climb_ladder(movecoord(coord(), 0, -1, 0), false);
 
 [oploc1,loc_1750]
 p_arrivedelay;
-@climb_ladder(movecoord(coord(), 0, 1, 0), true);
+~climb_ladder(movecoord(coord(), 0, 1, 0), true);
 
 [oploc1,loc_1754]
 p_arrivedelay;
-@climb_ladder(movecoord(coord(), 0, 0, 6400), false);
+~climb_ladder(movecoord(coord(), 0, 0, 6400), false);
 
 [oploc1,loc_1755] // mining guild ladder
 def_coord $coord = loc_coord;
 p_arrivedelay;
 if(loc_coord = 0_50_149_22_52) { // Zanaris ladder (entrance room)
-    @climb_ladder(0_50_49_1_33, true);
+    ~climb_ladder(0_50_49_1_33, true);
+    return;
 }
-@climb_ladder(movecoord(coord(), 0, 0, -6400), true);
+~climb_ladder(movecoord(coord(), 0, 0, -6400), true);
 
 [oploc1,loc_1757] 
 p_arrivedelay;
-@climb_ladder(movecoord(coord(), 0, 0, -6400), true);
+~climb_ladder(movecoord(coord(), 0, 0, -6400), true);
 
 [oploc1,loc_1759]
 p_arrivedelay;
-@climb_ladder(movecoord(coord(), 0, 0, 6400), false);
+~climb_ladder(movecoord(coord(), 0, 0, 6400), false);
 
 [oploc1,loc_1765]
 def_coord $coord = loc_coord();
 p_arrivedelay;
 switch_coord ($coord) {
-    case 0_40_50_1_22 : @climb_ladder(0_40_150_1_21, false); // Monk's Friend hidden ladder
+    case 0_40_50_1_22 : ~climb_ladder(0_40_150_1_21, false); // Monk's Friend hidden ladder
     case 0_47_60_9_9 : p_teleport(0_47_160_61_15); // kdb entrance (yes its a p_teleport)
     case default : mes("unhandled ladder <~coord_tostring($coord)>");
 }
@@ -108,14 +114,14 @@ def_coord $coord = loc_coord();
 
 // wizard tower cellar
 if ($coord = 0_48_149_31_40) {
-    @climb_ladder(0_48_49_33_26, true);
+    ~climb_ladder(0_48_49_33_26, true);
 } else {
     mes("unhandled ladder <~coord_tostring($coord)>");
 }
 
 [oploc1,loc_2405]
 p_arrivedelay;
-@climb_ladder(0_50_52_44_54, true);
+~climb_ladder(0_50_52_44_54, true);
 
 [oploc1,loc_2884]
 p_arrivedelay;
@@ -133,17 +139,17 @@ if ($option = 1) {
 [oploc2,loc_2884]
 ~grandtree_spawn_charlie; // before the arrivedelay
 p_arrivedelay;
-@climb_ladder(movecoord(coord(), 0, 1, 0), true);
+~climb_ladder(movecoord(coord(), 0, 1, 0), true);
 
 [oploc3,loc_2884]
 p_arrivedelay;
-@climb_ladder(movecoord(coord(), 0, -1, 0), true);
+~climb_ladder(movecoord(coord(), 0, -1, 0), true);
 
 [oploc1,laddertop_norim]
 p_arrivedelay;
-@climb_ladder(movecoord(coord(), 0, -1, 0), false);
+~climb_ladder(movecoord(coord(), 0, -1, 0), false);
 
-[label,climb_ladder](coord $coord, boolean $up)
+[proc,climb_ladder](coord $coord, boolean $up)
 if ($up = true) {
     anim(human_reachforladder, 0);
 } else {

--- a/data/src/scripts/ladders+stairs/scripts/ladders.rs2
+++ b/data/src/scripts/ladders+stairs/scripts/ladders.rs2
@@ -69,11 +69,9 @@ p_arrivedelay;
 p_arrivedelay;
 switch_coord (loc_coord) {
     case 1_47_54_14_62 : 
+        // https://youtu.be/6RNx7Sbut8A?t=423
         ~climb_ladder(movecoord(coord(), 0, -1, 0), false); // black knights
-        if (npc_find(coord, black_knight_aggre, 5, 0) = true) { // checks from player coord! - osrs
-            npc_say("Die intruder!!!");
-            npc_setmode(opplayer2);
-        }
+        ~black_knights_aggro(coord, 0_47_54_17_59); // checks from player coord! - osrs
         return;
 }
 ~climb_ladder(movecoord(coord(), 0, -1, 0), false);

--- a/data/src/scripts/minigames/game_partyroom/scripts/partyroom.rs2
+++ b/data/src/scripts/minigames/game_partyroom/scripts/partyroom.rs2
@@ -78,17 +78,9 @@ if (last_int < 9) {
     npc_queue(10, calc(last_int + 1), $delay);
     return;
 }
-npc_findallzone(^partyroom_starting_knight_coord);
+npc_findall(movecoord(^partyroom_starting_knight_coord, 2, 0, 0), partyroom_dancingknight, 3, 0);
 while (npc_findnext = true) {
-    if (npc_type = partyroom_dancingknight) {
-        npc_del;
-    }
-}
-npc_findallzone(movecoord(^partyroom_starting_knight_coord, 6, 0, 0));
-while (npc_findnext = true) {
-    if (npc_type = partyroom_dancingknight) {
-        npc_del;
-    }
+    npc_del;
 }
 
 [proc,random_balloon]()(loc)

--- a/data/src/scripts/quests/quest_ball/scripts/quest_ball.rs2
+++ b/data/src/scripts/quests/quest_ball/scripts/quest_ball.rs2
@@ -79,11 +79,8 @@ loc_change(loc_2868, 500);
 
 [label,ball_cheese](string $pref)
 inv_del(inv, cheese, 1);
-npc_findallzone(coord);
-while(npc_findnext = true) {
-    if(npc_type = ball_mouse) {
-        npc_del;
-    }
+if (npc_find(coord, ball_mouse, 5, 0) = true) {
+    npc_del;
 }
 npc_add(^ball_mouse_coord, ball_mouse, 50);
 ~mesbox("A mouse runs out of <$pref> hole.");

--- a/data/src/scripts/quests/quest_blackarmgang/scripts/quest_blackarmgang.rs2
+++ b/data/src/scripts/quests/quest_blackarmgang/scripts/quest_blackarmgang.rs2
@@ -18,17 +18,14 @@ if(%phoenixgang_progress >= ^phoenixgang_joined | $leaving = true) {
     ~open_hideout_door($leaving, "The door automatically opens for you.");
     return;
 }
-npc_findallzone(coord);
-while (npc_findnext = true) {
-    if (npc_type = straven & distance(coord, npc_coord) <= 1) {
-        if(%blackarmgang_progress >= ^blackarmgang_joined) {
-            @straven_blackarmdog;
-        }
-        if(%phoenixgang_progress = ^phoenixgang_spoken_straven) {
-            @straven_mission;
-        } 
-        @straven_cant_enter;
+if (npc_find(coord, straven, 1, 0) = true) {
+    if(%blackarmgang_progress >= ^blackarmgang_joined) {
+        @straven_blackarmdog;
     }
+    if(%phoenixgang_progress = ^phoenixgang_spoken_straven) {
+        @straven_mission;
+    } 
+    @straven_cant_enter;
 }
 mes("The door is securely locked.");
 

--- a/data/src/scripts/quests/quest_blackknight/scripts/quest_blackknight.rs2
+++ b/data/src/scripts/quests/quest_blackknight/scripts/quest_blackknight.rs2
@@ -4,11 +4,12 @@
 // 3031 3508 1 - Hole
 // 3025 3508 0 - Grate
 
+// https://youtu.be/cbJE-AjhON4?t=269
 [oploc1,inaclefayeunopenabledoorr]
-mes("The doors are locked.");
+mes("You can't open this door.");
 
 [oploc1,inaclefayeunopenabledoorl]
-mes("The doors are locked.");
+mes("You can't open this door.");
 
 [oploc1,blackknight_front_door]
 def_boolean $is_outside = ~check_axis(coord, loc_coord, loc_angle);

--- a/data/src/scripts/quests/quest_blackknight/scripts/quest_blackknight.rs2
+++ b/data/src/scripts/quests/quest_blackknight/scripts/quest_blackknight.rs2
@@ -13,7 +13,9 @@ mes("The doors are locked.");
 [oploc1,blackknight_front_door]
 def_boolean $is_outside = ~check_axis(coord, loc_coord, loc_angle);
 if ($is_outside = true & ((inv_getobj(worn, ^wearpos_hat) ! bronze_med_helm) | (inv_getobj(worn, ^wearpos_torso) ! iron_chainbody))) {
-    @blackknight_entrance_dialogue;
+    if (npc_find(0_47_54_8_56, fortress_guard, 5, 1) = true) {
+        @blackknight_entrance_fortress_guard;
+    }
 } else {
     ~open_and_close_door(loc_param(next_loc_stage), $is_outside, false);
 }
@@ -22,18 +24,13 @@ if ($is_outside = true & ((inv_getobj(worn, ^wearpos_hat) ! bronze_med_helm) | (
 def_boolean $is_outside = ~check_axis(coord, loc_coord, loc_angle);
 if ($is_outside = false) {
     // black knights guarding the ladder down to the grill will aggress the player
-    ~set_black_knight_aggro(1_47_54_17_55);
-    ~set_black_knight_aggro(1_47_54_15_55);
-}
-~open_and_close_door(loc_param(next_loc_stage), $is_outside, false);
-
-[label,blackknight_entrance_dialogue]
-npc_findallzone(0_47_54_8_59);
-while (npc_findnext = true) {
-    if (npc_type = fortress_guard) {
-        @blackknight_entrance_fortress_guard;
+    // - https://youtu.be/6RNx7Sbut8A?t=250
+    if (npc_find(coord, black_knight_aggre, 5, 0) = true) {
+        npc_say("Die intruder!!!");
+        npc_setmode(opplayer2);
     }
 }
+~open_and_close_door(loc_param(next_loc_stage), $is_outside, false);
 
 [label,blackknight_entrance_fortress_guard]
 ~chatnpc("<p,angry>Hey, you can't come in here!|This is a high security military installation.");
@@ -63,36 +60,29 @@ def_boolean $is_inside = ~check_axis(coord, loc_coord, loc_angle);
 def_coord $blackknight_near_banquet_hall = 0_47_54_11_59;
 def_coord $blackknight_outside = 0_47_54_8_57;
 if ($is_inside = false) {
-    npc_findallzone($blackknight_near_banquet_hall);
-    while (npc_findnext = true) {
-        if (npc_type = fortress_guard) {
-           @blackknight_banquet_hall_fortress_guard($is_inside);
-        }
-    }
-
-    npc_findallzone($blackknight_outside);
-    while (npc_findnext = true) {
-        if (npc_type = fortress_guard) {
-           @blackknight_banquet_hall_fortress_guard($is_inside);
-        }
+    if (npc_find(coord, fortress_guard, 10, 1) = true) {
+        @blackknight_banquet_hall_fortress_guard;
     }
 } else {
     ~open_and_close_door(loc_param(next_loc_stage), $is_inside, false);
 }
 
-[label,blackknight_banquet_hall_fortress_guard](boolean $is_inside)
-def_loc $next_loc = loc_param(next_loc_stage);
+[label,blackknight_banquet_hall_fortress_guard]
 ~chatnpc("<p,neutral>I wouldn't go in there if I woz you.|Those Black Knights are in an important meeting;|They said they'd kill anyone who went in there!");
 def_int $option = ~p_choice2("Ok I won't.", 1, "I don't care. I'm going in anyway.", 2);
 if ($option = 1) {
     ~chatplayer("<p,neutral>Ok I won't.");
 } else {
    ~chatplayer("<p,neutral>I don't care. I'm going in anyway.");
-   ~open_and_close_door($next_loc, $is_inside, false);
-   // black knights in the banquet hall will aggress the player
-   ~set_black_knight_aggro(0_47_54_13_59);
-   ~set_black_knight_aggro(0_47_54_21_59);
-   ~set_black_knight_aggro(0_47_54_22_55);
+   ~open_and_close_door(loc_param(next_loc_stage), false, false);
+   // search for one black knight to yell
+   // - https://youtu.be/vNPISjaWfvQ?t=123
+   // - https://youtu.be/6RNx7Sbut8A?t=306
+   // - in osrs it gets flinched, but in https://youtu.be/6RNx7Sbut8A?t=306 it insta retals and i doubt its a hunt
+    if (npc_find(0_47_54_17_59, black_knight_aggre, 5, 0) = true) {
+        npc_say("Die intruder!!!"); // https://youtu.be/6RNx7Sbut8A?t=310
+        npc_setmode(opplayer2);
+    }
 }
 [oploc1,blackknight_potion_room_door]
 mes("It's locked.");
@@ -158,15 +148,6 @@ if (%blackknight_progress = 1) {
     ~update_blackknight_progress;
 } else {
     mes("I can't hear much right now.");
-}
-
-[proc,set_black_knight_aggro](coord $coord)
-npc_findallzone($coord);
-while (npc_findnext = true) {
-    if (npc_type = black_knight_aggre) {
-        npc_say("Die intruder!");
-        npc_setmode(opplayer2);
-    }
 }
 
 [proc,update_blackknight_progress]

--- a/data/src/scripts/quests/quest_blackknight/scripts/quest_blackknight.rs2
+++ b/data/src/scripts/quests/quest_blackknight/scripts/quest_blackknight.rs2
@@ -26,10 +26,7 @@ def_boolean $is_outside = ~check_axis(coord, loc_coord, loc_angle);
 if ($is_outside = false) {
     // black knights guarding the ladder down to the grill will aggress the player
     // - https://youtu.be/6RNx7Sbut8A?t=250
-    if (npc_find(coord, black_knight_aggre, 5, 0) = true) {
-        npc_say("Die intruder!!!");
-        npc_setmode(opplayer2);
-    }
+    ~black_knights_aggro(coord, coord);
 }
 ~open_and_close_door(loc_param(next_loc_stage), $is_outside, false);
 
@@ -80,10 +77,7 @@ if ($option = 1) {
    // - https://youtu.be/vNPISjaWfvQ?t=123
    // - https://youtu.be/6RNx7Sbut8A?t=306
    // - in osrs it gets flinched, but in https://youtu.be/6RNx7Sbut8A?t=306 it insta retals and i doubt its a hunt
-    if (npc_find(0_47_54_17_59, black_knight_aggre, 5, 0) = true) {
-        npc_say("Die intruder!!!"); // https://youtu.be/6RNx7Sbut8A?t=310
-        npc_setmode(opplayer2);
-    }
+   ~black_knights_aggro(0_47_54_17_59, 0_47_54_17_59);
 }
 [oploc1,blackknight_potion_room_door]
 mes("It's locked.");
@@ -161,3 +155,16 @@ inv_add(inv, coins, 2500);
 mes("Sir Amik hands you 2500 coins.");
 session_log(^log_adventure, "Quest complete: Black Knight's Fortress");
 ~send_quest_complete(questlist:fortress, coins, 250, ^blackknight_questpoints, "You have completed the\\nBlack Knights' Fortress Quest!");
+
+[proc,black_knights_aggro](coord $first_search_coord, coord $all_search_coord)
+if (npc_find($first_search_coord, black_knight_aggre, 5, 0) = true) {
+    npc_say("Die intruder!!!");
+}
+// def does this findall thing https://youtu.be/6RNx7Sbut8A?t=423
+// isnt the case in osrs!
+npc_findall($all_search_coord, black_knight_aggre, 5, 0);
+while (npc_findnext = true) {
+    if (npc_getmode ! opplayer2) {
+        npc_setmode(opplayer2);
+    }
+}

--- a/data/src/scripts/quests/quest_dragon/scripts/lady_lumbridge.rs2
+++ b/data/src/scripts/quests/quest_dragon/scripts/lady_lumbridge.rs2
@@ -33,15 +33,15 @@ switch_int (loc_angle) {
 [oploc1,lady_lumbridge_ladder]
 p_arrivedelay; //osrs
 if (%dragon_planks < 3) {
-    @climb_ladder(1_47_150_39_40, true);
+    ~climb_ladder(1_47_150_39_40, true);
 } else if ((%dragon_progress = ^quest_dragon_ned_given_map | %dragon_progress = ^quest_dragon_sailed_to_crandor) & %dragon_ned_hired = ^true) {
-    @climb_ladder(3_47_150_39_40, true);
+    ~climb_ladder(3_47_150_39_40, true);
 }else {
-    @climb_ladder(2_47_150_39_40, true);
+    ~climb_ladder(2_47_150_39_40, true);
 }
 
 [oploc1,lady_lumbridge_ladder2]
-@climb_ladder(1_47_50_39_7, true);
+~climb_ladder(1_47_50_39_7, true);
 
 [oploc1,lady_lumbridge_hole]
 // left click didnt auto add planks
@@ -96,4 +96,4 @@ def_coord $coord = movecoord(coord, 0, -1, 0);
 if (map_blocked($coord) = true) { // just incase the player wants to hide behind the ladder
     $coord = 0_44_50_33_35;
 }
-@climb_ladder($coord, true);
+~climb_ladder($coord, true);

--- a/data/src/scripts/quests/quest_dragon/scripts/melzars_maze.rs2
+++ b/data/src/scripts/quests/quest_dragon/scripts/melzars_maze.rs2
@@ -32,7 +32,7 @@ mes("The ladder is broken, I can't climb it."); // osrs
 // ladder
 [oploc1,melzar_maze_ladder]
 // No arrivedelay in osrs
-@climb_ladder(movecoord(coord, 0, 0, 6400), true);
+~climb_ladder(movecoord(coord, 0, 0, 6400), true);
 
 // red door
 [oploc1,melzar_maze_red_door] mes("This door is securely locked."); // osrs

--- a/data/src/scripts/quests/quest_haunted/scripts/quest_haunted.rs2
+++ b/data/src/scripts/quests/quest_haunted/scripts/quest_haunted.rs2
@@ -153,11 +153,11 @@ p_teleport($dest);
 
 [oploc1,puzzle_ladder_top]
 ~reset_haunted_levers;
-@climb_ladder(0_48_152_44_26, false);
+~climb_ladder(0_48_152_44_26, false);
 
 [oploc1,puzzle_ladder]
 ~reset_haunted_levers;
-@climb_ladder(0_48_52_20_33, true);
+~climb_ladder(0_48_52_20_33, true);
 
 [proc,reset_haunted_levers]
 %haunted_lever = clearbit_range(%haunted_lever, 0, 5);

--- a/data/src/scripts/quests/quest_hunt/scripts/dig.rs2
+++ b/data/src/scripts/quests/quest_hunt/scripts/dig.rs2
@@ -4,21 +4,8 @@ if (%hunt_progress ! 3) {
     return;
 }
 
-npc_findallzone(0_46_52_48_48);
-while (npc_findnext = true) {
-    if (npc_type = wyson) @wyson_attack;
-}
-npc_findallzone(0_46_52_56_48);
-while (npc_findnext = true) {
-    if (npc_type = wyson) @wyson_attack;
-}
-npc_findallzone(0_46_52_48_56);
-while (npc_findnext = true) {
-    if (npc_type = wyson) @wyson_attack;
-}
-npc_findallzone(0_46_52_56_56);
-while (npc_findnext = true) {
-    if (npc_type = wyson) @wyson_attack;
+if (npc_find(coord, wyson, 10, 0) = true) {
+    @wyson_attack;
 }
 
 p_arrivedelay;

--- a/data/src/scripts/quests/quest_hunt/scripts/food_store.rs2
+++ b/data/src/scripts/quests/quest_hunt/scripts/food_store.rs2
@@ -1,13 +1,16 @@
 [oploc1,food_store_door]
 def_boolean $entering = ~check_axis(coord, loc_coord, loc_angle);
 if ($entering = true) {
-    if (testbit(%hunt_store_employed, ^food_store) = false) {
-        @wydin_get_pointer(wydin_employees_only);
+    if (npc_find(coord, wydin, 10, 0) = true) {
+        if (testbit(%hunt_store_employed, ^food_store) = false) {
+            @wydin_employees_only;
+        }
+
+        if (inv_getobj(worn, ^wearpos_torso) ! white_apron) {
+            @wydin_apron_required;
+        }
     }
 
-    if (inv_getobj(worn, ^wearpos_torso) ! white_apron) {
-        @wydin_get_pointer(wydin_apron_required);
-    }
 }
 
 ~open_and_close_door(loc_2070, $entering, false);
@@ -18,14 +21,6 @@ if ($entering = true) {
 
 [label,wydin_apron_required]
 ~chatnpc("<p,neutral>Can you put your apron on before going in there, please?");
-
-[label,wydin_get_pointer](label $l)
-npc_findallzone(coord);
-while (npc_findnext = true) {
-    if (npc_type = wydin) {
-        jump($l);
-    }
-}
 
 [oploc1,food_store_crate]
 mes("There are a lot of bananas in the crate.");

--- a/data/src/scripts/quests/quest_itgronigen/scripts/quest_itgronigen.rs2
+++ b/data/src/scripts/quests/quest_itgronigen/scripts/quest_itgronigen.rs2
@@ -15,15 +15,15 @@ if(%itgronigen_progress = ^itgronigen_not_started) {
 
 [oploc1,loc_2188]
 p_arrivedelay;
-@climb_ladder(0_38_49_12_56, true);
+~climb_ladder(0_38_49_12_56, true);
 
 [oploc1,loc_2189]
 p_arrivedelay;
-@climb_ladder(0_38_49_8_29, true);
+~climb_ladder(0_38_49_8_29, true);
 
 [oploc1,loc_2190]
 p_arrivedelay;
-@climb_ladder(0_37_147_55_30, false);
+~climb_ladder(0_37_147_55_30, false);
 
 [oploc1,loc_2191] 
 mes("You open the chest.");

--- a/data/src/scripts/quests/quest_itwatchtower/scripts/quest_itwatchtower.rs2
+++ b/data/src/scripts/quests/quest_itwatchtower/scripts/quest_itwatchtower.rs2
@@ -90,7 +90,7 @@ if(%itwatchtower_progress = ^itwatchtower_not_started) {
 } else {
     ~chatnpc_specific(nc_name(tower_guard), tower_guard, "<p,neutral>It is the wizards' helping hand - let 'em up.");
     if_close;
-    @climb_ladder(movecoord(coord, 0, 1, 0), true);
+    ~climb_ladder(movecoord(coord, 0, 1, 0), true);
 }
 
 // checks if the player has a map, lightsource, and tinderbox. possible outcomes are:
@@ -258,12 +258,13 @@ mes("I am going to need someone with experience to help me with this.");
 
 [oploc1,loc_2796]
 if(%itwatchtower_progress >= ^itwatchtower_complete) {
-    @climb_ladder(2_45_73_53_40, true);
+    ~climb_ladder(2_45_73_53_40, true);
+    return;
 }
-@climb_ladder(2_39_48_53_40, true);
+~climb_ladder(2_39_48_53_40, true);
 
 [oploc1,loc_2797]
-@climb_ladder(1_39_48_53_40, true);
+~climb_ladder(1_39_48_53_40, true);
 
 [oploc1,loc_2786] @open_gutanoth_gate(^left, ogre_guard_east);
 [oploc1,loc_2787] @open_gutanoth_gate(^right, ogre_guard_east);

--- a/data/src/scripts/quests/quest_mcannon/scripts/locs/mcannon_ladders.rs2
+++ b/data/src/scripts/quests/quest_mcannon/scripts/locs/mcannon_ladders.rs2
@@ -4,5 +4,5 @@ if (%mcannon_progress < ^mcannon_tasked_with_checking_guard_tower) {
     p_delay(0);
     mes("but the trap door will not open.");
 } else {
-    @climb_ladder(movecoord(coord(), 0, 1, 0), true);
+    ~climb_ladder(movecoord(coord(), 0, 1, 0), true);
 }

--- a/data/src/scripts/quests/quest_seaslug/scripts/quest_seaslug.rs2
+++ b/data/src/scripts/quests/quest_seaslug/scripts/quest_seaslug.rs2
@@ -73,7 +73,7 @@ if(%seaslug_progress >= ^seaslug_spoken_kent & %seaslug_progress < ^seaslug_comp
     } 
     mes("The fishermen seem afraid of your torch.");
 }
-@climb_ladder(movecoord(coord(), 0, 1, 0), true);
+~climb_ladder(movecoord(coord(), 0, 1, 0), true);
 
 [oploc1,loc_2518]
 mes("You kick the loose panel.");

--- a/data/src/scripts/quests/quest_seaslug/scripts/quest_seaslug.rs2
+++ b/data/src/scripts/quests/quest_seaslug/scripts/quest_seaslug.rs2
@@ -114,11 +114,8 @@ if(%seaslug_progress = ^seaslug_need_kennith_path) {
 p_delay(4);
 
 [oploc1,loc_2519]
-npc_findallzone(movecoord(coord, 0, 0, 2));
-while (npc_findnext = true) {
-    if (npc_type = kennith) {
-        @kennith_chat;
-    }
+if (npc_find(movecoord(coord, 0, 0, 2), kennith, 5, 0) = true) {
+    @kennith_chat;
 }
 
 [queue,seaslug_quest_complete]

--- a/data/src/scripts/quests/quest_waterfall/scripts/quest_waterfall.rs2
+++ b/data/src/scripts/quests/quest_waterfall/scripts/quest_waterfall.rs2
@@ -151,23 +151,20 @@ switch_int (%waterfall_progress) {
         p_delay(2);
         if (%waterfall_progress = ^waterfall_started) {
             // Forced Hudon Dialogue
-            npc_findallzone(movecoord(coord, -1, 0, 0));
-            while (npc_findnext = true) {
-                if (npc_type = hudon) {
-                    ~chatplayer("<p,neutral>Hello son, are you okay? You need help?");
-                    ~chatnpc("<p,neutral>It looks like you need the help.");
-                    ~chatplayer("<p,neutral>Your mum sent me to find you.");
-                    ~chatnpc("<p,neutral>Don't play nice with me,|I know you're looking for the treasure.");
-                    ~chatplayer("<p,neutral>Where is this treasure you talk of?");
-                    ~chatnpc("<p,neutral>Just because I'm small doesn't mean I'm dumb! If I told you, you would take it all for yourself.");
-                    ~chatplayer("<p,neutral>Maybe I could help.");
-                    %waterfall_progress = ^waterfall_spoken_to_hudon;
-                    ~chatnpc("<p,neutral>I'm fine alone.");
-                    mes("Hudon is refusing to leave the waterfall");
-                    return;
-                }
+            if (npc_find(movecoord(coord, -1, 0, 0), hudon, 5, 0) = true) {
+                ~chatplayer("<p,neutral>Hello son, are you okay? You need help?");
+                ~chatnpc("<p,neutral>It looks like you need the help.");
+                ~chatplayer("<p,neutral>Your mum sent me to find you.");
+                ~chatnpc("<p,neutral>Don't play nice with me,|I know you're looking for the treasure.");
+                ~chatplayer("<p,neutral>Where is this treasure you talk of?");
+                ~chatnpc("<p,neutral>Just because I'm small doesn't mean I'm dumb! If I told you, you would take it all for yourself.");
+                ~chatplayer("<p,neutral>Maybe I could help.");
+                %waterfall_progress = ^waterfall_spoken_to_hudon;
+                ~chatnpc("<p,neutral>I'm fine alone.");
+                mes("Hudon is refusing to leave the waterfall");
+                return;
+            }
         }
-    }
 }
 
 // Swim to rock
@@ -329,9 +326,8 @@ if($is_outside = false) {
         return;
     }
     if(%waterfall_progress <= ^waterfall_opened_book_on_baxtorian & inv_total(inv, golrie_key_waterfall_quest) = 0) {
-        npc_findallzone(movecoord(coord, 0, 0, 2));
-        while (npc_findnext = true) {
-            if(npc_type = golrie) @waterfall_golrie_door_dialogue;
+        if (npc_find(movecoord(coord, 0, 0, 2), golrie, 5, 0) = true) {
+            @waterfall_golrie_door_dialogue;
         }
     }
     mes("The gate is locked.");

--- a/data/src/scripts/skill_fishing/scripts/fishing_guild.rs2
+++ b/data/src/scripts/skill_fishing/scripts/fishing_guild.rs2
@@ -3,27 +3,13 @@
 def_boolean $is_inside = ~check_axis(coord, loc_coord, loc_angle);
 if ($is_inside = false) {
     if (stat(fishing) < 68) {
-        @fishing_guild_level_fail;
+        if (npc_find(coord, master_fisher, 10, 0) = true) {
+            ~chatnpc("<p,happy>Hello, only the top fishers are allowed in here, you need a fishing level of 68 to enter.");
+        }
+        return;
     }
 }
 ~open_and_close_door(loc_param(next_loc_stage), $is_inside, false);
-
-[label,fishing_guild_level_fail]
-// find master fisher
-npc_findallzone(0_40_53_51_1);
-while (npc_findnext = true) {
-    if (npc_type = master_fisher) {
-        ~chatnpc("<p,happy>Hello, only the top fishers are allowed in here, you need a fishing level of 68 to enter.");
-        return;
-    }
-}
-npc_findallzone(0_40_52_51_63);
-while (npc_findnext = true) {
-    if (npc_type = master_fisher) {
-        ~chatnpc("<p,happy>Hello, only the top fishers are allowed in here, you need a fishing level of 68 to enter.");
-        return;
-    }
-}
 
 [opnpc1,master_fisher]
 if (stat(fishing) < 68) {

--- a/data/src/scripts/skill_fishing/scripts/fishing_movement.rs2
+++ b/data/src/scripts/skill_fishing/scripts/fishing_movement.rs2
@@ -15,26 +15,22 @@ if (nc_param($npc, fishing_movement_enum) = null) {
     return (npc_coord);
 }
 def_int $output_count = enum_getoutputcount(nc_param($npc, fishing_movement_enum));
-def_npc_uid $original_fishing_spot = npc_uid;
 def_coord $rand_coord;
 def_int $i;
 while ($i < 50) {
     $rand_coord = enum(int, coord, nc_param($npc, fishing_movement_enum), random($output_count));
-    //npc_say("<tostring($int)>, <~coord_tostring($rand_coord)>");
     if (~check_fishing_spot_empty($rand_coord) = true) {
-        npc_finduid($original_fishing_spot);
         return ($rand_coord);
     }
     $i = calc($i + 1);
 }
-npc_finduid($original_fishing_spot);
-return (npc_coord);
+return(npc_coord);
 
 //proc checks if fishing spot is empty
 [proc,check_fishing_spot_empty](coord $rand_coord)(boolean)
-npc_findallzone($rand_coord);
-while (npc_findnext = true) {
-    if (npc_coord = $rand_coord & (nc_category(npc_type) = saltfish | nc_category(npc_type) = freshfish | nc_category(npc_type) = saltfish | nc_category(npc_type) = rarefish | nc_category(npc_type) = memberfish | npc_type = 0_45_152_lava_eel)) {
+npc_findallany($rand_coord, 0, 0);
+while (.npc_findnext = true) {
+    if (.npc_coord = $rand_coord & (nc_category(.npc_type) = saltfish | nc_category(.npc_type) = freshfish | nc_category(.npc_type) = saltfish | nc_category(.npc_type) = rarefish | nc_category(.npc_type) = memberfish | .npc_type = 0_45_152_lava_eel)) {
         return (false);
     }
 }

--- a/data/src/scripts/tutorial/scripts/guides/survival_guide.rs2
+++ b/data/src/scripts/tutorial/scripts/guides/survival_guide.rs2
@@ -62,11 +62,8 @@ if (inv_total(inv, net) < 1 & inv_freespace(inv) > 0) {
 
 [label,survival_guide_fishing]
 ~chatnpc("<p,neutral>There's nothing like a good fire to warm the bones.|Next thing is getting food in our bellies. We'll need|something to cook. There are shrimp in the pond there.|So let's catch and cook some.");
-npc_findallzone(0_48_48_29_20);
-while (npc_findnext = true) {
-    if (npc_coord = 0_48_48_29_20 & npc_type = tut_fishing_spot) {
-        hint_npc(npc_uid);
-    }
+if (npc_findexact(0_48_48_29_20, tut_fishing_spot) = true) {
+    hint_npc(npc_uid);
 }
 inv_add(inv, net, 1);
 %tutorial_progress = ^survival_guide_fish_shrimps;

--- a/data/src/scripts/tutorial/scripts/locs/tut_bank_booth.rs2
+++ b/data/src/scripts/tutorial/scripts/locs/tut_bank_booth.rs2
@@ -1,5 +1,5 @@
 [oploc1,newbiebankbooth]
-if (npc_find(loc_coord, tut_banker, 1, 0) = true) {
+if (npc_find(loc_coord, tut_banker, 2, 0) = true) {
     @tut_banker;
 }
 @openbank; // default to just open bank if a bank teller was not found to start dialogue.

--- a/data/src/scripts/tutorial/scripts/locs/tut_bank_booth.rs2
+++ b/data/src/scripts/tutorial/scripts/locs/tut_bank_booth.rs2
@@ -1,30 +1,5 @@
 [oploc1,newbiebankbooth]
-npc_findallzone(movecoord(loc_coord, 1, 0, 0));
-while (npc_findnext = true) {
-    // find a banker on 4 different axis from the booth.
-    if (npc_type = tut_banker & (npc_coord = movecoord(loc_coord, 1, 0, 0) | npc_coord = movecoord(loc_coord, -1, 0, 0) | npc_coord = movecoord(loc_coord, 0, 0, 1) | npc_coord = movecoord(loc_coord, 0, 0, -1))) {
-        @tut_banker;
-    }
-}
-npc_findallzone(movecoord(loc_coord, -1, 0, 0));
-while (npc_findnext = true) {
-    // find a banker on 4 different axis from the booth.
-    if (npc_type = tut_banker & (npc_coord = movecoord(loc_coord, 1, 0, 0) | npc_coord = movecoord(loc_coord, -1, 0, 0) | npc_coord = movecoord(loc_coord, 0, 0, 1) | npc_coord = movecoord(loc_coord, 0, 0, -1))) {
-        @tut_banker;
-    }
-}
-npc_findallzone(movecoord(loc_coord, 0, 0, 1));
-while (npc_findnext = true) {
-    // find a banker on 4 different axis from the booth.
-    if (npc_type = tut_banker & (npc_coord = movecoord(loc_coord, 1, 0, 0) | npc_coord = movecoord(loc_coord, -1, 0, 0) | npc_coord = movecoord(loc_coord, 0, 0, 1) | npc_coord = movecoord(loc_coord, 0, 0, -1))) {
-        @tut_banker;
-    }
-}
-npc_findallzone(movecoord(loc_coord, 0, 0, -1));
-while (npc_findnext = true) {
-    // find a banker on 4 different axis from the booth.
-    if (npc_type = tut_banker & (npc_coord = movecoord(loc_coord, 1, 0, 0) | npc_coord = movecoord(loc_coord, -1, 0, 0) | npc_coord = movecoord(loc_coord, 0, 0, 1) | npc_coord = movecoord(loc_coord, 0, 0, -1))) {
-        @tut_banker;
-    }
+if (npc_find(loc_coord, tut_banker, 1, 0) = true) {
+    @tut_banker;
 }
 @openbank; // default to just open bank if a bank teller was not found to start dialogue.

--- a/data/src/scripts/tutorial/scripts/tut_doors_and_gates.rs2
+++ b/data/src/scripts/tutorial/scripts/tut_doors_and_gates.rs2
@@ -100,12 +100,12 @@ if (%tutorial_progress = ^quest_guide_finished) {
     %tutorial_progress = ^mining_instructor_start;
 }
 ~set_tutorial_progress;
-@climb_ladder(movecoord(coord, 0, 0, 6400), false);
+~climb_ladder(movecoord(coord, 0, 0, 6400), false);
 
 // Ladder out of mine to quest guide
 [oploc1,newbieladder1]
 p_arrivedelay;
-@climb_ladder(movecoord(coord, 0, 0, -6400), true);
+~climb_ladder(movecoord(coord, 0, 0, -6400), true);
 
 // Gate to Combat Instructor
 [oploc1,_tut_mining_exit]
@@ -209,11 +209,11 @@ if(%tutorial_progress = ^combat_instructor_after_attacking_ranged) {
     %tutorial_progress = ^tutorial_open_banking;
     ~set_tutorial_progress;
 }
-@climb_ladder(movecoord(coord, 0, 0, -6400), true);
+~climb_ladder(movecoord(coord, 0, 0, -6400), true);
 
 [oploc1,newbieladdertop2]
 p_arrivedelay;
-@climb_ladder(movecoord(coord, 0, 0, 6400), false);
+~climb_ladder(movecoord(coord, 0, 0, 6400), false);
 
 [oploc1,newbie_door6]
 if (%tutorial_progress < ^tutorial_opened_bank) {

--- a/data/src/scripts/tutorial/scripts/tutorial.rs2
+++ b/data/src/scripts/tutorial/scripts/tutorial.rs2
@@ -119,11 +119,8 @@ if (%tutorial_progress > ^tutorial_open_magic_tab) {
 
 [proc,tutorial_set_npc_hints]
 if (%tutorial_progress = ^survival_guide_fish_shrimps) {
-    npc_findallzone(0_48_48_29_20);
-    while (npc_findnext = true) {
-        if (npc_coord = 0_48_48_29_20 & npc_type = tut_fishing_spot) {
-            hint_npc(npc_uid);
-        }
+    if (npc_findexact(0_48_48_29_20, tut_fishing_spot) = true) {
+        hint_npc(npc_uid);
     }
 }
 

--- a/src/engine/script/ScriptOpcode.ts
+++ b/src/engine/script/ScriptOpcode.ts
@@ -220,6 +220,7 @@ export const enum ScriptOpcode {
     NPC_DELAY, // official
     NPC_FACESQUARE, // official
     NPC_FIND, // official
+    NPC_FINDCAT,
     NPC_FINDALLANY, // official
     NPC_FINDALL,
     NPC_FINDEXACT, // official
@@ -662,6 +663,7 @@ export const ScriptOpcodeMap: Map<string, number> = new Map([
     ['NPC_DELAY', ScriptOpcode.NPC_DELAY],
     ['NPC_FACESQUARE', ScriptOpcode.NPC_FACESQUARE],
     ['NPC_FIND', ScriptOpcode.NPC_FIND],
+    ['NPC_FINDCAT', ScriptOpcode.NPC_FINDCAT],
     ['NPC_FINDALLANY', ScriptOpcode.NPC_FINDALLANY],
     ['NPC_FINDALL', ScriptOpcode.NPC_FINDALL],
     ['NPC_FINDEXACT', ScriptOpcode.NPC_FINDEXACT],

--- a/src/engine/script/ScriptOpcodePointers.ts
+++ b/src/engine/script/ScriptOpcodePointers.ts
@@ -568,6 +568,11 @@ const ScriptOpcodePointers: {
         set2: ['active_npc2'],
         conditional: true
     },
+    [ScriptOpcode.NPC_FINDCAT]: {
+        set: ['active_npc'],
+        set2: ['active_npc2'],
+        conditional: true
+    },
     [ScriptOpcode.NPC_FINDALLANY]: {
         set: ['find_npc']
     },


### PR DESCRIPTION
- refactors `npc_findallzone()` calls to `npc_find()`, `npc_findall()`, `npc_findallany()`, and `npc_findexact()`. We have no idea if this command exists, and lots of our content used it before we knew of npc_find commands. Npc_findallzone is particularly messy/annoying to use. I checked all of our useage with osrs, and osrs never really uses npc_findallzone - which makes sense when you have the far simpler npc_find command :)
- Changes `climb_ladder` label to a proc.  This matches the design choice with doors, I needed specific behavior *after* climbing a ladder for black knights.
- adds `npc_findcat()` command. This is unconfirmed but it really helps with bankers especially, might be able to ask Ash if this command exists
- matches wines of zamorak and black knights fortress with old videos. These had outdated implementations; they're now much simpler & authentic.