### PR TITLE
fix(content): queue shantay pass enter to match old bug, move ana barrel tele check

### DIFF
--- a/data/src/scripts/areas/area_alkharid/scripts/shantay_pass.rs2
+++ b/data/src/scripts/areas/area_alkharid/scripts/shantay_pass.rs2
@@ -35,18 +35,11 @@ if (inv_total(inv, thshantaydisc) < 1) {
 ~objbox(shantay_pass, "You hand over a Shantay Pass.", 250, 0, 0);
 ~chatplayer("<p,neutral>Sure, here you go!");
 inv_del(inv, shantay_pass, 1);
+queue(shantay_pass_enter, 0);
 if (inv_total(inv, thshantaydisc) < 1) {
     inv_add(inv, thshantaydisc, 1);
     ~chatnpc("<p,neutral>Here, have a disclaimer... It means that Shantay isn't|responsible if you die in the desert.");
 }
-if_close;
-p_teleport(0_51_48_40_46);
-p_delay(0);
-facesquare(movecoord(coord, 0, 0, -3));
-p_delay(0);
-mes("You go through the gate.");
-p_telejump(movecoord(coord, 0, 0, -3));
-~start_desertheat_timer;
 
 
 [oploc1,shantay_jail_door]
@@ -100,14 +93,18 @@ if (inv_total(inv, thshantaydisc) < 1) {
 ~objbox(shantay_pass, "You hand over a Shantay Pass.", 250, 0, 0);
 ~chatplayer("<p,neutral>Sure, here you go!");
 inv_del(inv, shantay_pass, 1);
+queue(shantay_pass_enter, 0);
 if (inv_total(inv, thshantaydisc) < 1) {
     inv_add(inv, thshantaydisc, 1);
     ~chatnpc("<p,neutral>Here, have a disclaimer... It means that Shantay isn't|responsible if you die in the desert.");
 }
-if_close;
+
+[queue,shantay_pass_enter]
+mes("You go through the gate.");
+p_teleport(0_51_48_40_46);
+p_delay(0);
 facesquare(movecoord(coord, 0, 0, -3));
 p_delay(0);
-mes("You go through the gate.");
 p_telejump(movecoord(coord, 0, 0, -3));
 ~start_desertheat_timer;
 

--- a/data/src/scripts/skill_magic/scripts/spells/teleport.rs2
+++ b/data/src/scripts/skill_magic/scripts/spells/teleport.rs2
@@ -13,11 +13,6 @@ if (p_finduid(uid) = true) {
     if (~check_spell_requirements($spell_data)= false) {
         return;
     }
-    // todo: 
-    // - check for additional reqs, BEFORE deleting runes
-    if (~pre_tele_checks(coord) = false) {
-        return;
-    }
     if (~wilderness_level(coord) > 20) {
         mes("A mysterious force blocks your teleport spell!");
         mes("You can't use this teleport after level 20 wilderness.");
@@ -36,6 +31,9 @@ if (p_finduid(uid) = true) {
         mes("You havn't learnt how to cast this spell yet.");
         return;
     }
+    if (~pre_tele_checks(coord) = false) {
+        return;
+    }
     if (afk_event = ^true) {
         ~macro_event_general_spawn(~macro_event_set_random);
         return;
@@ -51,10 +49,6 @@ if (p_finduid(uid) = true) {
 [proc,player_teleport_normal](coord $coord)
 if_close;
 p_stopaction;
-if(inv_total(inv, thanainabarrel) > 0) {
-    ~chatnpc_specific("Ana (in a Barrel)", anabarrel, "<p,idle>@dbl@-- You can't teleport while holding the barrel, it's just @dbl@too difficult to concentrate. --");
-    return;
-}
 sound_synth(teleport_all, 0, 0);
 anim(human_castteleport, 0);
 spotanim_pl(teleport_casting, 92, 0);
@@ -80,6 +74,10 @@ if(inv_total(inv, plaguesample) > 0) {
 }
 
 [proc,pre_tele_checks](coord $coord)(boolean)
+if(inv_total(inv, thanainabarrel) > 0) {
+    ~chatnpc_specific("Ana (in a Barrel)", anabarrel, "<p,idle>@dbl@-- You can't teleport while holding the barrel, it's just @dbl@too difficult to concentrate. --");
+    return(false);
+}
 if (~inzone_coord_pair_table(trawler_wreck_zones, $coord) = true) {
     ~mesbox("Water and magic don't mix!|You can't teleport whilst swimming."); // osrs
     return(false);


### PR DESCRIPTION
From https://www.se7ensins.com/forums/threads/svews-bug-abuse-notes-everything-about-glitches-and-finding-them-in-runescape.437147/:
`Hipi was kind enough to notice that if you were trying to enter the shanty pass, and you teleported somewhere right as the disclaimer was placed in your inventory, it would tele you there, then immediately teleport you back to the pass. This works in a few other situations as well, i don't want go into detail explaining why, so we'll just leave it at that. I had the bright idea that you could teleport to you house, then be transported back to the pass, tricking the game into thinking your still inside the house. It worked perfectly, and as a result whenever you turned on build mode, it would take you into the build mode of your house.`

This behavior makes sense, if you clicked off the dialogue when hes giving the disclaimer to you, you'd lose the shantay pass!!! Queuing the entrance will fix this issue... But it also creates some bugs like the forum post describes.

Heres what ours now looks like:

https://github.com/user-attachments/assets/05c6b5bf-0389-4d00-a41f-d704ef3b643a

