### PR TITLE
fix(content): Potential crash when digging for clues

### DIFF
--- a/data/src/scripts/general_use/scripts/spade.rs2
+++ b/data/src/scripts/general_use/scripts/spade.rs2
@@ -26,7 +26,7 @@ if (inzone(0_52_53_0_0, 0_52_53_63_63, coord) = true) {
 if(map_members = true & ~trail_hasclue_inv = true) {
     def_obj $clue = ~trail_getclue_inv;
 
-    if(~trail_clue_coord($clue) = true) {
+    if(~trail_clue_coord($clue) = true & oc_param($clue, trail_casket) ! null) {
         def_boolean $sextant_clue = oc_param($clue, trail_sextant);
         def_coord $trail_coord = oc_param($clue, trail_coord);
         // for coord clues, https://www.youtube.com/watch?v=rcNbwik5-Ig looking at wiki and this 2013 video you can be 1 tile off and it will still work


### PR DESCRIPTION
Digging at `trail_coord` for clues can cause the server to crash with error:
```
script error: inv_add An input for a Obj type was not valid to use. Input was -1.
file: spade.rs2

stack backtrace:
    1: [opheld1,spade] - spade.rs2:64
```

This is because the `trail_casket` param is assumed to exist but might be undefined:
```
def_namedobj $casket = oc_param($clue, trail_casket);
inv_add(inv, $casket, 1);
```

This PR updates the logic to ensure that both then trail_coord and trail_casket params are defined before allowing the dig action. 