### PR TITLE
feat(content): wilderness mapsquares, and missing 0_46_161 mapsquare trigger

### DIFF
--- a/data/src/scripts/music/configs/musicregion.dbrow
+++ b/data/src/scripts/music/configs/musicregion.dbrow
@@ -823,6 +823,11 @@ table=musicregion
 data=mapsquare,0_46_153_0_0
 data=name,Cave Background1
 
+[musicregion_46_161]
+table=musicregion
+data=mapsquare,0_46_161_0_0
+data=name,Serene
+
 [musicregion_47_47]
 table=musicregion
 data=mapsquare,0_47_47_0_0

--- a/data/src/scripts/music/scripts/move.rs2
+++ b/data/src/scripts/music/scripts/move.rs2
@@ -314,25 +314,43 @@ settimer(move_ikovtrigger, 1);
 
 [mapzone,0_46_54] @music_playbyregion(coord);
 
-[mapzone,0_46_55] @music_playbyregion(coord);
+[mapzone,0_46_55]
+%wilderness = ^true;
+@music_playbyregion(coord);
 
-[mapzone,0_46_56] @music_playbyregion(coord);
+[mapzone,0_46_56]
+%wilderness = ^true;
+@music_playbyregion(coord);
 
-[mapzone,0_46_57] @music_playbyregion(coord);
+[mapzone,0_46_57]
+%wilderness = ^true;
+@music_playbyregion(coord);
 
-[mapzone,0_46_58] @music_playbyregion(coord);
+[mapzone,0_46_58]
+%wilderness = ^true;
+@music_playbyregion(coord);
 
-[mapzone,0_46_59] @music_playbyregion(coord);
+[mapzone,0_46_59]
+%wilderness = ^true;
+@music_playbyregion(coord);
 
-[mapzone,0_46_60] @music_playbyregion(coord);
+[mapzone,0_46_60]
+%wilderness = ^true;
+@music_playbyregion(coord);
 
-[mapzone,0_46_61] @music_playbyregion(coord);
+[mapzone,0_46_61]
+%wilderness = ^true;
+@music_playbyregion(coord);
 
 [mapzone,0_46_149] @music_playbyregion(coord);
 
 [mapzone,0_46_152] @music_playbyregion(coord);
 
 [mapzone,0_46_153] @music_playbyregion(coord);
+
+[mapzone,0_46_161]
+%wilderness = ^true;
+@music_playbyregion(coord);
 
 [mapzone,0_47_47] @music_playbyregion(coord);
 
@@ -350,19 +368,33 @@ settimer(move_ikovtrigger, 1);
 
 [mapzone,0_47_54] @music_playbyregion(coord);
 
-[mapzone,0_47_55] @music_playbyregion(coord);
+[mapzone,0_47_55]
+%wilderness = ^true;
+@music_playbyregion(coord);
 
-[mapzone,0_47_56] @music_playbyregion(coord);
+[mapzone,0_47_56]
+%wilderness = ^true;
+@music_playbyregion(coord);
 
-[mapzone,0_47_57] @music_playbyregion(coord);
+[mapzone,0_47_57]
+%wilderness = ^true;
+@music_playbyregion(coord);
 
-[mapzone,0_47_58] @music_playbyregion(coord);
+[mapzone,0_47_58]
+%wilderness = ^true;
+@music_playbyregion(coord);
 
-[mapzone,0_47_59] @music_playbyregion(coord);
+[mapzone,0_47_59]
+%wilderness = ^true;
+@music_playbyregion(coord);
 
-[mapzone,0_47_60] @music_playbyregion(coord);
+[mapzone,0_47_60]
+%wilderness = ^true;
+@music_playbyregion(coord);
 
-[mapzone,0_47_61] @music_playbyregion(coord);
+[mapzone,0_47_61]
+%wilderness = ^true;
+@music_playbyregion(coord);
 
 [mapzone,0_47_149] @music_playbyregion(coord);
 
@@ -370,9 +402,13 @@ settimer(move_ikovtrigger, 1);
 
 [mapzone,0_47_153] @music_playbyregion(coord);
 
-[mapzone,0_47_160] @music_playbyregion(coord);
+[mapzone,0_47_160]
+%wilderness = ^true;
+@music_playbyregion(coord);
 
-[mapzone,0_47_161] @music_playbyregion(coord);
+[mapzone,0_47_161]
+%wilderness = ^true;
+@music_playbyregion(coord);
 
 [mapzone,0_48_47] @music_playbyregion(coord);
 
@@ -390,19 +426,33 @@ settimer(move_ikovtrigger, 1);
 
 [mapzone,0_48_54] @music_playbyregion(coord);
 
-[mapzone,0_48_55] @music_playbyregion(coord);
+[mapzone,0_48_55]
+%wilderness = ^true;
+@music_playbyregion(coord);
 
-[mapzone,0_48_56] @music_playbyregion(coord);
+[mapzone,0_48_56]
+%wilderness = ^true;
+@music_playbyregion(coord);
 
-[mapzone,0_48_57] @music_playbyregion(coord);
+[mapzone,0_48_57]
+%wilderness = ^true;
+@music_playbyregion(coord);
 
-[mapzone,0_48_58] @music_playbyregion(coord);
+[mapzone,0_48_58]
+%wilderness = ^true;
+@music_playbyregion(coord);
 
-[mapzone,0_48_59] @music_playbyregion(coord);
+[mapzone,0_48_59]
+%wilderness = ^true;
+@music_playbyregion(coord);
 
-[mapzone,0_48_60] @music_playbyregion(coord);
+[mapzone,0_48_60]
+%wilderness = ^true;
+@music_playbyregion(coord);
 
-[mapzone,0_48_61] @music_playbyregion(coord);
+[mapzone,0_48_61]
+%wilderness = ^true;
+@music_playbyregion(coord);
 
 [mapzone,0_48_148] @music_playbyregion(coord);
 
@@ -412,9 +462,13 @@ settimer(move_ikovtrigger, 1);
 
 [mapzone,0_48_154] @music_playbyregion(coord);
 
-[mapzone,0_48_155] @music_playbyregion(coord);
+[mapzone,0_48_155]
+%wilderness = ^true;
+@music_playbyregion(coord);
 
-[mapzone,0_48_156] @music_playbyregion(coord);
+[mapzone,0_48_156]
+%wilderness = ^true;
+@music_playbyregion(coord);
 
 [mapzone,0_49_46] ~start_desertheat_timer;
 
@@ -436,19 +490,33 @@ settimer(move_ikovtrigger, 1);
 
 [mapzone,0_49_54] @music_playbyregion(coord);
 
-[mapzone,0_49_55] @music_playbyregion(coord);
+[mapzone,0_49_55]
+%wilderness = ^true;
+@music_playbyregion(coord);
 
-[mapzone,0_49_56] @music_playbyregion(coord);
+[mapzone,0_49_56]
+%wilderness = ^true;
+@music_playbyregion(coord);
 
-[mapzone,0_49_57] @music_playbyregion(coord);
+[mapzone,0_49_57]
+%wilderness = ^true;
+@music_playbyregion(coord);
 
-[mapzone,0_49_58] @music_playbyregion(coord);
+[mapzone,0_49_58]
+%wilderness = ^true;
+@music_playbyregion(coord);
 
-[mapzone,0_49_59] @music_playbyregion(coord);
+[mapzone,0_49_59]
+%wilderness = ^true;
+@music_playbyregion(coord);
 
-[mapzone,0_49_60] @music_playbyregion(coord);
+[mapzone,0_49_60]
+%wilderness = ^true;
+@music_playbyregion(coord);
 
-[mapzone,0_49_61] @music_playbyregion(coord);
+[mapzone,0_49_61]
+%wilderness = ^true;
+@music_playbyregion(coord);
 
 [mapzone,0_49_148] @music_playbyregion(coord);
 
@@ -480,19 +548,33 @@ settimer(move_ikovtrigger, 1);
 
 [mapzone,0_50_54] @music_playbyregion(coord);
 
-[mapzone,0_50_55] @music_playbyregion(coord);
+[mapzone,0_50_55]
+%wilderness = ^true;
+@music_playbyregion(coord);
 
-[mapzone,0_50_56] @music_playbyregion(coord);
+[mapzone,0_50_56]
+%wilderness = ^true;
+@music_playbyregion(coord);
 
-[mapzone,0_50_57] @music_playbyregion(coord);
+[mapzone,0_50_57]
+%wilderness = ^true;
+@music_playbyregion(coord);
 
-[mapzone,0_50_58] @music_playbyregion(coord);
+[mapzone,0_50_58]
+%wilderness = ^true;
+@music_playbyregion(coord);
 
-[mapzone,0_50_59] @music_playbyregion(coord);
+[mapzone,0_50_59]
+%wilderness = ^true;
+@music_playbyregion(coord);
 
-[mapzone,0_50_60] @music_playbyregion(coord);
+[mapzone,0_50_60]
+%wilderness = ^true;
+@music_playbyregion(coord);
 
-[mapzone,0_50_61] @music_playbyregion(coord);
+[mapzone,0_50_61]
+%wilderness = ^true;
+@music_playbyregion(coord);
 
 [mapzone,0_50_149] @music_playbyregion(coord);
 
@@ -529,19 +611,33 @@ settimer(mercenary_check, 25);
 
 [mapzone,0_51_54] @music_playbyregion(coord);
 
-[mapzone,0_51_55] @music_playbyregion(coord);
+[mapzone,0_51_55]
+%wilderness = ^true;
+@music_playbyregion(coord);
 
-[mapzone,0_51_56] @music_playbyregion(coord);
+[mapzone,0_51_56]
+%wilderness = ^true;
+@music_playbyregion(coord);
 
-[mapzone,0_51_57] @music_playbyregion(coord);
+[mapzone,0_51_57]
+%wilderness = ^true;
+@music_playbyregion(coord);
 
-[mapzone,0_51_58] @music_playbyregion(coord);
+[mapzone,0_51_58]
+%wilderness = ^true;
+@music_playbyregion(coord);
 
-[mapzone,0_51_59] @music_playbyregion(coord);
+[mapzone,0_51_59]
+%wilderness = ^true;
+@music_playbyregion(coord);
 
-[mapzone,0_51_60] @music_playbyregion(coord);
+[mapzone,0_51_60]
+%wilderness = ^true;
+@music_playbyregion(coord);
 
-[mapzone,0_51_61] @music_playbyregion(coord);
+[mapzone,0_51_61]
+%wilderness = ^true;
+@music_playbyregion(coord);
 
 [mapzone,0_51_147] 
 settimer(mercenary_check, 25);


### PR DESCRIPTION
When I originally wrote the wilderness warning code, I didnt take into account getting into the wilderness without crossing the wilderness border! Such as, logging in, using the ardy lever, and entrana door. I now set %wilderness = ^true for each wilderness mapsquare.

Was also missing 0_46_161 music track:
![image](https://github.com/user-attachments/assets/9d9ec93b-4fcd-4f98-b234-307cec197ea9)