### PR TITLE
chore: Clean up quest completions

### DIFF
--- a/data/src/scripts/_test/scripts/cheats/cheat_quest.rs2
+++ b/data/src/scripts/_test/scripts/cheats/cheat_quest.rs2
@@ -127,7 +127,6 @@ if (p_finduid(uid) = true) {
                 case 40 : queue(scorpcatcher_quest_complete, 0);
                 case 41 : 
                     %seaslug_progress = ^seaslug_complete;
-                    %questpoints = add(%questpoints, ^seaslug_questpoints);
                     inv_add(inv, bigoysterpearls, 1);
                     stat_advance(fishing, 71750);
                     queue(seaslug_quest_complete, 0);
@@ -302,14 +301,14 @@ queue(quest_chompybird_complete, 0);
 queue(quest_biohazard_complete, 0);
 queue(cog_complete, 0);
 queue(itexam_complete, 0);
-    if (npc_find(0_45_54_45_30, kaqemeex, 7, 0) = true) {
-        queue(druid_quest_complete, 0, npc_uid);
-    }
+if (npc_find(0_45_54_45_30, kaqemeex, 7, 0) = true) {
+    queue(druid_quest_complete, 0, npc_uid);
+}
 queue(mcannon_complete, 0);
-queue(crest_complete, 0);
-// Complete all blast spells and levers, gauntlet choice unselected
-%crest_spells_levers_gauntlets = calc(pow(2, ^crest_south_lever) - 1);
-%arena_progress = ^arena_defeated_genkhazard;
+    // Complete all blast spells and levers, gauntlet choice unselected
+    %crest_spells_levers_gauntlets = calc(pow(2, ^crest_south_lever) - 1);
+    %arena_progress = ^arena_defeated_genkhazard;
+queue(crest_complete, 0);    
 queue(arena_quest_complete, 0);
 queue(fishingcompo_quest_complete, 0);
 queue(fluffs_complete, 0);
@@ -325,7 +324,7 @@ queue(murder_quest_complete, 0);
 queue(itgronigen_quest_complete, 0);
 queue(quest_elena_complete, 0);
 queue(scorpcatcher_quest_complete, 0);
-%seaslug_progress = ^seaslug_complete;
+    %seaslug_progress = ^seaslug_complete;
     %questpoints = add(%questpoints, ^seaslug_questpoints);
     inv_add(inv, bigoysterpearls, 1);
     stat_advance(fishing, 71750);

--- a/data/src/scripts/_test/scripts/cheats/cheat_quest.rs2
+++ b/data/src/scripts/_test/scripts/cheats/cheat_quest.rs2
@@ -321,6 +321,7 @@ queue(zanaris_quest_complete, 0);
 queue(arthur_quest_complete, 0);
 queue(drunkmonk_complete, 0);
 queue(murder_quest_complete, 0);
+    %itgronigen_progress = ^itgronigen_complete;
 queue(itgronigen_quest_complete, 0);
 queue(quest_elena_complete, 0);
 queue(scorpcatcher_quest_complete, 0);

--- a/data/src/scripts/_test/scripts/cheats/cheat_quest.rs2
+++ b/data/src/scripts/_test/scripts/cheats/cheat_quest.rs2
@@ -121,6 +121,8 @@ if (p_finduid(uid) = true) {
                 case 36 : queue(drunkmonk_complete, 0);
                 case 37 : queue(murder_quest_complete, 0);
                 case 38 :
+                    stat_advance(crafting, 22500);
+                    inv_add(inv, uncut_sapphire, 1);
                     %itgronigen_progress = ^itgronigen_complete;
                     queue(itgronigen_quest_complete, 0);
                 case 39 : queue(quest_elena_complete, 0);
@@ -322,6 +324,8 @@ queue(arthur_quest_complete, 0);
 queue(drunkmonk_complete, 0);
 queue(murder_quest_complete, 0);
     %itgronigen_progress = ^itgronigen_complete;
+    stat_advance(crafting, 22500);
+    inv_add(inv, uncut_sapphire, 1);
 queue(itgronigen_quest_complete, 0);
 queue(quest_elena_complete, 0);
 queue(scorpcatcher_quest_complete, 0);

--- a/data/src/scripts/_test/scripts/cheats/cheat_quest.rs2
+++ b/data/src/scripts/_test/scripts/cheats/cheat_quest.rs2
@@ -99,7 +99,9 @@ if (p_finduid(uid) = true) {
                     queue(crest_complete, 0);
                     // Complete all blast spells and levers, gauntlet choice unselected
                     %crest_spells_levers_gauntlets = calc(pow(2, ^crest_south_lever) - 1);
-                case 25 : queue(arena_quest_complete, 0);
+                case 25 :
+                    %arena_progress = ^arena_defeated_genkhazard;
+                    queue(arena_quest_complete, 0);
                 case 26 : queue(fishingcompo_quest_complete, 0);
                 case 27 : 
                     %fluffs_progress = ^fluffs_complete;
@@ -118,7 +120,9 @@ if (p_finduid(uid) = true) {
                 case 35 : queue(arthur_quest_complete, 0);
                 case 36 : queue(drunkmonk_complete, 0);
                 case 37 : queue(murder_quest_complete, 0);
-                case 38 : queue(itgronigen_quest_complete, 0);
+                case 38 :
+                    %itgronigen_progress = ^itgronigen_complete;
+                    queue(itgronigen_quest_complete, 0);
                 case 39 : queue(quest_elena_complete, 0);
                 case 40 : queue(scorpcatcher_quest_complete, 0);
                 case 41 : 
@@ -305,6 +309,7 @@ queue(mcannon_complete, 0);
 queue(crest_complete, 0);
 // Complete all blast spells and levers, gauntlet choice unselected
 %crest_spells_levers_gauntlets = calc(pow(2, ^crest_south_lever) - 1);
+%arena_progress = ^arena_defeated_genkhazard;
 queue(arena_quest_complete, 0);
 queue(fishingcompo_quest_complete, 0);
 queue(fluffs_complete, 0);

--- a/data/src/scripts/_test/scripts/cheats/cheat_quest.rs2
+++ b/data/src/scripts/_test/scripts/cheats/cheat_quest.rs2
@@ -151,12 +151,12 @@ if (p_finduid(uid) = true) {
                 case 47 : queue(totem_quest_complete, 0);
                 case 48 : queue(upass_quest_complete, 0);
                 case 49 : 
-                    queue(itwatchtower_quest_complete, 0);
-                    %itwatchtower_progress = ^itwatchtower_complete;
                     // Rewards are given before quest completion, so give here
                     stat_advance(magic, 153000);
                     inv_add(inv, coins, 5000);
                     inv_add(inv, watchtowerspell, 1);
+                    %itwatchtower_progress = ^itwatchtower_complete;
+                    queue(itwatchtower_quest_complete, 0);
                 case 50 : queue(waterfall_quest_complete, 0);
                 case 51 : queue(ball_quest_complete, 0);
                 case default : mes("Quest not found.");
@@ -335,12 +335,12 @@ queue(zombiequeen_quest_complete, 0);
 queue(tree_quest_complete, 0);
 queue(totem_quest_complete, 0);
 queue(upass_quest_complete, 0);
-queue(itwatchtower_quest_complete, 0);
-%itwatchtower_progress = ^itwatchtower_complete;
+    %itwatchtower_progress = ^itwatchtower_complete;
     // Rewards are given before quest completion, so give here
     stat_advance(magic, 153000);
     inv_add(inv, coins, 5000);
     inv_add(inv, watchtowerspell, 1);
+queue(itwatchtower_quest_complete, 0);
 queue(waterfall_quest_complete, 0);
 queue(ball_quest_complete, 0);
 

--- a/data/src/scripts/_test/scripts/cheats/cheat_quest.rs2
+++ b/data/src/scripts/_test/scripts/cheats/cheat_quest.rs2
@@ -326,7 +326,6 @@ queue(itgronigen_quest_complete, 0);
 queue(quest_elena_complete, 0);
 queue(scorpcatcher_quest_complete, 0);
     %seaslug_progress = ^seaslug_complete;
-    %questpoints = add(%questpoints, ^seaslug_questpoints);
     inv_add(inv, bigoysterpearls, 1);
     stat_advance(fishing, 71750);
 queue(seaslug_quest_complete, 0);

--- a/data/src/scripts/_test/scripts/cheats/cheat_quest.rs2
+++ b/data/src/scripts/_test/scripts/cheats/cheat_quest.rs2
@@ -162,6 +162,7 @@ if (p_finduid(uid) = true) {
                 case 51 : queue(ball_quest_complete, 0);
                 case default : mes("Quest not found.");
             }
+            ~update_quests;
         } else if ($choice3 = 1) {
             switch_int ($quest) {
                 case 0 : %blackknight_progress = 0;
@@ -376,7 +377,6 @@ if ($ikov_choice = 0) {
     if (npc_find(0_42_52_34_45, radimus_erkle, 20, 0) = true) {
         @radimus_training;
     }
-
 ~update_quests;
 mes("All quests have been completed.");
 return;

--- a/data/src/scripts/areas/area_ardougne_east/scripts/caroline.rs2
+++ b/data/src/scripts/areas/area_ardougne_east/scripts/caroline.rs2
@@ -40,6 +40,7 @@ switch_int(~p_choice2("I suppose so, how do I get there?", 1, "I'm sorry, I'm to
 ~chatnpc("<p,neutral>Here, take these Oyster pearls as a reward.|They're worth quite a bit|and can be used to make lethal crossbow bolts.");
 // QUEST REWARD
 %seaslug_progress = ^seaslug_complete;
+~update_questpoints;
 inv_add(inv, bigoysterpearls, 1);
 stat_advance(fishing, 71750);
 queue(seaslug_quest_complete, 0);

--- a/data/src/scripts/areas/area_ardougne_east/scripts/caroline.rs2
+++ b/data/src/scripts/areas/area_ardougne_east/scripts/caroline.rs2
@@ -40,7 +40,6 @@ switch_int(~p_choice2("I suppose so, how do I get there?", 1, "I'm sorry, I'm to
 ~chatnpc("<p,neutral>Here, take these Oyster pearls as a reward.|They're worth quite a bit|and can be used to make lethal crossbow bolts.");
 // QUEST REWARD
 %seaslug_progress = ^seaslug_complete;
-%questpoints = add(%questpoints, ^seaslug_questpoints);
 inv_add(inv, bigoysterpearls, 1);
 stat_advance(fishing, 71750);
 queue(seaslug_quest_complete, 0);

--- a/data/src/scripts/areas/area_draynor/scripts/professor_oddenstein.rs2
+++ b/data/src/scripts/areas/area_draynor/scripts/professor_oddenstein.rs2
@@ -75,6 +75,7 @@ if(inv_total(inv, pressure_gauge) > 0 & inv_total(inv, oil_can) > 0 & inv_total(
     inv_del(inv, oil_can, 1);
     inv_del(inv, rubber_tube, 1);
     %haunted_progress = ^haunted_complete;
+    ~update_questpoints;
     queue(haunted_quest_complete, 0); // reward is queued as soon as changetype completes in OSRS
     ~chatnpc_specific("Ernest", ernest_human, "<p,happy>Thank you <text_gender("sir", "m'lady")>.|It was dreadfully irritating being a chicken.|How can I ever thank you?");
     ~chatplayer("<p,shifty>Well a cash reward is always nice...");

--- a/data/src/scripts/general/scripts/quests.rs2
+++ b/data/src/scripts/general/scripts/quests.rs2
@@ -13,6 +13,7 @@ if ($progress = 0) {
 }
 
 [proc,send_quest_complete](component $component, namedobj $obj, int $objscale, int $questpoints, string $questmessage)
+~update_quests;
 def_int $random = random(128);// Random quest complete jingle.
 if ($random < 32) {// The least common music that plays when completing a quest.
     ~midi_jingle(^quest_complete_3_jingle, ^quest_complete_3_millis);

--- a/data/src/scripts/general/scripts/quests.rs2
+++ b/data/src/scripts/general/scripts/quests.rs2
@@ -29,7 +29,6 @@ if ($component = questlist:fluffs) {
 } else {
     ~quest_complete_interface($component, $obj, $objscale, $questpoints, $questmessage);
 }
-
 if_setcolour($component, ^green_rgb);
 if_settab(questlist, ^tab_quest_journal);
 mes("Congratulations! Quest complete!");

--- a/data/src/scripts/general/scripts/quests.rs2
+++ b/data/src/scripts/general/scripts/quests.rs2
@@ -27,16 +27,13 @@ if ($component = questlist:fluffs) {
 } else if ($component = questlist:itgronigen) {
     if_openmain(questscroll_itgronigen);
 } else {
-    ~quest_complete_interface($component, $obj, $objscale, $questpoints, $questmessage);
+    if_settext(questscroll:com_3, $questmessage);
+    if_settext(questscroll:com_9, tostring($questpoints));
+    if_settext(questscroll:com_10, "Quest points.");
+    if_setobject(questscroll:com_4, $obj, $objscale);
+    if_openmain(questscroll);
 }
 mes("Congratulations! Quest complete!");
-
-[proc,quest_complete_interface](component $component, namedobj $obj, int $objscale, int $questpoints, string $questmessage)
-if_settext(questscroll:com_3, $questmessage);
-if_settext(questscroll:com_9, tostring($questpoints));
-if_settext(questscroll:com_10, "Quest points.");
-if_setobject(questscroll:com_4, $obj, $objscale);
-if_openmain(questscroll);
 
 [proc,update_questpoints]
 def_int $questpoints = 0;
@@ -144,7 +141,7 @@ if (%itwatchtower_progress >= ^itwatchtower_complete) {
     $questpoints = add($questpoints, ^itwatchtower_questpoints); }
 if (%legends_progress = ^legends_complete) {
     $questpoints = add($questpoints, ^legends_questpoints); }
-%questpoints = $questpoints;
+if (%questpoints ! $questpoints) { %questpoints = $questpoints; }//only update varp if changed
 
 [proc,update_quests]
 ~update_questpoints;

--- a/data/src/scripts/general/scripts/quests.rs2
+++ b/data/src/scripts/general/scripts/quests.rs2
@@ -14,29 +14,32 @@ if ($progress = 0) {
 
 [proc,send_quest_complete](component $component, namedobj $obj, int $objscale, int $questpoints, string $questmessage)
 ~update_questpoints;
-~quest_complete_interface($component, $obj, $objscale, $questpoints, $questmessage);
-
-[proc,quest_complete_interface](component $component, namedobj $obj, int $objscale, int $questpoints, string $questmessage)
-// Random quest complete jingle.
-def_int $random = random(128);
-if ($random < 32) {
-    // The least common music that plays when completing a quest.
+def_int $random = random(128);// Random quest complete jingle.
+if ($random < 32) {// The least common music that plays when completing a quest.
     ~midi_jingle(^quest_complete_3_jingle, ^quest_complete_3_millis);
-} else if ($random < 64) {
-    // A less common music that plays when completing a quest.
+} else if ($random < 64) {// A less common music that plays when completing a quest.
     ~midi_jingle(^quest_complete_2_jingle, ^quest_complete_2_millis);
-} else {
-    // The most common music that plays when completing a quest.
+} else {// The most common music that plays when completing a quest.
     ~midi_jingle(^quest_complete_1_jingle, ^quest_complete_1_millis);
 }
+if ($component = questlist:fluffs) {
+    if_openmain(questscroll_fluffs);
+} else if ($component = questlist:itgronigen) {
+    if_openmain(questscroll_itgronigen);
+} else {
+    ~quest_complete_interface($component, $obj, $objscale, $questpoints, $questmessage);
+}
+
+if_setcolour($component, ^green_rgb);
+if_settab(questlist, ^tab_quest_journal);
+mes("Congratulations! Quest complete!");
+
+[proc,quest_complete_interface](component $component, namedobj $obj, int $objscale, int $questpoints, string $questmessage)
 if_settext(questscroll:com_3, $questmessage);
 if_settext(questscroll:com_9, tostring($questpoints));
 if_settext(questscroll:com_10, "Quest points.");
 if_setobject(questscroll:com_4, $obj, $objscale);
 if_openmain(questscroll);
-if_setcolour($component, ^green_rgb);
-if_settab(questlist, ^tab_quest_journal);
-mes("Congratulations! Quest complete!");
 
 [proc,update_questpoints]
 def_int $questpoints = 0;

--- a/data/src/scripts/general/scripts/quests.rs2
+++ b/data/src/scripts/general/scripts/quests.rs2
@@ -6,14 +6,13 @@ if_settab(questlist, ^tab_quest_journal);
 // if_setcolor uses 5 bits per color
 if ($progress = 0) {
     if_setcolour($component, ^red_rgb);
-} else if($progress >= $complete_progress) {
+} else if ($progress >= $complete_progress) {
     if_setcolour($component, ^green_rgb);
 } else {
     if_setcolour($component, ^yellow_rgb);
 }
 
 [proc,send_quest_complete](component $component, namedobj $obj, int $objscale, int $questpoints, string $questmessage)
-~update_questpoints;
 def_int $random = random(128);// Random quest complete jingle.
 if ($random < 32) {// The least common music that plays when completing a quest.
     ~midi_jingle(^quest_complete_3_jingle, ^quest_complete_3_millis);
@@ -29,8 +28,6 @@ if ($component = questlist:fluffs) {
 } else {
     ~quest_complete_interface($component, $obj, $objscale, $questpoints, $questmessage);
 }
-if_setcolour($component, ^green_rgb);
-if_settab(questlist, ^tab_quest_journal);
 mes("Congratulations! Quest complete!");
 
 [proc,quest_complete_interface](component $component, namedobj $obj, int $objscale, int $questpoints, string $questmessage)
@@ -43,213 +40,109 @@ if_openmain(questscroll);
 [proc,update_questpoints]
 def_int $questpoints = 0;
 if (%runemysteries_progress = ^runemysteries_complete) {
-    $questpoints = add($questpoints, ^runemysteries_questpoints);
-}
-
+    $questpoints = add($questpoints, ^runemysteries_questpoints); }
 if (%doric_progress = ^doric_complete) {
-    $questpoints = add($questpoints, ^doric_questpoints);
-}
-
+    $questpoints = add($questpoints, ^doric_questpoints); }
 if (%cook_progress = ^cook_complete) {
-    $questpoints = add($questpoints, ^cook_questpoints);
-}
-
+    $questpoints = add($questpoints, ^cook_questpoints); }
 if (%romeojuliet_progress = ^romeojuliet_complete) {
-    $questpoints = add($questpoints, ^romeojuliet_questpoints);
-}
-
+    $questpoints = add($questpoints, ^romeojuliet_questpoints); }
 if (%hetty_progress = ^hetty_complete) {
-    $questpoints = add($questpoints, ^hetty_questpoints);
-}
-
+    $questpoints = add($questpoints, ^hetty_questpoints); }
 if (%chompybird_progress = ^chompybird_complete) {
-    $questpoints = add($questpoints, ^chompybird_questpoints);
-}
-
+    $questpoints = add($questpoints, ^chompybird_questpoints); }
 if (%priest_progress = ^priest_complete) {
-    $questpoints = add($questpoints, ^priest_questpoints);
-}
-
+    $questpoints = add($questpoints, ^priest_questpoints); }
 if (%squire_progress = ^squire_complete) {
-    $questpoints = add($questpoints, ^squire_questpoints);
-}
-
+    $questpoints = add($questpoints, ^squire_questpoints); }
 if (%imp_progress = ^imp_complete) {
-    $questpoints = add($questpoints, ^imp_questpoints);
-}
-
+    $questpoints = add($questpoints, ^imp_questpoints); }
 if (%druid_progress = ^druid_complete) {
-    $questpoints = add($questpoints, ^druid_questpoints);
-}
-
+    $questpoints = add($questpoints, ^druid_questpoints); }
 if (%gobdip_progress = ^gobdip_complete) {
-    $questpoints = add($questpoints, ^gobdip_questpoints);
-}
-
+    $questpoints = add($questpoints, ^gobdip_questpoints); }
 if (%sheep_progress = ^sheep_complete) {
-    $questpoints = add($questpoints, ^sheep_questpoints);
-}
-
+    $questpoints = add($questpoints, ^sheep_questpoints); }
 if (%fluffs_progress = ^fluffs_complete) {
-    $questpoints = add($questpoints, ^fluffs_questpoints);
-}
-
+    $questpoints = add($questpoints, ^fluffs_questpoints); }
 if (%demon_progress = ^demon_complete) {
-    $questpoints = add($questpoints, ^demon_questpoints);
-}
-
+    $questpoints = add($questpoints, ^demon_questpoints); }
 if (%prince_progress = ^prince_complete) {
-    $questpoints = add($questpoints, ^prince_questpoints);
-}
-
+    $questpoints = add($questpoints, ^prince_questpoints); }
 if (%blackknight_progress = ^blackknight_complete) {
-    $questpoints = add($questpoints, ^blackknight_questpoints);
-}
-
+    $questpoints = add($questpoints, ^blackknight_questpoints); }
 if (%haunted_progress = ^haunted_complete) {
-    $questpoints = add($questpoints, ^haunted_questpoints);
-}
-
+    $questpoints = add($questpoints, ^haunted_questpoints); }
 if (%hunt_progress = ^hunt_complete) {
-    $questpoints = add($questpoints, ^hunt_questpoints);
-}
-
+    $questpoints = add($questpoints, ^hunt_questpoints); }
 if (%drunkmonk_progress = ^drunkmonk_complete) {
-    $questpoints = add($questpoints, ^drunkmonk_questpoints);
-}
-
+    $questpoints = add($questpoints, ^drunkmonk_questpoints); }
 if (%vampire_progress = ^vampire_complete) {
-    $questpoints = add($questpoints, ^vampire_questpoints);
-}
-
+    $questpoints = add($questpoints, ^vampire_questpoints); }
 if (%totem_progress = ^totem_complete) {
-    $questpoints = add($questpoints, ^totem_questpoints);
-}
-
+    $questpoints = add($questpoints, ^totem_questpoints); }
 if (%fishingcompo_progress = ^fishingcompo_complete) {
-    $questpoints = add($questpoints, ^fishingcompo_questpoints);
-}
-
+    $questpoints = add($questpoints, ^fishingcompo_questpoints); }
 if (%scorpcatcher_progress = ^scorpcatcher_complete) {
-    $questpoints = add($questpoints, ^scorpcatcher_questpoints);
-}
-
+    $questpoints = add($questpoints, ^scorpcatcher_questpoints); }
 if (%zanaris_progress = ^zanaris_complete) {
-    $questpoints = add($questpoints, ^zanaris_questpoints);
-}
-
+    $questpoints = add($questpoints, ^zanaris_questpoints); }
 if (%blackarmgang_progress = ^blackarmgang_complete | %phoenixgang_progress = ^phoenixgang_complete) {
-    $questpoints = add($questpoints, ^blackarmgang_questpoints);
-}
-
+    $questpoints = add($questpoints, ^blackarmgang_questpoints); }
 if (%elena_progress >= ^elena_complete) {
-    $questpoints = add($questpoints, ^elena_questpoints);
-}
-
+    $questpoints = add($questpoints, ^elena_questpoints); }
 if (%dragon_progress >= ^dragon_complete) {
-    $questpoints = add($questpoints, ^dragon_questpoints);
-}
-
+    $questpoints = add($questpoints, ^dragon_questpoints); }
 if (%seaslug_progress = ^seaslug_complete) {
-    $questpoints = add($questpoints, ^seaslug_questpoints);
-}
-
+    $questpoints = add($questpoints, ^seaslug_questpoints); }
 if (%arthur_progress = ^arthur_complete) {
-    $questpoints = add($questpoints, ^arthur_questpoints);
-}
-
+    $questpoints = add($questpoints, ^arthur_questpoints); }
 if (%tree_progress = ^tree_complete) {
-    $questpoints = add($questpoints, ^tree_questpoints);
-}
-
+    $questpoints = add($questpoints, ^tree_questpoints); }
 if (%waterfall_progress = ^waterfall_complete) {
-    $questpoints = add($questpoints, ^waterfall_questpoints);
-}
-
+    $questpoints = add($questpoints, ^waterfall_questpoints); }
 if (%grail_progress = ^grail_complete) {
-    $questpoints = add($questpoints, ^grail_questpoints);
-}
-
+    $questpoints = add($questpoints, ^grail_questpoints); }
 if (%ball_progress = ^ball_complete) {
-    $questpoints = add($questpoints, ^ball_questpoints);
-}
-
+    $questpoints = add($questpoints, ^ball_questpoints); }
 if (%murder_progress = ^murder_complete) {
-    $questpoints = add($questpoints, ^murder_questpoints);
-}
-
+    $questpoints = add($questpoints, ^murder_questpoints); }
 if (%hazeelcult_progress = ^hazeelcult_complete) {
-    $questpoints = add($questpoints, ^hazeelcult_questpoints);
-}
-
+    $questpoints = add($questpoints, ^hazeelcult_questpoints); }
 if (%hero_progress = ^hero_complete) {
-    $questpoints = add($questpoints, ^hero_questpoints);
-}
-
+    $questpoints = add($questpoints, ^hero_questpoints); }
 if (%itgronigen_progress >= ^itgronigen_complete) { // varp is incremented for getting wine post quest
-    $questpoints = add($questpoints, ^itgronigen_questpoints);
-}
-
+    $questpoints = add($questpoints, ^itgronigen_questpoints); }
 if (%arena_progress >= ^arena_complete) { // different completion states based on if you kill general khazard or not
-    $questpoints = add($questpoints, ^arena_questpoints);
-}
-
+    $questpoints = add($questpoints, ^arena_questpoints); }
 if (%junglepotion_progress >= ^junglepotion_complete) {
-    $questpoints = add($questpoints, ^junglepotion_questpoints);
-}
-
+    $questpoints = add($questpoints, ^junglepotion_questpoints); }
 if (%ikov_progress >= ^ikov_completed_armadyl) { // 80 = armadyl completion, 90 = lucien completion
-    $questpoints = add($questpoints, ^ikov_questpoints);
-}
-
+    $questpoints = add($questpoints, ^ikov_questpoints); }
 if (%biohazard_progress >= ^biohazard_complete) {
-    $questpoints = add($questpoints, ^biohazard_questpoints);
-}
-
+    $questpoints = add($questpoints, ^biohazard_questpoints); }
 if (%sheepherder_progress >= ^sheepherder_complete) {
-    $questpoints = add($questpoints, ^sheepherder_questpoints);
-}
-
+    $questpoints = add($questpoints, ^sheepherder_questpoints); }
 if (%mcannon_progress = ^mcannon_complete) {
-    $questpoints = add($questpoints, ^mcannon_questpoints);
-}
-
+    $questpoints = add($questpoints, ^mcannon_questpoints); }
 if (~get_cog_progress = ^quest_cog_complete) {
-    $questpoints = add($questpoints, ^cog_questpoints);
-}
-
+    $questpoints = add($questpoints, ^cog_questpoints); }
 if (%grandtree_progress = ^grandtree_complete) {
-    $questpoints = add($questpoints, ^grandtree_questpoints);
-}
-
+    $questpoints = add($questpoints, ^grandtree_questpoints); }
 if (%upass_progress = ^upass_complete) {
-    $questpoints = add($questpoints, ^upass_questpoints);
-}
-
+    $questpoints = add($questpoints, ^upass_questpoints); }
 if (%zombiequeen_progress >= ^zombiequeen_complete) {
-    $questpoints = add($questpoints, ^zombiequeen_questpoints);
-}
-
+    $questpoints = add($questpoints, ^zombiequeen_questpoints); }
 if (%crest_progress = ^crest_complete) {
-    $questpoints = add($questpoints, ^crest_questpoints);
-}
-
+    $questpoints = add($questpoints, ^crest_questpoints); }
 if (%itexam_progress = ^itexam_complete) {
-    $questpoints = add($questpoints, ^itexam_questpoints);
-}
-
+    $questpoints = add($questpoints, ^itexam_questpoints); }
 if (%desertrescue_progress = ^desertrescue_complete) {
-    $questpoints = add($questpoints, ^desertrescue_questpoints);
-}
-
+    $questpoints = add($questpoints, ^desertrescue_questpoints); }
 if (%itwatchtower_progress >= ^itwatchtower_complete) {
-    $questpoints = add($questpoints, ^itwatchtower_questpoints);
-}
-
+    $questpoints = add($questpoints, ^itwatchtower_questpoints); }
 if (%legends_progress = ^legends_complete) {
-    $questpoints = add($questpoints, ^legends_questpoints);
-}
-
+    $questpoints = add($questpoints, ^legends_questpoints); }
 %questpoints = $questpoints;
 
 [proc,update_quests]
@@ -315,7 +208,6 @@ if (testbit(%upass_map_mechanisms, ^upass_started_bit) = true & %upass_progress 
 ~send_quest_progress_colour(questlist:itwatchtower, %itwatchtower_progress, ^itwatchtower_complete);
 ~send_quest_progress_colour(questlist:legends, %legends_progress, ^legends_complete);
 if_settab(questlist, ^tab_quest_journal);
-
 if (%drunkmonk_progress >= ^drunkmonk_spoken_to_omad) {
     settimer(blanket_ladder, 1);
 }

--- a/data/src/scripts/quests/quest_arena/scripts/quest_arena.rs2
+++ b/data/src/scripts/quests/quest_arena/scripts/quest_arena.rs2
@@ -277,7 +277,8 @@ if(p_finduid(uid) = false) {
 @arena_release_bouncer;
 
 [queue,arena_quest_complete]
-%arena_progress = calc(%arena_progress + 2); // 14 if you're on 12 or 15 on if you're on 13 
+%arena_progress = calc(%arena_progress + 2); // 14 if you're on 12 or 15 on if you're on 13
+~update_questpoints;
 inv_add(inv, coins, 1000);
 stat_advance(attack, 121750);
 stat_advance(thieving, 21750);

--- a/data/src/scripts/quests/quest_arthur/scripts/quest_arthur.rs2
+++ b/data/src/scripts/quests/quest_arthur/scripts/quest_arthur.rs2
@@ -272,5 +272,6 @@ switch_obj(last_useitem) {
 
 [queue,arthur_quest_complete]
 %arthur_progress = ^arthur_complete;
+~update_questpoints;
 session_log(^log_adventure, "Quest complete: Merlin's Crystal");
 ~send_quest_complete(questlist:arthur, excalibur, 250, ^arthur_questpoints, "You have completed the\\nMerlins' Crystal Quest!");

--- a/data/src/scripts/quests/quest_ball/scripts/quest_ball.rs2
+++ b/data/src/scripts/quests/quest_ball/scripts/quest_ball.rs2
@@ -198,6 +198,7 @@ mes("A shapeshifter appears, and knocks you back from the ball!");
 [queue,ball_quest_complete]
 // https://web.archive.org/web/20060908030634im_/http://www.runeweb.net/fireball/Witchs%20House%20Images/Witch3.PNG
 %ball_progress = ^ball_complete;
+~update_questpoints;
 inv_del(inv, ball, 1);
 stat_advance(hitpoints, 63250);
 session_log(^log_adventure, "Quest complete: Witches House");

--- a/data/src/scripts/quests/quest_biohazard/scripts/quest_biohazard.rs2
+++ b/data/src/scripts/quests/quest_biohazard/scripts/quest_biohazard.rs2
@@ -162,5 +162,6 @@ mes("and find Elena's distillator.");
 [queue,quest_biohazard_complete]
 stat_advance(thieving, 12500);
 %biohazard_progress = ^biohazard_complete;
+~update_questpoints;
 session_log(^log_adventure, "Quest complete: Biohazard");
 ~send_quest_complete(questlist:biohazard, distillator, 250, ^biohazard_questpoints, "You have completed the\\nBiohazard Quest!");

--- a/data/src/scripts/quests/quest_blackarmgang/scripts/quest_blackarmgang.rs2
+++ b/data/src/scripts/quests/quest_blackarmgang/scripts/quest_blackarmgang.rs2
@@ -123,6 +123,7 @@ if(%phoenixgang_progress = ^phoenixgang_joined) {
     %blackarmgang_progress = ^blackarmgang_complete;
     session_log(^log_adventure, "Quest complete: Shield of Arrav (Black Arm Gang)");
 }
+~update_questpoints;
 ~send_quest_complete(questlist:blackarmgang, coins, 250, ^blackarmgang_questpoints, "You have completed the\\nShield of Arrav Quest!");
 inv_del(inv, arravcertificate, 1);
 inv_add(inv, coins, 600);

--- a/data/src/scripts/quests/quest_blackknight/scripts/quest_blackknight.rs2
+++ b/data/src/scripts/quests/quest_blackknight/scripts/quest_blackknight.rs2
@@ -151,6 +151,7 @@ if (%blackknight_progress = 1) {
 
 [queue,black_knights_fortress_quest_complete]
 %blackknight_progress = ^blackknight_complete;
+~update_questpoints;
 inv_add(inv, coins, 2500);
 mes("Sir Amik hands you 2500 coins.");
 session_log(^log_adventure, "Quest complete: Black Knight's Fortress");

--- a/data/src/scripts/quests/quest_chompybird/scripts/quest_chompybird.rs2
+++ b/data/src/scripts/quests/quest_chompybird/scripts/quest_chompybird.rs2
@@ -43,6 +43,7 @@ inv_add(inv, filled_ogre_bellow3, 1);
 // https://x.com/JagexAsh/status/1820722879937343844, 294 is probably cleared entirely after quest
 %chompybird_progress = ^chompybird_complete;
 %chompybird_kills = 0;
+~update_questpoints;
 stat_advance(fletching, 2620);
 stat_advance(cooking, 14700);
 stat_advance(ranged, 7350);

--- a/data/src/scripts/quests/quest_cog/scripts/quest_cog.rs2
+++ b/data/src/scripts/quests/quest_cog/scripts/quest_cog.rs2
@@ -2,6 +2,7 @@
 // https://web.archive.org/web/20051025140435/http://www.runeweb.net/index.php?page=rs2-quest-clocktower
 [queue,cog_complete]
 ~cog_update_main_quest_step(^quest_cog_complete);
+~update_questpoints;
 inv_add(inv, coins, 500);
 session_log(^log_adventure, "Quest complete: Clock Tower");
 ~send_quest_complete(questlist:cog, coins_25, 250, ^cog_questpoints, "You have completed the\\nClock Tower Quest!");

--- a/data/src/scripts/quests/quest_cook/scripts/quest_cook.rs2
+++ b/data/src/scripts/quests/quest_cook/scripts/quest_cook.rs2
@@ -86,6 +86,7 @@ queue(cooks_quest_complete, 0);
 
 [queue,cooks_quest_complete]
 %cook_progress = ^cook_complete;
+~update_questpoints;
 stat_advance(cooking, 3000);
 session_log(^log_adventure, "Quest complete: Cook's Assistant");
 ~send_quest_complete(questlist:cook, cake, 250, ^cook_questpoints, "You have completed the Cooks' Quest!");

--- a/data/src/scripts/quests/quest_crest/scripts/quest_crest.rs2
+++ b/data/src/scripts/quests/quest_crest/scripts/quest_crest.rs2
@@ -6,6 +6,7 @@
 %crest_progress = ^crest_complete;
 // resets this var after completion (choronozon needs to be hit with all 4 blasts to kill again, gold door is always unlocked but lever puzzle resets)
 %crest_spells_levers_gauntlets = 0;
+~update_questpoints;
 inv_add(inv, steel_gauntlets, 1);
 session_log(^log_adventure, "Quest complete: Family Crest");
 ~send_quest_complete(questlist:crest, steel_gauntlets, 250, ^squire_questpoints, "You have completed the\\nFamily Crest Quest!");

--- a/data/src/scripts/quests/quest_demon/scripts/demon_slayer.rs2
+++ b/data/src/scripts/quests/quest_demon/scripts/demon_slayer.rs2
@@ -2,6 +2,7 @@
 
 [queue,demon_slayer_complete]
 %demon_progress = ^demon_complete;
+~update_questpoints;
 session_log(^log_adventure, "Quest complete: Demon Slayer");
 ~send_quest_complete(questlist:demon, silverlight, 250, ^demon_questpoints, "You have completed the\\nDemon Slayer Quest!");
 

--- a/data/src/scripts/quests/quest_desertrescue/scripts/quest_desertrescue.rs2
+++ b/data/src/scripts/quests/quest_desertrescue/scripts/quest_desertrescue.rs2
@@ -894,5 +894,6 @@ p_opnpc(1);
 
 [queue,desertrescue_complete]
 %desertrescue_progress = ^desertrescue_complete;
+~update_questpoints;
 // https://web.archive.org/web/20051025141912im_/http://runeweb.net/rathofdoom/quests/touristtrap/7.png
 ~send_quest_complete(questlist:desertrescue, bronze_dart, 200, ^desertrescue_questpoints, "You have completed the\\nTourist Trap Quest!");

--- a/data/src/scripts/quests/quest_doric/scripts/quest_doric.rs2
+++ b/data/src/scripts/quests/quest_doric/scripts/quest_doric.rs2
@@ -112,6 +112,7 @@ if (inv_total(inv, clay) > 5 & inv_total(inv, copper_ore) > 3 & inv_total(inv, i
 // Reward Scroll
 [queue,doric_quest_complete]
 %doric_progress = ^doric_complete;
+~update_questpoints;
 stat_advance(mining, 13000);
 session_log(^log_adventure, "Quest complete: Doric's Quest");
 ~send_quest_complete(questlist:doric, steel_pickaxe, 250, ^doric_questpoints, "You have completed\\nDoric's Quest!");

--- a/data/src/scripts/quests/quest_dragon/scripts/quest_dragon.rs2
+++ b/data/src/scripts/quests/quest_dragon/scripts/quest_dragon.rs2
@@ -30,6 +30,7 @@ if (inzone(0_44_150_31_28, 0_44_150_47_46, coord) = true) { // only tele if in t
 %dragon_ned_hired = ^false;
 %dragon_planks = 0;
 %dragon_progress = ^dragon_complete;
+~update_questpoints;
 stat_advance(strength, 186500);
 stat_advance(defence, 186500);
 session_log(^log_adventure, "Quest complete: Dragon Slayer");

--- a/data/src/scripts/quests/quest_druid/scripts/quest_druid.rs2
+++ b/data/src/scripts/quests/quest_druid/scripts/quest_druid.rs2
@@ -1,5 +1,6 @@
 [queue,druid_quest_complete](npc_uid $uid)
 %druid_progress = ^druid_complete;
+~update_questpoints;
 stat_advance(herblore, 2500);
 session_log(^log_adventure, "Quest complete: Druidic Ritual");
 ~send_quest_complete(questlist:druid, marentill, 220, ^druid_questpoints, "You have completed the\\nDruidic Ritual Quest!");

--- a/data/src/scripts/quests/quest_drunkmonk/scripts/quest_drunkmonk.rs2
+++ b/data/src/scripts/quests/quest_drunkmonk/scripts/quest_drunkmonk.rs2
@@ -83,6 +83,7 @@ if(random(3) > 0) {
 
 [queue,drunkmonk_complete]
 %drunkmonk_progress = ^drunkmonk_complete;
+~update_questpoints;
 session_log(^log_adventure, "Quest complete: Monk's Friend");
 ~send_quest_complete(questlist:drunkmonk, lawrune, 250, ^drunkmonk_questpoints, "You have completed the\\nMonk's Friend Quest!");
 inv_add(inv, lawrune, 8);

--- a/data/src/scripts/quests/quest_elena/scripts/quest_elena.rs2
+++ b/data/src/scripts/quests/quest_elena/scripts/quest_elena.rs2
@@ -11,5 +11,6 @@ inv_del(inv, turnip_book, ^max_32bit_int);
 inv_add(inv, ardougnescroll, 1);
 stat_advance(mining, 24250);
 ~quest_elena_set_progress(^elena_complete);
+~update_questpoints;
 session_log(^log_adventure, "Quest complete: Plague City");
 ~send_quest_complete(questlist:elena, gasmask, 250, ^elena_questpoints, "You have completed the\\nPlague City Quest!");

--- a/data/src/scripts/quests/quest_fishingcompo/scripts/quest_fishingcompo.rs2
+++ b/data/src/scripts/quests/quest_fishingcompo/scripts/quest_fishingcompo.rs2
@@ -107,6 +107,7 @@ if(npc_find(coord, sinister_stranger, 8, 0) = true) {
 
 [queue,fishingcompo_quest_complete]
 %fishingcompo_progress = ^fishingcompo_complete;
+~update_questpoints;
 session_log(^log_adventure, "Quest complete: Fishing Contest");
 ~send_quest_complete(questlist:fishingcompo, hemenster_fishing_trophy, 180, ^fishingcompo_questpoints, "You have completed the\\nFishing Competition Quest!");
 stat_advance(fishing, 24370);

--- a/data/src/scripts/quests/quest_fluffs/scripts/quest_fluffs.rs2
+++ b/data/src/scripts/quests/quest_fluffs/scripts/quest_fluffs.rs2
@@ -309,6 +309,7 @@ npc_del;
 ~mesbox("The kitten has run off!");
 
 [queue,fluffs_complete] //imgur.com/6ePHvef
+~update_questpoints;
 session_log(^log_adventure, "Quest complete: Gertrude's Cat");
 stat_advance(cooking, 15250);
 ~send_quest_complete(questlist:fluffs, null, 0, ^fluffs_questpoints, null);

--- a/data/src/scripts/quests/quest_fluffs/scripts/quest_fluffs.rs2
+++ b/data/src/scripts/quests/quest_fluffs/scripts/quest_fluffs.rs2
@@ -310,21 +310,5 @@ npc_del;
 
 [queue,fluffs_complete] //imgur.com/6ePHvef
 session_log(^log_adventure, "Quest complete: Gertrude's Cat");
-%questpoints = calc(%questpoints + ^fluffs_questpoints);
-// Random quest complete jingle.
-def_int $random = random(128);
-if ($random < 32) {
-    // The least common music that plays when completing a quest.
-    ~midi_jingle(^quest_complete_3_jingle, ^quest_complete_3_millis);
-} else if ($random < 64) {
-    // A less common music that plays when completing a quest.
-    ~midi_jingle(^quest_complete_2_jingle, ^quest_complete_2_millis);
-} else {
-    // The most common music that plays when completing a quest.
-    ~midi_jingle(^quest_complete_1_jingle, ^quest_complete_1_millis);
-}
 stat_advance(cooking, 15250);
-if_openmain(questscroll_fluffs);
-if_setcolour(questlist:fluffs, ^green_rgb);
-if_settab(questlist, ^tab_quest_journal);
-mes("Congratulations! Quest complete!");
+~send_quest_complete(questlist:fluffs, null, 0, ^fluffs_questpoints, null);

--- a/data/src/scripts/quests/quest_gobdip/scripts/quest_gobdip.rs2
+++ b/data/src/scripts/quests/quest_gobdip/scripts/quest_gobdip.rs2
@@ -59,6 +59,7 @@ queue(goblin_diplomacy_complete_quest, 0);
 
 [queue,goblin_diplomacy_complete_quest]
 %gobdip_progress = ^gobdip_complete;
+~update_questpoints;
 stat_advance(crafting, 2000);
 inv_add(inv, gold_bar, 1);
 session_log(^log_adventure, "Quest complete: Goblin Diplomacy");

--- a/data/src/scripts/quests/quest_grail/scripts/quest_grail.rs2
+++ b/data/src/scripts/quests/quest_grail/scripts/quest_grail.rs2
@@ -112,6 +112,7 @@ if(abs($delta_x) > 5 & abs($delta_z) > 5) {
 
 [queue,grail_quest_complete]
 %grail_progress = ^grail_complete;
+~update_questpoints;
 inv_del(inv, holy_grail, 1);
 stat_advance(prayer, 110000);
 stat_advance(defence, 153000);

--- a/data/src/scripts/quests/quest_grandtree/scripts/quest_grandtree.rs2
+++ b/data/src/scripts/quests/quest_grandtree/scripts/quest_grandtree.rs2
@@ -188,6 +188,7 @@ if($rand < 2) {
 inv_del(inv, grandtree_daconiarock, ^max_32bit_int);
 inv_del(bank, grandtree_daconiarock, ^max_32bit_int);
 %grandtree_progress = ^grandtree_complete;
+~update_questpoints;
 stat_advance(agility, 79000);
 stat_advance(attack, 184000);
 stat_advance(magic, 21500);

--- a/data/src/scripts/quests/quest_hazeelcult/scripts/quest_hazeelcult.rs2
+++ b/data/src/scripts/quests/quest_hazeelcult/scripts/quest_hazeelcult.rs2
@@ -168,6 +168,7 @@ if_openmain(questscroll);
 
 [queue,hazeelcult_quest_complete]
 %hazeelcult_progress = ^hazeelcult_complete;
+~update_questpoints;
 inv_del(inv, hazeel_scroll, 1);
 stat_advance(thieving, 15000);
 inv_add(inv, coins, 2000);

--- a/data/src/scripts/quests/quest_hero/scripts/quest_hero.rs2
+++ b/data/src/scripts/quests/quest_hero/scripts/quest_hero.rs2
@@ -26,6 +26,7 @@ return (false);
 
 [queue,hero_quest_complete]
 %hero_progress = ^hero_complete;
+~update_questpoints;
 stat_advance(attack, 30750);
 stat_advance(defence, 30750);
 stat_advance(strength, 30750);

--- a/data/src/scripts/quests/quest_hetty/scripts/quest_hetty.rs2
+++ b/data/src/scripts/quests/quest_hetty/scripts/quest_hetty.rs2
@@ -8,6 +8,7 @@ if(%hetty_progress = ^hetty_objects_given) {
 
 [queue,hetty_quest_complete]
 %hetty_progress = ^hetty_complete;
+~update_questpoints;
 stat_advance(magic, 3250);
 session_log(^log_adventure, "Quest complete: Witch's Potion");
 ~send_quest_complete(questlist:hetty, eye_of_newt, 250, ^hetty_questpoints, "You have completed the\\nWitches Potion Quest!");

--- a/data/src/scripts/quests/quest_hunt/scripts/dig.rs2
+++ b/data/src/scripts/quests/quest_hunt/scripts/dig.rs2
@@ -21,6 +21,7 @@ inv_add(inv, coins, 450);
 inv_add(inv, gold_ring, 1);
 inv_add(inv, emerald, 1);
 %hunt_progress = 4;
+~update_questpoints;
 session_log(^log_adventure, "Quest complete: Pirate's Treasure");
 // https://web.archive.org/web/20080325101204/http://www.global-rs.com/quests/piratestreasure/
 ~send_quest_complete(questlist:hunt, emerald, 250, ^hunt_questpoints, "You have completed the Pirate's Treasure Quest!");

--- a/data/src/scripts/quests/quest_ikov/scripts/quest_ikov.rs2
+++ b/data/src/scripts/quests/quest_ikov/scripts/quest_ikov.rs2
@@ -59,6 +59,7 @@ while (npc_huntnext = true) {
 
 [queue,ikov_armadyl_quest_complete](npc_uid $npc)
 %ikov_progress = ^ikov_completed_armadyl;
+~update_questpoints;
 stat_advance(ranged, 105000);
 stat_advance(fletching, 80000);
 session_log(^log_adventure, "Quest complete: Temple of Ikov (Armadyl)");
@@ -69,6 +70,7 @@ if (npc_finduid($npc) = true) {
 
 [queue,ikov_lucien_quest_complete]
 %ikov_progress = ^ikov_completed_lucien;
+~update_questpoints;
 inv_del(inv, ikov_staffofarmardyl, 1);
 stat_advance(ranged, 105000);
 stat_advance(fletching, 80000);

--- a/data/src/scripts/quests/quest_imp/scripts/quest_imp.rs2
+++ b/data/src/scripts/quests/quest_imp/scripts/quest_imp.rs2
@@ -1,5 +1,6 @@
 [queue,imp_quest_complete]
 %imp_progress = ^imp_complete;
+~update_questpoints;
 inv_add(inv, amulet_of_accuracy, 1);
 stat_advance(magic, 8750);
 session_log(^log_adventure, "Quest complete: Imp Catcher");

--- a/data/src/scripts/quests/quest_itexam/scripts/quest_itexam.rs2
+++ b/data/src/scripts/quests/quest_itexam/scripts/quest_itexam.rs2
@@ -35,6 +35,7 @@ return (testbit(%itexam_bits, $bit));
 
 [queue,itexam_complete]
 ~itexam_set_progress(^itexam_complete);
+~update_questpoints;
 stat_advance(mining, 153000);
 stat_advance(herblore, 20000);
 inv_add(inv, gold_bar, 2);

--- a/data/src/scripts/quests/quest_itgronigen/scripts/quest_itgronigen.rs2
+++ b/data/src/scripts/quests/quest_itgronigen/scripts/quest_itgronigen.rs2
@@ -259,6 +259,7 @@ switch_int($constellation_numb) {
         inv_add(inv, amulet_of_defence, 1);
 }
 %itgronigen_progress = ^itgronigen_complete;
+~update_questpoints;
 stat_advance(crafting, 22500);
 inv_add(inv, uncut_sapphire, 1);
 queue(itgronigen_quest_complete, 0);

--- a/data/src/scripts/quests/quest_itgronigen/scripts/quest_itgronigen.rs2
+++ b/data/src/scripts/quests/quest_itgronigen/scripts/quest_itgronigen.rs2
@@ -259,11 +259,11 @@ switch_int($constellation_numb) {
         inv_add(inv, amulet_of_defence, 1);
 }
 %itgronigen_progress = ^itgronigen_complete;
+stat_advance(crafting, 22500);
+inv_add(inv, uncut_sapphire, 1);
 queue(itgronigen_quest_complete, 0);
 @professor_friend_of_gods;
 
 [queue,itgronigen_quest_complete]
-stat_advance(crafting, 22500);
-inv_add(inv, uncut_sapphire, 1);
 session_log(^log_adventure, "Quest complete: Observatory");
 ~send_quest_complete(questlist:itgronigen, null, 0, ^itgronigen_questpoints, null);

--- a/data/src/scripts/quests/quest_itgronigen/scripts/quest_itgronigen.rs2
+++ b/data/src/scripts/quests/quest_itgronigen/scripts/quest_itgronigen.rs2
@@ -258,28 +258,12 @@ switch_int($constellation_numb) {
         ~chatnpc("<p,happy>Cancer the crab.|The armoured crab gives you an amulet of defence.");
         inv_add(inv, amulet_of_defence, 1);
 }
-stat_advance(crafting, 22500);
-inv_add(inv, uncut_sapphire, 1);
 %itgronigen_progress = ^itgronigen_complete;
-%questpoints = calc(%questpoints + ^itgronigen_questpoints);
 queue(itgronigen_quest_complete, 0);
 @professor_friend_of_gods;
 
 [queue,itgronigen_quest_complete]
+stat_advance(crafting, 22500);
+inv_add(inv, uncut_sapphire, 1);
 session_log(^log_adventure, "Quest complete: Observatory");
-// Random quest complete jingle.
-def_int $random = random(128);
-if ($random < 32) {
-    // The least common music that plays when completing a quest.
-    ~midi_jingle(^quest_complete_3_jingle, ^quest_complete_3_millis);
-} else if ($random < 64) {
-    // A less common music that plays when completing a quest.
-    ~midi_jingle(^quest_complete_2_jingle, ^quest_complete_2_millis);
-} else {
-    // The most common music that plays when completing a quest.
-    ~midi_jingle(^quest_complete_1_jingle, ^quest_complete_1_millis);
-}
-if_openmain(questscroll_itgronigen);
-if_setcolour(questlist:itgronigen, ^green_rgb);
-if_settab(questlist, ^tab_quest_journal);
-mes("Congratulations! Quest complete!");
+~send_quest_complete(questlist:itgronigen, null, 0, ^itgronigen_questpoints, null);

--- a/data/src/scripts/quests/quest_itwatchtower/scripts/quest_itwatchtower.rs2
+++ b/data/src/scripts/quests/quest_itwatchtower/scripts/quest_itwatchtower.rs2
@@ -556,22 +556,5 @@ mes("The scroll crumbles to dust.");
 
 [queue,itwatchtower_quest_complete]
 session_log(^log_adventure, "Quest complete: Watch Tower");
-def_int $random = random(128);
-if ($random < 32) {
-    // The least common music that plays when completing a quest.
-    ~midi_jingle(^quest_complete_3_jingle, ^quest_complete_3_millis);
-} else if ($random < 64) {
-    // A less common music that plays when completing a quest.
-    ~midi_jingle(^quest_complete_2_jingle, ^quest_complete_2_millis);
-} else {
-    // The most common music that plays when completing a quest.
-    ~midi_jingle(^quest_complete_1_jingle, ^quest_complete_1_millis);
-}
-if_settext(questscroll:com_3, "You have finished the Watchtower Quest.");
-if_settext(questscroll:com_9, tostring(4));
 // https://web.archive.org/web/20041229124758im_/http://img7.imageshack.us/img7/9247/complete.jpg
-if_setobject(questscroll:com_4, ogrerelic, 260);
-if_openmain(questscroll);
-if_setcolour(questlist:itwatchtower, ^green_rgb);
-if_settab(questlist, ^tab_quest_journal);
-mes("Congratulations! Quest complete!");
+~send_quest_complete(questlist:itwatchtower, ogrerelic, 260, ^itwatchtower_questpoints, "You have finished the Watchtower Quest.");

--- a/data/src/scripts/quests/quest_itwatchtower/scripts/quest_itwatchtower.rs2
+++ b/data/src/scripts/quests/quest_itwatchtower/scripts/quest_itwatchtower.rs2
@@ -529,8 +529,8 @@ if(~watchtower_has_all_crystals = true & %itwatchtower_progress = ^itwatchtower_
     stat_advance(magic, 153000);
     inv_add(inv, coins, 5000);
     inv_add(inv, watchtowerspell, 1);
+    ~update_questpoints;
     queue(itwatchtower_quest_complete, 0);
-    %questpoints = add(%questpoints, ^itwatchtower_questpoints);
     if(npc_find(coord, watchtower_wizard, 6, 0) = true) {
         ~chatnpc("<p,happy>Marvellous! It works!|The town will now be safe.");
         ~chatnpc("<p,happy>Your help was invaluable.|Take this payment as a token of my gratitude...");

--- a/data/src/scripts/quests/quest_junglepotion/scripts/quest_junglepotion.rs2
+++ b/data/src/scripts/quests/quest_junglepotion/scripts/quest_junglepotion.rs2
@@ -71,6 +71,7 @@ if ($loc ! null) {
 
 [queue,junglepotion_quest_complete]
 %junglepotion_progress = ^junglepotion_complete;
+~update_questpoints;
 stat_advance(herblore, 7750);
 session_log(^log_adventure, "Quest complete: Jungle Potion");
 ~send_quest_complete(questlist:junglepotion, marentill, 220, ^junglepotion_questpoints, "You have completed the\\nJungle Potion Quest!");

--- a/data/src/scripts/quests/quest_legends/scripts/quest_legends.rs2
+++ b/data/src/scripts/quests/quest_legends/scripts/quest_legends.rs2
@@ -2063,6 +2063,7 @@ if(%legends_progress < ^legends_replaced_totem) {
 [queue,legends_quest_complete]
 session_log(^log_adventure, "Quest complete: Legends Quest");
 %legends_progress = ^legends_complete;
+~update_questpoints;
 // todo: older ref image?
 // https://storage.googleapis.com/tannerdino/images/legendscomplt.png
 ~send_quest_complete(questlist:legends, thtotempolegift, 250, ^legends_questpoints, "You have completed the\\nLegends Guild Quest!");

--- a/data/src/scripts/quests/quest_mcannon/scripts/quest_mcannon.rs2
+++ b/data/src/scripts/quests/quest_mcannon/scripts/quest_mcannon.rs2
@@ -22,6 +22,7 @@
 
 [queue,mcannon_complete]
 %mcannon_progress = ^mcannon_complete;
+~update_questpoints;
 stat_advance(crafting, 7500);
 session_log(^log_adventure, "Quest complete: Dwarf Cannon");
 ~send_quest_complete(questlist:mcannon, mcannonball, 200, ^mcannon_questpoints, "You have finished the Dwarf Cannon Quest.");

--- a/data/src/scripts/quests/quest_murder/scripts/quest_murder.rs2
+++ b/data/src/scripts/quests/quest_murder/scripts/quest_murder.rs2
@@ -532,6 +532,7 @@ if(inv_total(bank, murderfingerprint1) > 0) {
 %murder_poisonproof_progress = 0;
 %murder_evidence = 0;
 %murder_murderer_id = 0;
+~update_questpoints;
 stat_advance(crafting, 14060);
 inv_add(inv, coins, 2000);
 session_log(^log_adventure, "Quest complete: Murder Mystery");

--- a/data/src/scripts/quests/quest_priest/scripts/quest_priest.rs2
+++ b/data/src/scripts/quests/quest_priest/scripts/quest_priest.rs2
@@ -93,6 +93,7 @@ if_close;
 
 [queue,priest_quest_complete]
 %priest_progress = ^priest_complete;
+~update_questpoints;
 session_log(^log_adventure, "Quest complete: The Restless Ghost");
 ~send_quest_complete(questlist:priest, ghost_skull, 220, ^priest_questpoints, "You have completed the\\nRestless Ghost Quest!");
 stat_advance(prayer, 11250);

--- a/data/src/scripts/quests/quest_prince/scripts/quest_prince.rs2
+++ b/data/src/scripts/quests/quest_prince/scripts/quest_prince.rs2
@@ -53,6 +53,7 @@ if(coordz(coord) > coordz(loc_coord)) {
 
 [queue,prince_complete]
 %prince_progress = ^prince_complete;
+~update_questpoints;
 session_log(^log_adventure, "Quest complete: Prince Ali Rescue");
 ~send_quest_complete(questlist:prince, coins, 250, ^prince_questpoints, "You have completed the\\nPrince Ali Rescue Quest!");
 inv_add(inv, coins, 700);

--- a/data/src/scripts/quests/quest_romeojuliet/scripts/quest_romeojuliet.rs2
+++ b/data/src/scripts/quests/quest_romeojuliet/scripts/quest_romeojuliet.rs2
@@ -1,4 +1,5 @@
 [queue,romeo_and_juliet_complete]
 %romeojuliet_progress = ^romeojuliet_complete;
+~update_questpoints;
 session_log(^log_adventure, "Quest complete: Romeo & Juliet");
 ~send_quest_complete(questlist:romeojuliet, cadava, 250, ^romeojuliet_questpoints, "You have completed the\\nRomeo & Juliet Quest!");

--- a/data/src/scripts/quests/quest_runemysteries/scripts/quest_runemysteries.rs2
+++ b/data/src/scripts/quests/quest_runemysteries/scripts/quest_runemysteries.rs2
@@ -1,4 +1,5 @@
 [queue,rune_mysteries_complete]
 %runemysteries_progress = ^runemysteries_complete;
+~update_questpoints;
 session_log(^log_adventure, "Quest complete: Rune Mysteries");
 ~send_quest_complete(questlist:runemysteries, air_talisman, 250, ^runemysteries_questpoints, "You have completed the\\nMysteries Of The Runes Quest!");

--- a/data/src/scripts/quests/quest_scorpcatcher/scripts/quest_scorpcatcher.rs2
+++ b/data/src/scripts/quests/quest_scorpcatcher/scripts/quest_scorpcatcher.rs2
@@ -55,6 +55,7 @@ mes("You've found a secret door");
 [queue,scorpcatcher_quest_complete]
 inv_del(inv, scorpioncagefull, 1);
 %scorpcatcher_progress = ^scorpcatcher_complete;
+~update_questpoints;
 session_log(^log_adventure, "Quest complete: Scorpion Catcher");
 ~send_quest_complete(questlist:scorpcatcher, scorpioncagefull, 250, ^scorpcatcher_questpoints, "You have completed the\\nScorpion Catcher Quest!");
 stat_advance(strength, 66250);

--- a/data/src/scripts/quests/quest_seaslug/scripts/quest_seaslug.rs2
+++ b/data/src/scripts/quests/quest_seaslug/scripts/quest_seaslug.rs2
@@ -120,4 +120,4 @@ if (npc_find(movecoord(coord, 0, 0, 2), kennith, 5, 0) = true) {
 
 [queue,seaslug_quest_complete]
 session_log(^log_adventure, "Quest complete: Sea Slug");
-~send_quest_complete(questlist:seaslug, seasluginv, 250, ^itwatchtower_questpoints, "You have completed the\\nSea Slug Quest!");
+~send_quest_complete(questlist:seaslug, seasluginv, 250, ^seaslug_questpoints, "You have completed the\\nSea Slug Quest!");

--- a/data/src/scripts/quests/quest_seaslug/scripts/quest_seaslug.rs2
+++ b/data/src/scripts/quests/quest_seaslug/scripts/quest_seaslug.rs2
@@ -120,21 +120,4 @@ if (npc_find(movecoord(coord, 0, 0, 2), kennith, 5, 0) = true) {
 
 [queue,seaslug_quest_complete]
 session_log(^log_adventure, "Quest complete: Sea Slug");
-def_int $random = random(128);
-if ($random < 32) {
-    // The least common music that plays when completing a quest.
-    ~midi_jingle(^quest_complete_3_jingle, ^quest_complete_3_millis);
-} else if ($random < 64) {
-    // A less common music that plays when completing a quest.
-    ~midi_jingle(^quest_complete_2_jingle, ^quest_complete_2_millis);
-} else {
-    // The most common music that plays when completing a quest.
-    ~midi_jingle(^quest_complete_1_jingle, ^quest_complete_1_millis);
-}
-if_settext(questscroll:com_3, "You have completed the\\nSea Slug Quest!");
-if_settext(questscroll:com_9, tostring(1));
-if_setobject(questscroll:com_4, seasluginv, 250);
-if_openmain(questscroll);
-if_setcolour(questlist:seaslug, ^green_rgb);
-if_settab(questlist, ^tab_quest_journal);
-mes("Congratulations! Quest complete!");
+~send_quest_complete(questlist:seaslug, seasluginv, 250, ^itwatchtower_questpoints, "You have completed the\\nSea Slug Quest!");

--- a/data/src/scripts/quests/quest_seaslug/scripts/quest_seaslug.rs2
+++ b/data/src/scripts/quests/quest_seaslug/scripts/quest_seaslug.rs2
@@ -119,5 +119,6 @@ if (npc_find(movecoord(coord, 0, 0, 2), kennith, 5, 0) = true) {
 }
 
 [queue,seaslug_quest_complete]
+//Quest point update happens immediately after speaking to Caroline, not queued
 session_log(^log_adventure, "Quest complete: Sea Slug");
 ~send_quest_complete(questlist:seaslug, seasluginv, 250, ^seaslug_questpoints, "You have completed the\\nSea Slug Quest!");

--- a/data/src/scripts/quests/quest_sheep/scripts/quest_sheep.rs2
+++ b/data/src/scripts/quests/quest_sheep/scripts/quest_sheep.rs2
@@ -1,5 +1,6 @@
 [queue,sheep_complete]
 %sheep_progress = ^sheep_complete;
+~update_questpoints;
 inv_del(inv, ball_of_wool, 1);
 inv_add(inv, coins, 60);
 stat_advance(crafting, 1500);

--- a/data/src/scripts/quests/quest_sheepherder/scripts/quest_sheepherder.rs2
+++ b/data/src/scripts/quests/quest_sheepherder/scripts/quest_sheepherder.rs2
@@ -4,6 +4,7 @@
 
 [queue,sheepherder_complete]
 %sheepherder_progress = ^sheepherder_complete;
+~update_questpoints;
 inv_add(inv, coins, 3100);
 session_log(^log_adventure, "Quest complete: Sheep Herder");
 ~send_quest_complete(questlist:sheepherder, coins_100, 200, ^sheepherder_questpoints, "You have completed the Sheep Herder Quest!");

--- a/data/src/scripts/quests/quest_squire/scripts/quest_squire.rs2
+++ b/data/src/scripts/quests/quest_squire/scripts/quest_squire.rs2
@@ -218,6 +218,7 @@ return(true);
 
 [queue,squire_complete]
 %squire_progress = ^squire_complete;
+~update_questpoints;
 session_log(^log_adventure, "Quest complete: The Knight's Sword");
 ~send_quest_complete(questlist:squire, faladian_sword, 250, ^squire_questpoints, "You have completed the Knight's Sword Quest!");
 stat_advance(smithing, 127250);

--- a/data/src/scripts/quests/quest_totem/scripts/quest_totem.rs2
+++ b/data/src/scripts/quests/quest_totem/scripts/quest_totem.rs2
@@ -157,8 +157,9 @@ if(%totem_progress >= ^totem_crate_marked) {
 ~mesbox("Senior Patents Clerk, Chamber of Invention, The Wizards' Tower, Misthalin. The crate is securely fastened shut and ready for delivery.");
 
 [queue,totem_quest_complete]
-%totem_progress = ^totem_complete;
 session_log(^log_adventure, "Quest complete: Tribal Totem");
+%totem_progress = ^totem_complete;
+~update_questpoints;
 ~send_quest_complete(questlist:totem, tribal_totem, 250, ^totem_questpoints, "You have completed the\\nTribal Totem Quest!");
 stat_advance(thieving, 17750);
 inv_add(inv, swordfish, 5);

--- a/data/src/scripts/quests/quest_tree/scripts/quest_tree.rs2
+++ b/data/src/scripts/quests/quest_tree/scripts/quest_tree.rs2
@@ -94,6 +94,7 @@ if(npc_find(coord, khazard_commander, 5, 0) = true) {
 
 [queue,tree_quest_complete]
 %tree_progress = ^tree_complete;
+~update_questpoints;
 inv_add(inv, gnome_amulet, 1);
 stat_advance(attack, 114500);
 session_log(^log_adventure, "Quest complete: Tree Gnome Village");

--- a/data/src/scripts/quests/quest_upass/scripts/quest_upass.rs2
+++ b/data/src/scripts/quests/quest_upass/scripts/quest_upass.rs2
@@ -780,6 +780,7 @@ if_openmain(stone);
 
 [queue,upass_quest_complete]
 %upass_progress = ^upass_complete;
+~update_questpoints;
 stat_advance(agility, 30000);
 stat_advance(attack, 30000);
 session_log(^log_adventure, "Quest complete: Underground Pass");

--- a/data/src/scripts/quests/quest_vampire/scripts/quest_vampire.rs2
+++ b/data/src/scripts/quests/quest_vampire/scripts/quest_vampire.rs2
@@ -41,5 +41,6 @@ p_delay(0);
 [queue,quest_vampire_complete]
 stat_advance(attack, 48250);
 ~quest_vampire_set_progress(^vampire_complete);
+~update_questpoints;
 session_log(^log_adventure, "Quest complete: Vampire Slayer");
 ~send_quest_complete(questlist:vampire, stake, 250, ^vampire_questpoints, "You have completed the\\nVampire Slayer Quest!");

--- a/data/src/scripts/quests/quest_waterfall/scripts/quest_waterfall.rs2
+++ b/data/src/scripts/quests/quest_waterfall/scripts/quest_waterfall.rs2
@@ -470,6 +470,7 @@ if(last_useitem = glarials_urn_full_waterfall_quest) {
 
 [queue,waterfall_quest_complete]
 %waterfall_progress = ^waterfall_complete;
+~update_questpoints;
 inv_add(inv, diamond, 2);
 inv_add(inv, gold_bar, 2);
 inv_add(inv, mithril_seed, 40);

--- a/data/src/scripts/quests/quest_zanaris/scripts/quest_zanaris.rs2
+++ b/data/src/scripts/quests/quest_zanaris/scripts/quest_zanaris.rs2
@@ -102,5 +102,6 @@ if($entering = false) {
 
 [queue,zanaris_quest_complete]
 %zanaris_progress = ^zanaris_complete;
+~update_questpoints;
 session_log(^log_adventure, "Quest complete: Lost City");
 ~send_quest_complete(questlist:zanaris, coins, 250, ^zanaris_questpoints, "You have completed the\\nLost City of Zanaris Quest!");

--- a/data/src/scripts/quests/quest_zombiequeen/scripts/quest_zombiequeen.rs2
+++ b/data/src/scripts/quests/quest_zombiequeen/scripts/quest_zombiequeen.rs2
@@ -1637,6 +1637,7 @@ switch_int(random(4)) {
 
 [queue,zombiequeen_quest_complete]
 %zombiequeen_progress = ^zombiequeen_complete;
+~update_questpoints;
 stat_advance(crafting, 38750);
 session_log(^log_adventure, "Quest complete: Shilo Village");
 // todo: find image for proof on sizing


### PR DESCRIPTION
**Quest Cheats:**
- Observatory & Fight Arena Quests weren't updating the progress varp (Still skipping the constellation menu for observatory though)

**Quest Completion Updates:**
- Send jingle when `[proc,send_quest_complete]` is called instead of in `[queue,X_quest_complete]`
- Adjust Sea Slug, Watchtower, Observatory, and Gertrude's Cat quests to use `~send_quest_complete`
- Removed unnecessary quest point updates in various places, since utilizing `~send_quest_complete` does this already with `~update_questpoints`

**[proc,send_quest_complete]**
- Added a check for Gertrude's Cat & Observatory since they use a specific quest scroll.
- Moved jingle, quest tab update, and `mes` outside of the `[proc,quest_complete_interface]` proc