### PR TITLE
feat(content): implement historical duel arena bugs, and some other duel arena fixes

### DIFF
--- a/data/src/scripts/_unpack/all.inv
+++ b/data/src/scripts/_unpack/all.inv
@@ -18,12 +18,6 @@ size=1
 [furstall]
 size=1
 
-[dueloffer]
-size=9
-
-[duelwinnings]
-size=9
-
 [trail_puzzleinv]
 scope=temp
 size=25

--- a/data/src/scripts/general/scripts/misc/coord_procs.rs2
+++ b/data/src/scripts/general/scripts/misc/coord_procs.rs2
@@ -218,3 +218,20 @@ while($i < db_getfieldcount($data, coord_pair_table:coord_pair)) {
     $i = add($i, 1);
 }
 return($sum);
+
+[proc,map_findsquare_inzone](coord $coord1, coord $coord2)(coord)
+def_int $x1 = coordx($coord1);
+def_int $x2 = coordx($coord2);
+def_int $z1 = coordz($coord1);
+def_int $z2 = coordz($coord2);
+def_coord $random_coord = movecoord($coord1, random(sub($x2, $x1)), 0, random(sub($z2, $z1)));
+
+def_int $i = 0;
+while (map_blocked($random_coord) = true) {
+    $random_coord = movecoord($coord1, random(sub($x2, $x1)), 0, random(sub($z2, $z1)));
+    $i = calc($i + 1);
+    if ($i = 50) {
+        return(null); // no way this is reached
+    }
+}
+return($random_coord);

--- a/data/src/scripts/general/scripts/misc/inv_procs.rs2
+++ b/data/src/scripts/general/scripts/misc/inv_procs.rs2
@@ -26,3 +26,29 @@ while ($i < inv_size($inv)) {
 $str = ~string_removeright($str, 2);
 
 return($str);
+
+[proc,moveallinv_itemspace](inv $from_inv, inv $to_inv)(boolean)
+def_int $space_needed = 0;
+def_int $i = 0;
+def_int $size = inv_size($from_inv);
+while ($i < $size) {
+    def_obj $obj = inv_getobj($from_inv, $i);
+    def_int $obj_num = inv_getnum($from_inv, $i);
+    if ($obj ! null) {
+        if (oc_stackable($obj) = true) {
+            if (inv_itemspace($to_inv, $obj, $obj_num, $size) = false) {
+                return(false);
+            }
+            if (inv_total($to_inv, $obj) < 0) {
+                $space_needed = add($space_needed, 1);
+            }
+        } else {
+            $space_needed = add($space_needed, 1);
+        }
+    }
+    $i = add($i, 1);
+}
+if ($space_needed > inv_freespace($to_inv)) {
+    return(false);
+}
+return(true);

--- a/data/src/scripts/general/scripts/misc/inv_procs.rs2
+++ b/data/src/scripts/general/scripts/misc/inv_procs.rs2
@@ -52,3 +52,175 @@ if ($space_needed > inv_freespace($to_inv)) {
     return(false);
 }
 return(true);
+
+// returns space taken up
+[proc,moveallinv_itemspace2](inv $from_inv, inv $to_inv)(int)
+def_int $space_needed = 0;
+def_int $i = 0;
+def_int $size = inv_size($from_inv);
+while ($i < $size) {
+    def_obj $obj = inv_getobj($from_inv, $i);
+    def_int $obj_num = inv_getnum($from_inv, $i);
+    if ($obj ! null) {
+        if (oc_stackable($obj) = true) {
+            if (inv_itemspace($to_inv, $obj, $obj_num, $size) = false) {
+                return(add(inv_size($to_inv), 1)); // fail
+            }
+            if (inv_total($to_inv, $obj) < 0) {
+                $space_needed = add($space_needed, 1);
+            }
+        } else {
+            $space_needed = add($space_needed, 1);
+        }
+    }
+    $i = add($i, 1);
+}
+return($space_needed);
+
+// returns space taken up when moving items from a secondary inventory to a primary inventory
+[proc,both_moveallinv_itemspace2](inv $secondary_from_inv, inv $primary_to_inv)(int)
+def_int $space_needed = 0;
+def_int $i = 0;
+def_int $size = inv_size($secondary_from_inv);
+while ($i < $size) {
+    def_obj $obj = .inv_getobj($secondary_from_inv, $i);
+    def_int $obj_num = .inv_getnum($secondary_from_inv, $i);
+    if ($obj ! null) {
+        if (oc_stackable($obj) = true) {
+            if (inv_itemspace($primary_to_inv, $obj, $obj_num, $size) = false) {
+                return(add(inv_size($primary_to_inv), 1)); // fail
+            }
+            if (inv_total($primary_to_inv, $obj) < 0) {
+                $space_needed = add($space_needed, 1);
+            }
+        } else {
+            $space_needed = add($space_needed, 1);
+        }
+    }
+    $i = add($i, 1);
+}
+return($space_needed);
+
+// returns space taken up
+[proc,enum_inv_itemspace](inv $from_inv, inv $to_inv, enum $enum)(int)
+def_int $space_needed = 0;
+def_int $i = 0;
+def_int $size = inv_size($from_inv);
+while ($i < enum_getoutputcount($enum)) {
+    def_obj $obj = inv_getobj($from_inv, enum(int, int, $enum, $i));
+    def_int $obj_num = inv_getnum($from_inv, enum(int, int, $enum, $i));
+    if ($obj ! null) {
+        if (oc_stackable($obj) = true) {
+            if (inv_itemspace($to_inv, $obj, $obj_num, $size) = false) {
+                return(add(inv_size($to_inv), 1)); // fail
+            }
+            if (inv_total($to_inv, $obj) < 0) {
+                $space_needed = add($space_needed, 1);
+            }
+        } else {
+            $space_needed = add($space_needed, 1);
+        }
+    }
+    $i = add($i, 1);
+}
+return($space_needed);
+
+
+// secondary procs
+[proc,.moveallinv_itemspace](inv $from_inv, inv $to_inv)(boolean)
+def_int $space_needed = 0;
+def_int $i = 0;
+def_int $size = inv_size($from_inv);
+while ($i < $size) {
+    def_obj $obj = .inv_getobj($from_inv, $i);
+    def_int $obj_num = .inv_getnum($from_inv, $i);
+    if ($obj ! null) {
+        if (oc_stackable($obj) = true) {
+            if (.inv_itemspace($to_inv, $obj, $obj_num, $size) = false) {
+                return(false);
+            }
+            if (.inv_total($to_inv, $obj) < 0) {
+                $space_needed = add($space_needed, 1);
+            }
+        } else {
+            $space_needed = add($space_needed, 1);
+        }
+    }
+    $i = add($i, 1);
+}
+if ($space_needed > .inv_freespace($to_inv)) {
+    return(false);
+}
+return(true);
+
+// returns space taken up
+[proc,.moveallinv_itemspace2](inv $from_inv, inv $to_inv)(int)
+def_int $space_needed = 0;
+def_int $i = 0;
+def_int $size = inv_size($from_inv);
+while ($i < $size) {
+    def_obj $obj = .inv_getobj($from_inv, $i);
+    def_int $obj_num = .inv_getnum($from_inv, $i);
+    if ($obj ! null) {
+        if (oc_stackable($obj) = true) {
+            if (.inv_itemspace($to_inv, $obj, $obj_num, $size) = false) {
+                return(add(inv_size($to_inv), 1)); // fail
+            }
+            if (.inv_total($to_inv, $obj) < 0) {
+                $space_needed = add($space_needed, 1);
+            }
+        } else {
+            $space_needed = add($space_needed, 1);
+        }
+    }
+    $i = add($i, 1);
+}
+return($space_needed);
+
+// returns space taken up when moving items from a secondary inventory to a primary inventory
+[proc,.both_moveallinv_itemspace2](inv $secondary_from_inv, inv $primary_to_inv)(int)
+def_int $space_needed = 0;
+def_int $i = 0;
+def_int $size = inv_size($secondary_from_inv);
+while ($i < $size) {
+    def_obj $obj = inv_getobj($secondary_from_inv, $i);
+    def_int $obj_num = inv_getnum($secondary_from_inv, $i);
+    if ($obj ! null) {
+        if (oc_stackable($obj) = true) {
+            if (.inv_itemspace($primary_to_inv, $obj, $obj_num, $size) = false) {
+                return(add(inv_size($primary_to_inv), 1)); // fail
+            }
+            if (.inv_total($primary_to_inv, $obj) < 0) {
+                $space_needed = add($space_needed, 1);
+            }
+        } else {
+            $space_needed = add($space_needed, 1);
+        }
+    }
+    $i = add($i, 1);
+}
+return($space_needed);
+
+// returns space taken up
+[proc,.enum_inv_itemspace](inv $from_inv, inv $to_inv, enum $enum)(int)
+def_int $space_needed = 0;
+def_int $i = 0;
+def_int $size = inv_size($from_inv);
+while ($i < enum_getoutputcount($enum)) {
+    def_obj $obj = .inv_getobj($from_inv, enum(int, int, $enum, $i));
+    def_int $obj_num = .inv_getnum($from_inv, enum(int, int, $enum, $i));
+    if ($obj ! null) {
+        if (oc_stackable($obj) = true) {
+            if (.inv_itemspace($to_inv, $obj, $obj_num, $size) = false) {
+                return(add(inv_size($to_inv), 1)); // fail
+            }
+            if (.inv_total($to_inv, $obj) < 0) {
+                $space_needed = add($space_needed, 1);
+            }
+        } else {
+            $space_needed = add($space_needed, 1);
+        }
+    }
+    $i = add($i, 1);
+}
+return($space_needed);

--- a/data/src/scripts/minigames/game_duelarena/configs/duelarena.constant
+++ b/data/src/scripts/minigames/game_duelarena/configs/duelarena.constant
@@ -22,9 +22,9 @@
 ^south_east_camera = 6
 ^south_west_camera = 7
 
-^duelstatus_lost = 5
-^duelstatus_victory = 6
-^duelstatus_opponent_resigned = 7
+^duelstatus_lost = 7
+^duelstatus_victory = 8
+^duelstatus_opponent_resigned = 9
 
 ^duelstatus_reset = 0
 ^duelstatus_received = 1

--- a/data/src/scripts/minigames/game_duelarena/configs/duelarena.dbrow
+++ b/data/src/scripts/minigames/game_duelarena/configs/duelarena.dbrow
@@ -1,14 +1,14 @@
 [duel_arena_fight_zones]
 table=coord_pair_table
-data=coord_pair,0_52_50_36_25,0_52_50_61_39
-data=coord_pair,0_52_50_4_6,0_52_50_29_20
-data=coord_pair,0_52_50_4_44,0_52_50_29_58
+data=coord_pair,0_52_50_5_44,0_52_50_29_58
+data=coord_pair,0_52_50_36_25,0_52_50_60_39
+data=coord_pair,0_52_50_5_6,0_52_50_29_20
 
 [duel_arena_obstacle_fight_zones]
 table=coord_pair_table
-data=coord_pair,0_52_50_36_6,0_52_50_61_20
-data=coord_pair,0_52_50_4_25,0_52_50_29_39
-data=coord_pair,0_52_50_36_44,0_52_50_61_58
+data=coord_pair,0_52_50_36_44,0_52_50_60_58
+data=coord_pair,0_52_50_5_25,0_52_50_29_39
+data=coord_pair,0_52_50_36_6,0_52_50_60_20
 
 [duel_arena_zones]
 table=coord_pair_table

--- a/data/src/scripts/minigames/game_duelarena/configs/duelarena.inv
+++ b/data/src/scripts/minigames/game_duelarena/configs/duelarena.inv
@@ -11,3 +11,11 @@ stock1=rotten_tomato,2000,10
 [duelarrows]
 size=29
 protect=no
+
+[dueloffer]
+size=28
+protect=no
+
+[duelwinnings]
+size=28
+protect=no

--- a/data/src/scripts/minigames/game_duelarena/scripts/duel_arena.rs2
+++ b/data/src/scripts/minigames/game_duelarena/scripts/duel_arena.rs2
@@ -391,7 +391,7 @@ if (.uid ! %duelpartner) {
     mes("You can only attack your opponent!"); // https://storage.googleapis.com/tannerdino/images/batwifahat-purpl.jpg
     return(false);
 }
-if (%duelstatus < ^duelstatus_start & .%duelstatus < ^duelstatus_start) {
+if (%duelstatus < ^duelstatus_start | .%duelstatus < ^duelstatus_start) {
     mes("The duel has not started yet!"); // https://youtu.be/64GEUr-lgS8?t=106
     return(false);
 }
@@ -432,4 +432,4 @@ if (.finduid(%duelpartner) = true) {
 [queue,duel_arena_disconnect]
 ~duel_give_stake_back;
 ~duel_reset_all;
-~mesbox("Your opponent timed out, there was no winner!"); // https://youtu.be/LZzhIWbSKpY?t=127
+mes("Your opponent timed out, there was no winner!"); // https://storage.googleapis.com/tannerdino/images/00timeout.jpg

--- a/data/src/scripts/minigames/game_duelarena/scripts/duel_arena.rs2
+++ b/data/src/scripts/minigames/game_duelarena/scripts/duel_arena.rs2
@@ -424,9 +424,9 @@ if (.finduid(%duelpartner) = true) {
 }
 %duelstatus = ^duelstatus_reset;
 %duelpartner = null;
-~duel_give_stake_back;
+~moveallinv(dueloffer, inv);
 
 [queue,duel_arena_disconnect]
-~duel_give_stake_back;
+~moveallinv(dueloffer, inv);
 ~duel_reset_all;
 mes("Your opponent timed out, there was no winner!"); // https://storage.googleapis.com/tannerdino/images/00timeout.jpg

--- a/data/src/scripts/minigames/game_duelarena/scripts/duel_arena.rs2
+++ b/data/src/scripts/minigames/game_duelarena/scripts/duel_arena.rs2
@@ -1,30 +1,30 @@
-[debugproc,tempinv]
+[debugproc,dueloffer]
 def_int $i = 0;
 def_int $null = 0;
-while ($i < inv_size(tradeoffer)) {
-    if (inv_getobj(tradeoffer, $i) ! null) {
-        mes("<tostring($i)>: <oc_debugname(inv_getobj(tradeoffer, $i))>");
+while ($i < inv_size(dueloffer)) {
+    if (inv_getobj(dueloffer, $i) ! null) {
+        mes("<tostring($i)>: <oc_debugname(inv_getobj(dueloffer, $i))>");
     } else {
         $null = add($null, 1);
     }
     $i = add($i, 1);
 }
-if ($null = inv_size(tradeoffer)) {
-    mes("tempinv is empty");
+if ($null = inv_size(dueloffer)) {
+    mes("dueloffer is empty");
 }
 
-[debugproc,stakeinv]
+[debugproc,duelwinnings]
 def_int $i = 0;
 def_int $null = 0;
-while ($i < inv_size(duelarrows)) {
-    if (inv_getobj(duelarrows, $i) ! null) {
-        mes("<tostring($i)>: <oc_debugname(inv_getobj(duelarrows, $i))>");
+while ($i < inv_size(duelwinnings)) {
+    if (inv_getobj(duelwinnings, $i) ! null) {
+        mes("<tostring($i)>: <oc_debugname(inv_getobj(duelwinnings, $i))>");
     } else {
         $null = add($null, 1);
     }
     $i = add($i, 1);
 }
-if ($null = inv_size(duelarrows)) {
+if ($null = inv_size(duelwinnings)) {
     mes("stakeinv is empty");
 }
 
@@ -59,16 +59,16 @@ if (.%duelpartner = uid & %duelstatus = ^duelstatus_received) {
     %duel_settings = 0;
     if_settext(duel_select_type:status, "");
     if_settext(duel_select_type:otherplayer, "Dueling with: <.displayname>");
-    inv_clear(tradeoffer);
-    inv_transmit(tradeoffer, duel_select_type:inv);
-    invother_transmit(.uid, tradeoffer, duel_select_type:otherinv);
+    inv_clear(dueloffer);
+    inv_transmit(dueloffer, duel_select_type:inv);
+    invother_transmit(.uid, dueloffer, duel_select_type:otherinv);
     inv_transmit(inv, duel_side:inv);
 
     .if_settext(duel_select_type:status, "");
     .if_settext(duel_select_type:otherplayer, "Dueling with: <displayname>");
-    .inv_clear(tradeoffer);
-    .inv_transmit(tradeoffer, duel_select_type:inv);
-    .invother_transmit(uid, tradeoffer, duel_select_type:otherinv);
+    .inv_clear(dueloffer);
+    .inv_transmit(dueloffer, duel_select_type:inv);
+    .invother_transmit(uid, dueloffer, duel_select_type:otherinv);
     .inv_transmit(inv, duel_side:inv);
 
     if_openmain_side(duel_select_type, duel_side);
@@ -95,7 +95,7 @@ if (.finduid(%duelpartner) = true) {
     }
 }
 
-~moveallinv(tradeoffer, inv);
+~moveallinv(dueloffer, inv);
 %duelpartner = null;
 
 [if_close,duel_confirm]
@@ -109,7 +109,7 @@ if (.finduid(%duelpartner) = true) {
     .mes("Other player declined stake and duel options."); // 2006 https://youtu.be/HFp6hOkiCns?t=304
     .%duelpartner = null;
 }
-~moveallinv(tradeoffer, inv);
+~moveallinv(dueloffer, inv);
 %duelpartner = null;
 
 [if_button,duel_select_type:accept]
@@ -131,10 +131,10 @@ if (.finduid(%duelpartner) = true & ~enough_duel_space = true) { // https://yout
         cam_reset;
         .cam_reset;
 
-        ~inv_remove_leading_empty_slots(tradeoffer);
-        ~.inv_remove_leading_empty_slots(tradeoffer);
+        ~inv_remove_leading_empty_slots(dueloffer);
+        ~.inv_remove_leading_empty_slots(dueloffer);
 
-        def_int $tempinvused = sub(inv_size(tradeoffer), inv_freespace(tradeoffer));
+        def_int $tempinvused = sub(inv_size(dueloffer), inv_freespace(dueloffer));
         if ($tempinvused < 1) {
             if_settext(duel_confirm:com_91, "Absolutely nothing!");
             .if_settext(duel_confirm:com_96, "Absolutely nothing!");
@@ -142,11 +142,11 @@ if (.finduid(%duelpartner) = true & ~enough_duel_space = true) { // https://yout
             if_settext(duel_confirm:com_91, "");
             .if_settext(duel_confirm:com_96, "");
 
-            inv_transmit(tradeoffer, duel_confirm:inv);
-            .invother_transmit(uid, tradeoffer, duel_confirm:otherinv);
+            inv_transmit(dueloffer, duel_confirm:inv);
+            .invother_transmit(uid, dueloffer, duel_confirm:otherinv);
         }
 
-        def_int $other_tempinvused = sub(inv_size(tradeoffer), .inv_freespace(tradeoffer));
+        def_int $other_tempinvused = sub(inv_size(dueloffer), .inv_freespace(dueloffer));
         if ($other_tempinvused < 1) {
             if_settext(duel_confirm:com_96, "Absolutely nothing!");
             .if_settext(duel_confirm:com_91, "Absolutely nothing!");
@@ -154,8 +154,8 @@ if (.finduid(%duelpartner) = true & ~enough_duel_space = true) { // https://yout
             if_settext(duel_confirm:com_96, "");
             .if_settext(duel_confirm:com_91, "");
 
-            invother_transmit(.uid, tradeoffer, duel_confirm:otherinv);
-            .inv_transmit(tradeoffer, duel_confirm:inv);
+            invother_transmit(.uid, dueloffer, duel_confirm:otherinv);
+            .inv_transmit(dueloffer, duel_confirm:inv);
         }
         if_openmain(duel_confirm);
         .if_openmain(duel_confirm);
@@ -187,7 +187,7 @@ if (testbit(%duel_settings, ^no_armour) = true) {
 if (testbit(%duel_settings, ^no_jewelry) = true) {
     $no_jewelry_size = enum_getoutputcount(duel_arena_jewelry_slots);
 }
-def_int $size = calc(inv_size(tradeoffer) + .inv_size(tradeoffer) + $no_weapons_size + $no_armour_size + $no_jewelry_size);
+def_int $size = calc(inv_size(dueloffer) + .inv_size(dueloffer) + $no_weapons_size + $no_armour_size + $no_jewelry_size);
 def_int $slot = 0;
 def_int $space_needed = 0;
 def_string $fail_message = "You do not have enough space for the items removed.";
@@ -203,13 +203,13 @@ while ($slot < $size) {
     } else if ($slot < calc($no_weapons_size + $no_armour_size + $no_jewelry_size)) {
         $obj = inv_getobj(worn, enum(int, int, duel_arena_jewelry_slots, calc($slot - $no_weapons_size - $no_armour_size)));
         $num = inv_getnum(worn, enum(int, int, duel_arena_jewelry_slots, calc($slot - $no_weapons_size - $no_armour_size)));
-    } else if ($slot < calc(.inv_size(tradeoffer) + $no_weapons_size + $no_armour_size + $no_jewelry_size)) {
-        $obj = inv_getobj(tradeoffer, calc($slot - $no_weapons_size - $no_armour_size - $no_jewelry_size));
-        $num = inv_getnum(tradeoffer, calc($slot - $no_weapons_size - $no_armour_size - $no_jewelry_size));
+    } else if ($slot < calc(.inv_size(dueloffer) + $no_weapons_size + $no_armour_size + $no_jewelry_size)) {
+        $obj = inv_getobj(dueloffer, calc($slot - $no_weapons_size - $no_armour_size - $no_jewelry_size));
+        $num = inv_getnum(dueloffer, calc($slot - $no_weapons_size - $no_armour_size - $no_jewelry_size));
         $fail_message = "You do not have enough space for the stake.";
     } else {
-        $obj = .inv_getobj(tradeoffer, calc($slot - .inv_size(tradeoffer) - $no_weapons_size - $no_armour_size - $no_jewelry_size));
-        $num = .inv_getnum(tradeoffer, calc($slot - .inv_size(tradeoffer) - $no_weapons_size - $no_armour_size - $no_jewelry_size));
+        $obj = .inv_getobj(dueloffer, calc($slot - .inv_size(dueloffer) - $no_weapons_size - $no_armour_size - $no_jewelry_size));
+        $num = .inv_getnum(dueloffer, calc($slot - .inv_size(dueloffer) - $no_weapons_size - $no_armour_size - $no_jewelry_size));
         $fail_message = "You do not have enough space for the stake.";
     }
     
@@ -248,7 +248,7 @@ if (testbit(.%duel_settings, ^no_armour) = true) {
 if (testbit(.%duel_settings, ^no_jewelry) = true) {
     $no_jewelry_size = enum_getoutputcount(duel_arena_jewelry_slots);
 }
-def_int $size = calc(.inv_size(tradeoffer) + inv_size(tradeoffer) + $no_weapons_size + $no_armour_size + $no_jewelry_size);
+def_int $size = calc(.inv_size(dueloffer) + inv_size(dueloffer) + $no_weapons_size + $no_armour_size + $no_jewelry_size);
 def_int $slot = 0;
 def_int $space_needed = 0;
 while ($slot < $size) {
@@ -263,12 +263,12 @@ while ($slot < $size) {
     } else if ($slot < calc($no_weapons_size + $no_armour_size + $no_jewelry_size)) {
         $obj = .inv_getobj(worn, enum(int, int, duel_arena_jewelry_slots, calc($slot - $no_weapons_size - $no_armour_size)));
         $num = .inv_getnum(worn, enum(int, int, duel_arena_jewelry_slots, calc($slot - $no_weapons_size - $no_armour_size)));
-    } else if ($slot < calc(.inv_size(tradeoffer) + $no_weapons_size + $no_armour_size + $no_jewelry_size)) {
-        $obj = .inv_getobj(tradeoffer, calc($slot - $no_weapons_size - $no_armour_size - $no_jewelry_size));
-        $num = .inv_getnum(tradeoffer, calc($slot - $no_weapons_size - $no_armour_size - $no_jewelry_size));
+    } else if ($slot < calc(.inv_size(dueloffer) + $no_weapons_size + $no_armour_size + $no_jewelry_size)) {
+        $obj = .inv_getobj(dueloffer, calc($slot - $no_weapons_size - $no_armour_size - $no_jewelry_size));
+        $num = .inv_getnum(dueloffer, calc($slot - $no_weapons_size - $no_armour_size - $no_jewelry_size));
     } else {
-        $obj = inv_getobj(tradeoffer, calc($slot - inv_size(tradeoffer) - $no_weapons_size - $no_armour_size - $no_jewelry_size));
-        $num = inv_getnum(tradeoffer, calc($slot - inv_size(tradeoffer) - $no_weapons_size - $no_armour_size - $no_jewelry_size));
+        $obj = inv_getobj(dueloffer, calc($slot - inv_size(dueloffer) - $no_weapons_size - $no_armour_size - $no_jewelry_size));
+        $num = inv_getnum(dueloffer, calc($slot - inv_size(dueloffer) - $no_weapons_size - $no_armour_size - $no_jewelry_size));
     }
     
     if ($obj ! null) {
@@ -300,9 +300,6 @@ if (.finduid(%duelpartner) = true) {
         mes("Accepted stake and duel options.");
         .mes("Accepted stake and duel options.");
 
-        // both_moveinv(inv, inv);
-        // .both_moveinv(tempinv, inv);
-
         %duelstatus = ^duelstatus_confirm;
         .%duelstatus = ^duelstatus_confirm;
 
@@ -329,10 +326,10 @@ if ($amount <= 0) {
     $amount = last_int;
 }
 
-def_obj $obj = inv_getobj(tradeoffer, $slot);
-def_int $total = inv_total(tradeoffer, $obj);
+def_obj $obj = inv_getobj(dueloffer, $slot);
+def_int $total = inv_total(dueloffer, $obj);
 if ($amount < $total) $total = $amount;
-inv_moveitem(tradeoffer, inv, $obj, $total);
+inv_moveitem(dueloffer, inv, $obj, $total);
 
 %duelstatus = ^duelstatus_reset;
 if_settext(duel_select_type:status, "");
@@ -370,7 +367,7 @@ if (oc_members($obj) = true & map_members = false) { // cant duel on f2p worlds 
 
 def_int $total = inv_total(inv, $obj);
 if ($amount < $total) $total = $amount;
-inv_moveitem(inv, tradeoffer, $obj, $total);
+inv_moveitem(inv, dueloffer, $obj, $total);
 
 %duelstatus = ^duelstatus_reset;
 if_settext(duel_select_type:status, "");

--- a/data/src/scripts/minigames/game_duelarena/scripts/duel_arena.rs2
+++ b/data/src/scripts/minigames/game_duelarena/scripts/duel_arena.rs2
@@ -175,119 +175,48 @@ if (.finduid(%duelpartner) = true & ~enough_duel_space = true) { // https://yout
 }
 
 [proc,enough_duel_space]()(boolean)
-def_int $no_weapons_size = 0;
-def_int $no_armour_size = 0;
-def_int $no_jewelry_size = 0;
+def_int $space_needed = 0;
 if (testbit(%duel_settings, ^no_weapons) = true) {
-    $no_weapons_size = enum_getoutputcount(duel_arena_weapon_slots);
+    $space_needed = add($space_needed, ~enum_inv_itemspace(worn, inv, duel_arena_weapon_slots));
 }
 if (testbit(%duel_settings, ^no_armour) = true) {
-    $no_armour_size = enum_getoutputcount(duel_arena_armour_slots);
+    $space_needed = add($space_needed, ~enum_inv_itemspace(worn, inv, duel_arena_armour_slots));
 }
 if (testbit(%duel_settings, ^no_jewelry) = true) {
-    $no_jewelry_size = enum_getoutputcount(duel_arena_jewelry_slots);
+    $space_needed = add($space_needed, ~enum_inv_itemspace(worn, inv, duel_arena_jewelry_slots));
 }
-def_int $size = calc(inv_size(dueloffer) + .inv_size(dueloffer) + $no_weapons_size + $no_armour_size + $no_jewelry_size);
-def_int $slot = 0;
-def_int $space_needed = 0;
-def_string $fail_message = "You do not have enough space for the items removed.";
-while ($slot < $size) {
-    def_obj $obj;
-    def_int $num;
-    if ($slot < $no_weapons_size) {
-        $obj = inv_getobj(worn, enum(int, int, duel_arena_weapon_slots, $slot));
-        $num = inv_getnum(worn, enum(int, int, duel_arena_weapon_slots, $slot));
-    } else if ($slot < calc($no_weapons_size + $no_armour_size)) {
-        $obj = inv_getobj(worn, enum(int, int, duel_arena_armour_slots, calc($slot - $no_weapons_size)));
-        $num = inv_getnum(worn, enum(int, int, duel_arena_armour_slots, calc($slot - $no_weapons_size)));
-    } else if ($slot < calc($no_weapons_size + $no_armour_size + $no_jewelry_size)) {
-        $obj = inv_getobj(worn, enum(int, int, duel_arena_jewelry_slots, calc($slot - $no_weapons_size - $no_armour_size)));
-        $num = inv_getnum(worn, enum(int, int, duel_arena_jewelry_slots, calc($slot - $no_weapons_size - $no_armour_size)));
-    } else if ($slot < calc(.inv_size(dueloffer) + $no_weapons_size + $no_armour_size + $no_jewelry_size)) {
-        $obj = inv_getobj(dueloffer, calc($slot - $no_weapons_size - $no_armour_size - $no_jewelry_size));
-        $num = inv_getnum(dueloffer, calc($slot - $no_weapons_size - $no_armour_size - $no_jewelry_size));
-        $fail_message = "You do not have enough space for the stake.";
-    } else {
-        $obj = .inv_getobj(dueloffer, calc($slot - .inv_size(dueloffer) - $no_weapons_size - $no_armour_size - $no_jewelry_size));
-        $num = .inv_getnum(dueloffer, calc($slot - .inv_size(dueloffer) - $no_weapons_size - $no_armour_size - $no_jewelry_size));
-        $fail_message = "You do not have enough space for the stake.";
-    }
-    
-    if ($obj ! null) {
-        if (oc_stackable($obj) = false) {
-            $num = 1;
-        }
-        if (inv_itemspace(inv, $obj, $num, .inv_size(inv)) = true) {
-            if (oc_stackable($obj) = false | (oc_stackable($obj) = true & inv_total(inv, $obj) < 1)) {
-                $space_needed = calc($space_needed + 1);
-            }
-        } else {
-            if_settext(duel_select_type:status, $fail_message);
-            return(false);
-        }
-        if (inv_freespace(inv) < $space_needed) {
-            if_settext(duel_select_type:status, $fail_message);
-            return(false);
-        }
-    }
-
-    $slot = add($slot, 1);
+if ($space_needed > inv_freespace(inv)) {
+    if_settext(duel_select_type:status, "You do not have enough space for the items removed.");
+    return(false);
+}
+$space_needed = add($space_needed, ~moveallinv_itemspace2(dueloffer, inv));
+$space_needed = add($space_needed, ~both_moveallinv_itemspace2(dueloffer, inv));
+if ($space_needed > inv_freespace(inv)) {
+    if_settext(duel_select_type:status, "You do not have enough space for the stake.");
+    return(false);
 }
 return(true);
 
 [proc,.enough_duel_space]()(boolean)
-def_int $no_weapons_size = 0;
-def_int $no_armour_size = 0;
-def_int $no_jewelry_size = 0;
+def_int $space_needed = 0;
 if (testbit(.%duel_settings, ^no_weapons) = true) {
-    $no_weapons_size = enum_getoutputcount(duel_arena_weapon_slots);
+    $space_needed = add($space_needed, ~.enum_inv_itemspace(worn, inv, duel_arena_weapon_slots));
 }
 if (testbit(.%duel_settings, ^no_armour) = true) {
-    $no_armour_size = enum_getoutputcount(duel_arena_armour_slots);
+    $space_needed = add($space_needed, ~.enum_inv_itemspace(worn, inv, duel_arena_armour_slots));
 }
 if (testbit(.%duel_settings, ^no_jewelry) = true) {
-    $no_jewelry_size = enum_getoutputcount(duel_arena_jewelry_slots);
+    $space_needed = add($space_needed, ~.enum_inv_itemspace(worn, inv, duel_arena_jewelry_slots));
 }
-def_int $size = calc(.inv_size(dueloffer) + inv_size(dueloffer) + $no_weapons_size + $no_armour_size + $no_jewelry_size);
-def_int $slot = 0;
-def_int $space_needed = 0;
-while ($slot < $size) {
-    def_obj $obj;
-    def_int $num;
-    if ($slot < $no_weapons_size) {
-        $obj = .inv_getobj(worn, enum(int, int, duel_arena_weapon_slots, $slot));
-        $num = .inv_getnum(worn, enum(int, int, duel_arena_weapon_slots, $slot));
-    } else if ($slot < calc($no_weapons_size + $no_armour_size)) {
-        $obj = .inv_getobj(worn, enum(int, int, duel_arena_armour_slots, calc($slot - $no_weapons_size)));
-        $num = .inv_getnum(worn, enum(int, int, duel_arena_armour_slots, calc($slot - $no_weapons_size)));
-    } else if ($slot < calc($no_weapons_size + $no_armour_size + $no_jewelry_size)) {
-        $obj = .inv_getobj(worn, enum(int, int, duel_arena_jewelry_slots, calc($slot - $no_weapons_size - $no_armour_size)));
-        $num = .inv_getnum(worn, enum(int, int, duel_arena_jewelry_slots, calc($slot - $no_weapons_size - $no_armour_size)));
-    } else if ($slot < calc(.inv_size(dueloffer) + $no_weapons_size + $no_armour_size + $no_jewelry_size)) {
-        $obj = .inv_getobj(dueloffer, calc($slot - $no_weapons_size - $no_armour_size - $no_jewelry_size));
-        $num = .inv_getnum(dueloffer, calc($slot - $no_weapons_size - $no_armour_size - $no_jewelry_size));
-    } else {
-        $obj = inv_getobj(dueloffer, calc($slot - inv_size(dueloffer) - $no_weapons_size - $no_armour_size - $no_jewelry_size));
-        $num = inv_getnum(dueloffer, calc($slot - inv_size(dueloffer) - $no_weapons_size - $no_armour_size - $no_jewelry_size));
-    }
-    
-    if ($obj ! null) {
-        if (oc_stackable($obj) = false) {
-            $num = 1;
-        }
-        if (.inv_itemspace(inv, $obj, $num, inv_size(inv)) = true) {
-            if (oc_stackable($obj) = false | (oc_stackable($obj) = true & .inv_total(inv, $obj) < 1)) {
-                $space_needed = calc($space_needed + 1);
-            }
-        } else {
-            return(false);
-        }
-        if (.inv_freespace(inv) < $space_needed) {
-            return(false);
-        }
-    }
-
-    $slot = add($slot, 1);
+if ($space_needed > .inv_freespace(inv)) {
+    .if_settext(duel_select_type:status, "You do not have enough space for the items removed.");
+    return(false);
+}
+$space_needed = add($space_needed, ~.moveallinv_itemspace2(dueloffer, inv));
+$space_needed = add($space_needed, ~.both_moveallinv_itemspace2(dueloffer, inv));
+if ($space_needed > .inv_freespace(inv)) {
+    .if_settext(duel_select_type:status, "You do not have enough space for the stake.");
+    return(false);
 }
 return(true);
 

--- a/data/src/scripts/minigames/game_duelarena/scripts/duel_arena_finish.rs2
+++ b/data/src/scripts/minigames/game_duelarena/scripts/duel_arena_finish.rs2
@@ -1,8 +1,8 @@
 [queue,player_death_duel]
-%duelstatus = ^duelstatus_lost;
 if (~in_duel_arena(coord) = true) {
     ~player_death;
 }
+%duelstatus = ^duelstatus_lost;
 clearqueue(duel_finish);
 queue(duel_finish, 0);
 
@@ -10,6 +10,7 @@ if (.finduid(%duelpartner) = true) {
     session_log(^log_moderator, "Lost a duel against <.name>");
     .if_close;
     .%duelstatus = ^duelstatus_victory;
+    both_moveinv(dueloffer, duelwinnings);
     .clearqueue(duel_finish);
     .queue(duel_finish, 0);
 }
@@ -40,33 +41,35 @@ if (.finduid(%duelpartner) = true) {
         return;
     }
 }
-~duel_reset_all;
+if (%duelstatus = ^duelstatus_lost) {
+    ~duel_reset_all;
+}
+
 [proc,duel_spoils]
 ~midi_jingle(^duel_win_2_jingle, ^duel_win_2_jingle_millis);
-if_openmain(duel_win);
 ~duel_adjust_scoreboard(displayname, ~player_combat_level, .displayname, ~.player_combat_level);
 if_settext(duel_win:displayname, .displayname);
 if_settext(duel_win:combat_level, tostring(~.player_combat_level));
 
 ~duel_give_stake_back;
+inv_transmit(duelwinnings, duel_win:spoils);
 
-// take stuff from other player's stakeinv
-.both_moveinv(duelarrows, duelarrows);
-inv_transmit(duelarrows, duel_win:spoils);
+if_openmain(duel_win);
 
 [proc,duel_reset_all]
 // get arrows back
 def_int $i = 0;
-while ($i < inv_size(tradeoffer)) {
-    if (inv_getobj(tradeoffer, $i) ! null) {
-        inv_movefromslot(tradeoffer, inv, $i);
+while ($i < inv_size(duelarrows)) {
+    if (inv_getobj(duelarrows, $i) ! null) {
+        inv_movefromslot(duelarrows, inv, $i);
     }
     $i = calc($i + 1);
 }
 
 buildappearance(worn);
 ~prayer_deactivate_all;
-p_telejump(~duel_arena_finish_coord(coord));
+
+p_telejump(~map_findsquare_inzone(0_52_51_27_3, 0_52_51_51_15)); // https://youtu.be/QggKGBAl_X8?t=111
 anim(null, 0);
 p_stopaction;
 
@@ -83,35 +86,19 @@ hint_stop;
 
 [proc,duel_give_stake_back]
 def_int $i = 0;
-while ($i < inv_size(duelarrows)) {
-    if (inv_getobj(duelarrows, $i) ! null) {
-        //mes("<oc_debugname(inv_getobj(stakeinv, $i))>: <tostring(inv_getnum(tempinv, $i))>");
-        inv_movefromslot(duelarrows, inv, $i);
+while ($i < inv_size(dueloffer)) {
+    if (inv_getobj(dueloffer, $i) ! null) {
+        inv_movefromslot(dueloffer, inv, $i);
     }
     $i = calc($i + 1);
 }
 
 [if_close,duel_win]
-~duel_give_stake_back;
-inv_stoptransmit(duel_win:spoils);
-
-// https://youtu.be/QggKGBAl_X8?t=111
-[proc,duel_arena_finish_coord](coord $coord)(coord)
-def_coord $coord1 = 0_52_51_27_3;
-def_coord $coord2 = 0_52_51_51_15;
-
-def_int $x1 = coordx($coord1);
-def_int $x2 = coordx($coord2);
-def_int $z1 = coordz($coord1);
-def_int $z2 = coordz($coord2);
 def_int $i = 0;
-def_coord $random_coord = movecoord($coord1, random(sub($x2, $x1)), 0, random(sub($z2, $z1)));
-
-while (map_blocked($random_coord) = true) {
-    $random_coord = movecoord($coord1, random(sub($x2, $x1)), 0, random(sub($z2, $z1)));
-    $i = calc($i + 1);
-    if ($i = 50) {
-        return($coord); // no way this is reached
+while ($i < inv_size(duelwinnings)) {
+    if (inv_getobj(duelwinnings, $i) ! null) {
+        inv_movefromslot(duelwinnings, inv, $i);
     }
+    $i = calc($i + 1);
 }
-return($random_coord);
+inv_stoptransmit(duel_win:spoils);

--- a/data/src/scripts/minigames/game_duelarena/scripts/duel_arena_finish.rs2
+++ b/data/src/scripts/minigames/game_duelarena/scripts/duel_arena_finish.rs2
@@ -55,9 +55,6 @@ if_settext(duel_win:combat_level, tostring(~.player_combat_level));
 inv_transmit(duelarrows, duel_win:spoils);
 
 [proc,duel_reset_all]
-if (~in_duel_arena(coord) = false) {
-    return;
-}
 // get arrows back
 def_int $i = 0;
 while ($i < inv_size(tradeoffer)) {

--- a/data/src/scripts/minigames/game_duelarena/scripts/duel_arena_finish.rs2
+++ b/data/src/scripts/minigames/game_duelarena/scripts/duel_arena_finish.rs2
@@ -51,7 +51,7 @@ if (%duelstatus = ^duelstatus_lost) {
 if_settext(duel_win:displayname, .displayname);
 if_settext(duel_win:combat_level, tostring(~.player_combat_level));
 
-~duel_give_stake_back;
+~moveallinv(dueloffer, inv);
 inv_transmit(duelwinnings, duel_win:spoils);
 
 if_openmain(duel_win);
@@ -84,21 +84,10 @@ hint_stop;
 %duelstatus = ^duelstatus_reset;
 %duelpartner = null;
 
-[proc,duel_give_stake_back]
-def_int $i = 0;
-while ($i < inv_size(dueloffer)) {
-    if (inv_getobj(dueloffer, $i) ! null) {
-        inv_movefromslot(dueloffer, inv, $i);
-    }
-    $i = calc($i + 1);
-}
-
 [if_close,duel_win]
-def_int $i = 0;
-while ($i < inv_size(duelwinnings)) {
-    if (inv_getobj(duelwinnings, $i) ! null) {
-        inv_movefromslot(duelwinnings, inv, $i);
-    }
-    $i = calc($i + 1);
+if (~moveallinv_itemspace(duelwinnings, inv) = false) {
+    inv_dropall(duelwinnings, coord, ^lootdrop_duration);
+    return;
 }
+~moveallinv(duelwinnings, inv);
 inv_stoptransmit(duel_win:spoils);

--- a/data/src/scripts/minigames/game_duelarena/scripts/duel_arena_finish.rs2
+++ b/data/src/scripts/minigames/game_duelarena/scripts/duel_arena_finish.rs2
@@ -1,8 +1,8 @@
 [queue,player_death_duel]
+%duelstatus = ^duelstatus_lost;
 if (~in_duel_arena(coord) = true) {
     ~player_death;
 }
-%duelstatus = ^duelstatus_lost;
 clearqueue(duel_finish);
 queue(duel_finish, 0);
 

--- a/data/src/scripts/minigames/game_duelarena/scripts/duel_arena_start.rs2
+++ b/data/src/scripts/minigames/game_duelarena/scripts/duel_arena_start.rs2
@@ -83,9 +83,7 @@ if (.finduid(%duelpartner) = false) {
 }
 if (~.in_duel_arena(.coord) = false) {
     queue(duel_arena_disconnect, 0);
-    .%duelstatus = ^duelstatus_reset;
-    .%duelpartner = null;
-    ~.moveallinv(dueloffer, inv);
+    .queue(duel_arena_disconnect, 0);
     .clearqueue(duel_arena_prepare_start);
     return;
 }

--- a/data/src/scripts/minigames/game_duelarena/scripts/duel_arena_start.rs2
+++ b/data/src/scripts/minigames/game_duelarena/scripts/duel_arena_start.rs2
@@ -125,6 +125,6 @@ if (~in_duel_arena(coord) = false) {
 }
 %duelstatus = ^duelstatus_reset;
 %duelpartner = null;
-~duel_give_stake_back;
+~moveallinv(dueloffer, inv);
 ~duel_reset_all;
 ~mesbox("Your duel ended in an honourable draw."); // RS3 message: https://archive.org/details/runelibris

--- a/data/src/scripts/minigames/game_duelarena/scripts/duel_arena_start.rs2
+++ b/data/src/scripts/minigames/game_duelarena/scripts/duel_arena_start.rs2
@@ -24,8 +24,6 @@ if (.finduid(%duelpartner) = true) {
         .p_telejump($random_coord2);
     }
 
-    // move tempinv to stakeinv
-    ~moveallinv(tradeoffer, duelarrows);
     p_stopaction;
     // only deactive prayers if no prayers is selected. based off: https://imgur.com/ETH1z4L
     if (testbit(%duel_settings, ^no_prayer) = true) {
@@ -94,54 +92,25 @@ say("FIGHT!");
 %duelstatus = ^duelstatus_start;
 
 [proc,duel_arena_coord]()(coord)
-// random coord between 2 coords, checks if map blocked and not inside dueler
-def_coord $coord1;
-def_coord $coord2;
-def_int $i = 0;
-def_int $random_arena;
 // if all arenas are full, return null
 if (~duel_arena_obstacles_check = true) {
-    def_int $obstacle_arenas = db_getfieldcount(duel_arena_obstacle_fight_zones, coord_pair_table:coord_pair);
-    while ($i < $obstacle_arenas) {
-        if (map_playercount(db_getfield(duel_arena_obstacle_fight_zones, coord_pair_table:coord_pair, $i)) >= 24) {
-            $random_arena = ~random_range($i, $obstacle_arenas);
-            if ($i = calc($obstacle_arenas - 1)) {
-                return(null); // if its the last one and it fails, return null
-            }
+    def_int $i = 0;
+    while ($i < db_getfieldcount(duel_arena_obstacle_fight_zones, coord_pair_table:coord_pair)) {
+        if (map_playercount(db_getfield(duel_arena_obstacle_fight_zones, coord_pair_table:coord_pair, $i)) < 24) {
+            return(~map_findsquare_inzone(db_getfield(duel_arena_obstacle_fight_zones, coord_pair_table:coord_pair, $i)));
         }
         $i = calc($i + 1);
     }
-    $coord1, $coord2 = db_getfield(duel_arena_obstacle_fight_zones, coord_pair_table:coord_pair, $random_arena);
 } else {
-    def_int $normal_arenas = db_getfieldcount(duel_arena_fight_zones, coord_pair_table:coord_pair);
-    $i = 0;
-    while ($i < $normal_arenas) {
-        if (map_playercount(db_getfield(duel_arena_fight_zones, coord_pair_table:coord_pair, $i)) >= 24) {
-            $random_arena = ~random_range($i, $normal_arenas);
-            if ($i = calc($normal_arenas - 1)) {
-                return(null);
-            }
+    def_int $i = 0;
+    while ($i < db_getfieldcount(duel_arena_fight_zones, coord_pair_table:coord_pair)) {
+        if (map_playercount(db_getfield(duel_arena_fight_zones, coord_pair_table:coord_pair, $i)) < 24) {
+            return(~map_findsquare_inzone(db_getfield(duel_arena_fight_zones, coord_pair_table:coord_pair, $i)));
         }
         $i = calc($i + 1);
     }
-    $coord1, $coord2 = db_getfield(duel_arena_fight_zones, coord_pair_table:coord_pair, $random_arena);
 }
-
-def_int $x1 = coordx($coord1);
-def_int $x2 = coordx($coord2);
-def_int $z1 = coordz($coord1);
-def_int $z2 = coordz($coord2);
-def_coord $random_coord = movecoord($coord1, random(sub($x2, $x1)), 0, random(sub($z2, $z1)));
-
-$i = 0;
-while (map_blocked($random_coord) = true) {
-    $random_coord = movecoord($coord1, random(sub($x2, $x1)), 0, random(sub($z2, $z1)));
-    $i = calc($i + 1);
-    if ($i = 50) {
-        return(null); // no way this is reached
-    }
-}
-return($random_coord);
+return(null);
 
 [walktrigger,duel_arena_no_move]
 if (~duel_arena_movement_check = true & ~in_duel_arena(coord) = true) {

--- a/data/src/scripts/minigames/game_duelarena/scripts/duel_arena_start.rs2
+++ b/data/src/scripts/minigames/game_duelarena/scripts/duel_arena_start.rs2
@@ -53,12 +53,45 @@ if (.finduid(%duelpartner) = true) {
 
     hint_player(.uid);
 
-    softtimer(duel_arena_start_3, 3); // todo: confirm these timings
-    softtimer(duel_arena_time_limit, 6000); // 60 minute time limit https://runescape.wiki/w/Update:Assist_System
-
+    settimer(duel_arena_time_limit, 6000); // 60 minute time limit https://runescape.wiki/w/Update:Assist_System
     ~midi_jingle(^duel_start_jingle, ^duel_start_jingle_millis);
+    ~duel_arena_countdown;
 }
 
+
+[proc,duel_arena_countdown]
+world_delay(1);
+if (~in_duel_arena(coord) = false) {
+    return;
+}
+say("3");
+world_delay(1);
+if (~in_duel_arena(coord) = false) {
+    return;
+}
+say("2");
+world_delay(1);
+if (~in_duel_arena(coord) = false) {
+    return;
+}
+say("1");
+world_delay(1);
+if (~in_duel_arena(coord) = false) {
+    return;
+}
+if (.finduid(%duelpartner) = false) {
+    queue(duel_arena_disconnect, 0);
+    return;
+}
+if (~.in_duel_arena(.coord) = false) {
+    queue(duel_arena_disconnect, 0);
+    .%duelstatus = ^duelstatus_reset;
+    .%duelpartner = null;
+    .clearqueue(duel_arena_prepare_start);
+    return;
+}
+say("FIGHT!");
+%duelstatus = ^duelstatus_start;
 
 [proc,duel_arena_coord]()(coord)
 // random coord between 2 coords, checks if map blocked and not inside dueler
@@ -110,61 +143,19 @@ while (map_blocked($random_coord) = true) {
 }
 return($random_coord);
 
-
-[softtimer,duel_arena_start_3]
-if (~in_duel_arena(coord) = false) {
-    clearsofttimer(duel_arena_start_3);
-    return;
-}
-say("3");
-softtimer(duel_arena_start_2, 3);
-clearsofttimer(duel_arena_start_3);
-
-[softtimer,duel_arena_start_2]
-if (~in_duel_arena(coord) = false) {
-    clearsofttimer(duel_arena_start_2);
-    return;
-}
-say("2");
-softtimer(duel_arena_start_1, 3);
-clearsofttimer(duel_arena_start_2);
-
-[softtimer,duel_arena_start_1]
-if (~in_duel_arena(coord) = false) {
-    clearsofttimer(duel_arena_start_1);
-    return;
-}
-say("1");
-softtimer(duel_arena_start_fight, 3);
-clearsofttimer(duel_arena_start_1);
-
-[softtimer,duel_arena_start_fight]
-if (~in_duel_arena(coord) = false) {
-    clearsofttimer(duel_arena_start_fight);
-    return;
-}
-say("FIGHT!");
-%duelstatus = ^duelstatus_start;
-clearsofttimer(duel_arena_start_fight);
-
 [walktrigger,duel_arena_no_move]
 if (~duel_arena_movement_check = true & ~in_duel_arena(coord) = true) {
     p_walk(coord);
     walktrigger(duel_arena_no_move);
 }
 
-[softtimer,duel_arena_time_limit]
+[timer,duel_arena_time_limit]
 if (~in_duel_arena(coord) = false) {
-    clearsofttimer(duel_arena_time_limit);
+    cleartimer(duel_arena_time_limit);
     return;
 }
 %duelstatus = ^duelstatus_reset;
 %duelpartner = null;
-if_close;
-queue(duel_arena_time_limit, 0);
-
-
-[queue,duel_arena_time_limit]
 ~duel_give_stake_back;
 ~duel_reset_all;
 ~mesbox("Your duel ended in an honourable draw."); // RS3 message: https://archive.org/details/runelibris

--- a/data/src/scripts/minigames/game_duelarena/scripts/duel_arena_start.rs2
+++ b/data/src/scripts/minigames/game_duelarena/scripts/duel_arena_start.rs2
@@ -85,6 +85,7 @@ if (~.in_duel_arena(.coord) = false) {
     queue(duel_arena_disconnect, 0);
     .%duelstatus = ^duelstatus_reset;
     .%duelpartner = null;
+    ~.moveallinv(dueloffer, inv);
     .clearqueue(duel_arena_prepare_start);
     return;
 }

--- a/data/src/scripts/minigames/game_duelarena/scripts/duel_forfeit.rs2
+++ b/data/src/scripts/minigames/game_duelarena/scripts/duel_forfeit.rs2
@@ -17,6 +17,7 @@ queue(duel_finish, 0);
 if (.finduid(%duelpartner) = true) {
     session_log(^log_moderator, "Lost a duel by forfeit against <.name>");
     .if_close;
+    both_moveinv(dueloffer, duelwinnings);
     .%duelstatus = ^duelstatus_opponent_resigned;
     .queue(duel_finish, 0);
 }

--- a/data/src/scripts/skill_combat/scripts/pvp/pvp_ranged.rs2
+++ b/data/src/scripts/skill_combat/scripts/pvp/pvp_ranged.rs2
@@ -65,7 +65,7 @@ if (%damagestyle = ^style_ranged_rapid) {
 [proc,pvp_ranged_use_weapon](obj $rhand, obj $ammo)(int)
 spotanim_pl(oc_param($ammo, proj_launch), 96, 0);
 if (~in_duel_arena(coord) = true) {
-    inv_moveitem(worn, tradeoffer, $ammo, 1); // give rangers their arrows back from duels
+    inv_moveitem(worn, duelarrows, $ammo, 1); // give rangers their arrows back from duels
 } else {
     inv_del(worn, $ammo, 1);
 }
@@ -85,7 +85,7 @@ return($delay);
 [proc,ranged_dropammo_pvp](obj $ammo, int $chance, int $delay)
 if (~in_duel_arena(coord) = true) {
     if (random($chance) = 0) {
-        inv_del(tradeoffer, $ammo, 1);
+        inv_del(duelarrows, $ammo, 1);
     }
     return;
 }

--- a/src/engine/script/handlers/InvOps.ts
+++ b/src/engine/script/handlers/InvOps.ts
@@ -395,9 +395,20 @@ const InvOps: CommandHandlers = {
             }
 
             fromInv.delete(slot);
-            toInv.add(obj.id, obj.count);
 
+            const count = obj.count;
             const type = ObjType.get(obj.id);
+            const overflow = count - toPlayer.invAdd(toInv.type, type.id, count, false);
+            if (overflow > 0) {
+                if (!type.stackable || overflow === 1) {
+                    for (let i = 0; i < overflow; i++) {
+                        World.addObj(new Obj(toPlayer.level, toPlayer.x, toPlayer.z, EntityLifeCycle.DESPAWN, type.id, 1), toPlayer.hash64, 200);
+                    }
+                } else {
+                    World.addObj(new Obj(toPlayer.level, toPlayer.x, toPlayer.z, EntityLifeCycle.DESPAWN, type.id, overflow), toPlayer.hash64, 200);
+                }
+            }
+
             const event = fromLogs.get(type.id);
             if (event) {
                 event.count += obj.count;


### PR DESCRIPTION
Main source used: https://www.se7ensins.com/forums/threads/svews-bug-abuse-notes-everything-about-glitches-and-finding-them-in-runescape.437147/

- When your inventory is full, and you win the stake. The items *you* put up in the stake instantly drop to the floor (engine), visible to you for 2 minutes. If the duelwinnings wont fit into your inventory (checked in runescript), then `inv_dropall` runs, which will drop the entire winnings visible to everyone instantly. This matches: https://youtu.be/RYhIaNoP3Q8, https://youtu.be/GpPx9GmTvRo

https://github.com/user-attachments/assets/8a3b2cb0-05a6-4fe3-bbd4-25cc42e9cd1e


- allow smuggling food items into the duel arena by overflowing the duelwinnings inventory https://youtu.be/QkamyLQ52F8

- removes the ~in_duel_arena coord check when teleporting the player back to the challenge area after the duel ends. This will allow future bugs like ([video](https://www.youtube.com/watch?v=oj8Jgh_as_o)):
`You’d then quickly accept another duel before the 3 second countdown finished (if it finished, the server would see that your friend is alone in the duel arena and kick him out). After you accepted the second duel, you’d be in a 3-way duel with the player who you canceled being teleported in with and the player who’s challenge you accepted immediately after the first player was teleported in. Both players could attack you. The player who was teleported into the duel alone before you accepted the second challenge could then leave and do whatever he wished. You would not be teleported out of the duel with him as you were in a duel with the second player as well. When he wished to be forced teleported, you’d simply leave the duel and he’d be teleported back to the duel arena lobby, as the game still thought you were his partner. The player who was forced teleported would keep any player effects or minigame items he had with him, such as barricades from Castle Wars.`
- adds timeout if opponent isnt found after the "3, 2, 1" countdown is over. Matches the wording from:
`During a series of experiments in the duel arena, we discovered that someone could accept a duel, but never go into the arena if they were able to make a menu, or interface pop up before their entrance. This was very hard to do at first, because you had to quickly press accept, then open up a quest journal or something, and the timing was difficult. Then we discovered that someone could cast a teleother spell on you while you had the duel screen up, and this would immediately bring up the teleother screen before going into the duel. If you did not close the screen within 3 seconds, the duel would be canceled. If you did close the screen within 3 seconds, you would arrive in the duel a few seconds late. We discovered that if you did something to fill up your inventory at the same time you closed the screen, for example, slicing a pineapple so it takes up more spaces, or emptying a rune essence pouch, then it would not leave room for any items to be unequipped, and as a result you would keep them on.`

Weapon not unequipping bug (authentic). This is later changed to *not* put u in the duel in late 2005? Which allowed 3 way duels

https://github.com/user-attachments/assets/ddb37d86-a4bf-4d74-ac70-a6e781b25be8

Timeout in action:


https://github.com/user-attachments/assets/cd83215c-3e34-4ef7-8a32-200d76818f6c

It likely timed out both players?

`However, when the duel timed out after waiting for you, you would be instantly teleported to the duel arena hospital. Normally it would only take about 3 seconds to time out, but using multiple teleothers you could rig it so that you could delay it infinitely. As a result, you could be in castle wars with say, an inventory of barricades, then trick the game into thinking you just ended a duel, and be teleported to the duel arena with barricades in tote.`

https://github.com/user-attachments/assets/6b969da1-e373-416a-a081-4313d2dfd9b5


- when entering a duel, we had it going into a random arena. This is incorrect, it should only go to a new arena if the current one is full: https://youtu.be/QkamyLQ52F8
- There was 3 or so coords you could tele to that were unreachable (behind the forfeit trapdoor). Adjusted this in the dbrow
- adds `~map_findsquare_inzone` proc to return random coord within a zone of two coords. Wondering if this is a command they use
- adds `~moveallinv_itemspace` proc, to check if an all of an inv's items fits into another inv
- refactored to use the correct inv's for duels
- ~enough_duel_space proc would fail sometimes when it wasnt supposed to. I fixed this by just simplifying the logic  
- make both_moveinv drop items if inv is full
- countdown now uses world_delay instead of softtimer. The timings were also off. They match this [video](https://youtu.be/tMl473GbteU) now: 2 ticks per `say()`