### PR TITLE
fix(content): check if the player is dying with a varp instead of a hitpoints check

### DIFF
--- a/data/src/pack/varp.pack
+++ b/data/src/pack/varp.pack
@@ -217,7 +217,7 @@
 216=varp_216
 217=pk_prey1
 218=pk_prey2
-219=varp_219
+219=death
 220=varp_220
 221=varp_221
 222=demon_progress

--- a/data/src/scripts/_unpack/all.varp
+++ b/data/src/scripts/_unpack/all.varp
@@ -230,7 +230,7 @@ type=player_uid
 protect=no
 type=player_uid
 
-[varp_219]
+[death]
 
 [varp_220]
 

--- a/data/src/scripts/macro events/scripts/general/macro_event_drunken_dwarf.rs2
+++ b/data/src/scripts/macro events/scripts/general/macro_event_drunken_dwarf.rs2
@@ -77,6 +77,7 @@ npc_settimer(0);
 ~chatnpc("<p,drunk>I 'new it were you matey!|'Ere, have some ob the good stuff!"); // 2004
 
 // https://youtu.be/8wJZmDwcBKs?t=108
+// doesnt check for death!
 [ai_opplayer2,macro_event_drunken_dwarf]
 if (%npc_action_delay > map_clock) return;
 if (~npc_check_notcombat = false) {
@@ -93,10 +94,6 @@ npc_anim(npc_param(attack_anim), 20);
 sound_synth(npc_param(attack_sound), 0, 0);
 
 ~npc_set_attack_vars;
-
-if (stat(hitpoints) = 0) {
-    return;
-}
 
 def_int $attack_roll = ~npc_melee_attack_roll;
 def_int $defence_roll = ~player_defence_roll_specific(npc_param(damagetype));

--- a/data/src/scripts/npc/scripts/dragon.rs2
+++ b/data/src/scripts/npc/scripts/dragon.rs2
@@ -65,7 +65,8 @@ if (random(4) = 0) {
 }
 
 [proc,dragon_melee]
-if (stat(hitpoints) = 0) {
+if (%death = ^true) {
+    npc_setmode(null);
     return;
 }
 if (%npc_action_delay > map_clock) return;

--- a/data/src/scripts/npc/scripts/shadow_spider.rs2
+++ b/data/src/scripts/npc/scripts/shadow_spider.rs2
@@ -1,5 +1,5 @@
 [ai_opplayer2,shadow_spider] 
-if (stat(hitpoints) = 0) {
+if (%death = ^true) {
     npc_setmode(null);
     return;
 }

--- a/data/src/scripts/player/scripts/death.rs2
+++ b/data/src/scripts/player/scripts/death.rs2
@@ -8,11 +8,13 @@ if (.finduid(%duelpartner) = true) {
 queue(player_death_default, 0);
 
 [proc,player_death]
+%death = ^true;
 p_delay(1);
 p_stopaction;
 if_close;
 anim(human_death, 0);
 p_delay(3);
+%death = ^false;
 
 [queue,player_death_default]
 ~player_death;
@@ -191,3 +193,6 @@ if($is_worn = true) {
 
 [debugproc,death]
 ~damage_self(999);
+
+[debugproc,damage]
+queue(damage_player, 0, 100);

--- a/data/src/scripts/quests/quest_legends/scripts/nezikchened.rs2
+++ b/data/src/scripts/quests/quest_legends/scripts/nezikchened.rs2
@@ -15,7 +15,7 @@ if (%npc_aggressive_player ! uid) {
     npc_setmode(null);
     return;
 }
-if (stat(hitpoints) = 0) {
+if (%death = ^true) {
     npc_setmode(null);
     return;
 }

--- a/data/src/scripts/quests/quest_upass/scripts/kalrag.rs2
+++ b/data/src/scripts/quests/quest_upass/scripts/kalrag.rs2
@@ -35,7 +35,7 @@ if(%upass_progress = ^upass_found_doll) {
 [ai_opplayer2,blessed_spider] ~blessedspider_attack;
 
 [proc,blessedspider_attack]
-if (stat(hitpoints) = 0) {
+if (%death = ^true) {
     npc_setmode(null);
     return;
 }

--- a/data/src/scripts/quests/quest_vampire/scripts/count_draynor.rs2
+++ b/data/src/scripts/quests/quest_vampire/scripts/count_draynor.rs2
@@ -17,7 +17,7 @@ if (inv_total(inv, garlic) > 0) {
 }
 
 [ai_opplayer2,count_draynor]
-if (stat(hitpoints) = 0) {
+if (%death = ^true) {
     npc_setmode(null);
     return;
 }

--- a/data/src/scripts/skill_combat/scripts/npc/npc_combat.rs2
+++ b/data/src/scripts/skill_combat/scripts/npc/npc_combat.rs2
@@ -33,7 +33,7 @@ if (npc_stat(hitpoints) <= npc_param(retreat)) {
 
 // a default melee attack script.
 [proc,npc_default_attack]
-if (stat(hitpoints) = 0) {
+if (%death = ^true) {
     npc_setmode(null);
     return;
 }

--- a/data/src/scripts/skill_combat/scripts/pvp/pvp_magic.rs2
+++ b/data/src/scripts/skill_combat/scripts/pvp/pvp_magic.rs2
@@ -61,7 +61,8 @@ if (~pvp_hit_roll(^magic_style) = true) {
 [proc,pvp_combat_spell_checks](dbrow $spell_data)(boolean)
 if_close;
 p_stopaction;
-if (.stat(hitpoints) = 0) {
+if (.%death = ^true) {
+    p_stopaction;
     return(false);
 }
 if (map_clock < %action_delay) {

--- a/data/src/scripts/skill_combat/scripts/pvp/pvp_melee.rs2
+++ b/data/src/scripts/skill_combat/scripts/pvp/pvp_melee.rs2
@@ -7,7 +7,7 @@ if (%action_delay > map_clock) {
     return;
 }
 
-if (.stat(hitpoints) = 0) {
+if (.%death = ^true) {
     p_stopaction;
     return;
 }

--- a/data/src/scripts/skill_combat/scripts/pvp/pvp_ranged.rs2
+++ b/data/src/scripts/skill_combat/scripts/pvp/pvp_ranged.rs2
@@ -2,7 +2,7 @@
 if (~duel_arena_ranged_check = false) {
     return;
 }
-if (.stat(hitpoints) = 0) {
+if (.%death = ^true) {
     p_stopaction;
     return;
 }

--- a/data/src/scripts/tutorial/scripts/npcs/tut_giant_rat.rs2
+++ b/data/src/scripts/tutorial/scripts/npcs/tut_giant_rat.rs2
@@ -12,15 +12,14 @@ if (npc_findhero = true) {
     }
 }
 
-// Highkey stole this from the drunken dwarf random.
 [ai_opplayer2,tut_giant_rat]
-if (stat(hitpoints) = 0) {
+if (%death = ^true) {
+    npc_setmode(null);
     return;
 }
 if (map_clock < %npc_action_delay) {
     return;
 }
-
 if (~npc_check_notcombat = false) {
     npc_setmode(null);
     return;


### PR DESCRIPTION

- throwing knives is the perfect speed to attack your opponent between their health being 0, and their death queue running.
2006:

https://github.com/user-attachments/assets/d996216f-4644-4a94-8cf8-9fe809142957

Before my changes:

https://github.com/user-attachments/assets/c939ad2f-45a4-449e-92fd-e0bf99f69d18


After my changes:


https://github.com/user-attachments/assets/5acf716f-21b7-48a7-b994-a5c68235c242

- Npc's can hit you on the tick you die 

OSRS:

https://github.com/user-attachments/assets/6d8a551b-6ff0-4d06-a92b-92a03f5c721f


Before my changes:

https://github.com/user-attachments/assets/a0e6c997-a662-4f3e-9f9f-d37f68b4518c


After my changes:

https://github.com/user-attachments/assets/7531b225-48bc-49b0-8701-0b6dba188d00

