### PR TITLE
fix(content): some crafting levelups adjusted

### DIFF
--- a/data/src/scripts/interface_chat/scripts/chat.rs2
+++ b/data/src/scripts/interface_chat/scripts/chat.rs2
@@ -521,54 +521,55 @@ while ($page < $pagetotal) {
 
 // ----
 
-[proc,doubleobjbox_page](obj $obj_1, obj $obj_2, int $scale, int $page)
+[proc,doubleobjbox_page](obj $obj_1, int $scale1, int $x1, int $y1, obj $obj_2, int $scale2, int $x2, int $y2, int $page)
 def_int $lines = split_linecount($page);
 
-def_interface $interface = null;
-if ($lines = 0) {
+if ($lines = 0 | $lines > 4) {
     // sanity check
     return;
 } else if ($lines = 1) {
-    $interface = doubleobjbox;
-    if_setobject(doubleobjbox:com_0, $obj_1, $scale);
     if_settext(doubleobjbox:com_1, split_get($page, 0));
     if_settext(doubleobjbox:com_2, "");
     if_settext(doubleobjbox:com_4, "");
     if_settext(doubleobjbox:com_5, "");
-    if_setobject(doubleobjbox:com_6, $obj_2, $scale);
 } else if ($lines = 2) {
-    $interface = doubleobjbox;
-    if_setobject(doubleobjbox:com_0, $obj_1, $scale);
     if_settext(doubleobjbox:com_1, split_get($page, 0));
     if_settext(doubleobjbox:com_2, "");
     if_settext(doubleobjbox:com_4, split_get($page, 1));
     if_settext(doubleobjbox:com_5, "");
-    if_setobject(doubleobjbox:com_6, $obj_2, $scale);
 } else if ($lines = 3) {
-    $interface = doubleobjbox;
-    if_setobject(doubleobjbox:com_0, $obj_1, $scale);
     if_settext(doubleobjbox:com_1, split_get($page, 0));
     if_settext(doubleobjbox:com_2, "");
     if_settext(doubleobjbox:com_4, split_get($page, 1));
     if_settext(doubleobjbox:com_5, split_get($page, 2));
-    if_setobject(doubleobjbox:com_6, $obj_2, $scale);
 } else if ($lines = 4) {
-    $interface = doubleobjbox;
-    if_setobject(doubleobjbox:com_0, $obj_1, $scale);
     if_settext(doubleobjbox:com_1, split_get($page, 1));
     if_settext(doubleobjbox:com_2, split_get($page, 0));
     if_settext(doubleobjbox:com_4, split_get($page, 2));
     if_settext(doubleobjbox:com_5, split_get($page, 3));
-    if_setobject(doubleobjbox:com_6, $obj_2, $scale);
 }
-if_openchat($interface);
+if_setobject(doubleobjbox:com_0, $obj_1, $scale1);
+if_setobject(doubleobjbox:com_6, $obj_2, $scale2);
+if_setposition(doubleobjbox:com_0, $x1, $y1);
+if_setposition(doubleobjbox:com_6, $x2, $y2);
+if_openchat(doubleobjbox);
 
 [proc,doubleobjbox](obj $obj_1, obj $obj_2, string $string, int $scale)
 split_init($string, 350, 4, q8);
 def_int $page = 0;
 def_int $pagetotal = split_pagecount;
 while ($page < $pagetotal) {
-    ~doubleobjbox_page($obj_1, $obj_2, $scale, $page);
+    ~doubleobjbox_page($obj_1, $scale, 0, 0, $obj_2, $scale, 0, 0, $page);
+    p_pausebutton;
+    $page = calc($page + 1);
+}
+
+[proc,doubleobjbox2](obj $obj_1, int $scale1, int $x1, int $y1, obj $obj_2, int $scale2, int $x2, int $y2, string $string)
+split_init($string, 350, 4, q8);
+def_int $page = 0;
+def_int $pagetotal = split_pagecount;
+while ($page < $pagetotal) {
+    ~doubleobjbox_page($obj_1, $scale1, $x1, $y1, $obj_2, $scale2, $x2, $y2, $page);
     p_pausebutton;
     $page = calc($page + 1);
 }

--- a/data/src/scripts/levelup/scripts/levelup_unlocks_crafting.rs2
+++ b/data/src/scripts/levelup/scripts/levelup_unlocks_crafting.rs2
@@ -2,9 +2,9 @@
 //Crating level up unlock messages
 switch_int(stat_base(crafting)) {
     case 5 : ~objbox(gold_ring,"You can now craft @dbl@Gold Rings@bla@.", 250, 0, 0);
-    case 6 : ~objbox(gold_necklace,"You can now craft @dbl@Gold Necklaces@bla@.", 250, 0, 0);
+    case 6 : ~objbox(gold_necklace,"You can now craft @dbl@Gold Necklaces@bla@.", 180, 0, divide(^objbox_height, -2));
     case 7 : ~doubleobjbox(leather_boots,piedish,"You can now craft @dbl@Boots@bla@ and @dbl@Pie Dishes@bla@.", 200);
-    case 8 : ~doubleobjbox(strung_gold_amulet,bowl_empty,"You can now craft @dbl@Bowls@bla@ and @dbl@Gold Amulets@bla@.", 200);
+    case 8 : ~doubleobjbox2(strung_gold_amulet, 180, 0, divide(^objbox_height, -2), bowl_empty, 200, 0, 0,"You can now craft @dbl@Bowls@bla@ and @dbl@Gold Amulets@bla@.");
     case 9 : ~objbox(leather_cowl,"You can now craft @dbl@Leather Cowls@bla@.", 250, 0, ^objbox_height);
     case 10 : ~objbox(bow_string,"Members can now craft @dbl@Bow Strings@bla@.", 250, 0, 0);
     case 11 : ~objbox(leather_vambraces,"You can now craft @dbl@Leather Vambraces@bla@.", 250, 0, 0);
@@ -12,25 +12,25 @@ switch_int(stat_base(crafting)) {
     case 14 : ~objbox(leather_body,"You can now make @dbl@Leather Armour@bla@.", 250, 0, 0);
     case 16 : ~doubleobjbox(blessedstar,red_topaz,"You can now craft @dbl@Holy Symbols of Saradomin@bla@ and members can cut @dbl@Red Topaz@bla@.", 200); //imgur.com/PSmUwiG
     case 18 : ~objbox(leather_chaps,"You can now craft @dbl@Leather Chaps@bla@.", 250, 0, 0);
-    case 20 : ~doubleobjbox(sapphire,sapphire_ring,"You can now cut @dbl@Sapphires@bla@ and craft @dbl@Sapphire Rings@bla@.", 200);
-    case 22 : ~objbox(sapphire_necklace,"You can now craft @dbl@Sapphire Necklaces@bla@.", 250, 0, 0);
-    case 24 : ~objbox(strung_sapphire_amulet,"You can now craft @dbl@Sapphire Amulets@bla@.", 250, 0, 0);
-    case 27 : ~doubleobjbox(emerald,emerald_ring,"You can now cut @dbl@Emeralds@bla@ and craft @dbl@Emerald Rings@bla@.", 200);
+    case 20 : ~doubleobjbox(sapphire,sapphire_ring,"You can now cut @dbl@Sapphires@bla@ and craft @dbl@Sapphire @dbl@Rings@bla@.", 200);
+    case 22 : ~objbox(sapphire_necklace,"You can now craft @dbl@Sapphire Necklaces@bla@.", 180, 0, divide(^objbox_height, -2));
+    case 24 : ~objbox(strung_sapphire_amulet,"You can now craft @dbl@Sapphire Amulets@bla@.", 180, 0, divide(^objbox_height, -2));
+    case 27 : ~doubleobjbox(emerald,emerald_ring,"You can now cut @dbl@Emeralds@bla@ and craft @dbl@Emerald @dbl@Rings@bla@.", 200);
     case 28 : ~objbox(hardleather_body,"You can now craft @dbl@Hard Leather Armour@bla@.", 250, 0, 0);
-    case 29 : ~objbox(emerald_necklace,"You can now craft @dbl@Emerald Necklaces@bla@.", 250, 0, 0);
-    case 31 : ~objbox(strung_emerald_amulet,"You can now craft @dbl@Emerald Amulets@bla@.", 250, 0, 0);
+    case 29 : ~objbox(emerald_necklace,"You can now craft @dbl@Emerald Necklaces@bla@.", 180, 0, divide(^objbox_height, -2));
+    case 31 : ~objbox(strung_emerald_amulet,"You can now craft @dbl@Emerald Amulets@bla@.", 180, 0, divide(^objbox_height, -2));
     case 33 : ~objbox(vial_empty,"Members can now craft @dbl@Vials@bla@.", 250, 0, ^objbox_height);
     case 34 : ~doubleobjbox(ruby,ruby_ring,"You can now cut @dbl@Rubies@bla@ and craft @dbl@Ruby Rings@bla@.", 200);
     case 38 : ~objbox(coif,"Members can now craft @dbl@Leather Coifs@bla@.", 250, 0, ^objbox_height);
-    case 40 : ~doubleobjbox(chisel,hammer,"You can now enter the @dbl@Crafting Guild@bla@|and make @dbl@Ruby Necklaces@bla@.", 200);
+    case 40 : ~doubleobjbox(chisel,hammer,"You can now enter|the @dbl@Crafting Guild.", 200);
     case 41 : ~objbox(studded_body,"Members can now craft @dbl@Studded Leather Body Armour@bla@.", 250, 0, 0);
-    case 43 : ~doubleobjbox(diamond,diamond_ring,"You can now cut @dbl@Diamonds@bla@ and craft @dbl@Diamond Rings@bla@.", 200);
+    case 43 : ~doubleobjbox(diamond,diamond_ring,"You can now cut @dbl@Diamonds@bla@ and craft @dbl@Diamond @dbl@Rings@bla@.", 200);
     case 44 : ~objbox(studded_chaps,"Members can now craft @dbl@Studded Leather Chaps@bla@.", 250, 0, 0);
     case 46 : ~objbox(stafforb,"Members can now craft @dbl@Orbs@bla@.", 250, 0, 0);
-    case 50 : ~objbox(strung_ruby_amulet,"You can now craft @dbl@Ruby Amulets@bla@.", 250, 0, 0);
+    case 50 : ~objbox(strung_ruby_amulet,"You can now craft @dbl@Ruby Amulets@bla@.", 180, 0, divide(^objbox_height, -2));
     case 54 : ~objbox(water_battlestaff,"Members can now craft @dbl@Water Battlestaffs@bla@.", 250, 0, 0);
     case 55 : ~doubleobjbox(dragonstone,dragonstone_ring,"Members can now cut @dbl@Dragonstones|@bla@and craft @dbl@Dragonstone Rings.", 200); // imgur.com/m9Jq0hU
-    case 56 : ~objbox(diamond_necklace,"You can now craft @dbl@Diamond Necklaces@bla@.", 250, 0, 0);
+    case 56 : ~objbox(diamond_necklace,"You can now craft @dbl@Diamond Necklaces@bla@.", 180, 0, divide(^objbox_height, -2));
     case 57 : ~objbox(dragon_vambraces,"Members can now craft @dbl@Green Dragonhide Vambraces@bla@.", 250, 0, 0);
     case 58 : ~objbox(earth_battlestaff,"Members can now craft @dbl@Earth Battlestaffs@bla@.", 250, 0, 0);
     case 60 : ~objbox(dragonhide_chaps,"Members can now craft @dbl@Green Dragonhide Chaps@bla@.", 250, 0, 0);
@@ -38,14 +38,14 @@ switch_int(stat_base(crafting)) {
     case 63 : ~objbox(dragonhide_body,"Members can now craft @dbl@Green Dragonhide Armour@bla@.", 250, 0, divide(^objbox_height, 2));
     case 66 : ~doubleobjbox(air_battlestaff,blue_dragon_vambraces,"Members can now craft @dbl@Air Battlestaffs.|and @dbl@Blue Dragonhide Vambraces.", 200); //imgur.com/pl39sRP
     case 68 : ~objbox(blue_dragonhide_chaps,"Members can now craft @dbl@Blue Dragonhide Chaps@bla@.", 250, 0, 0);
-    case 70 : ~objbox(strung_diamond_amulet,"You can now craft @dbl@Diamond Amulets@bla@.", 250, 0, 0);
+    case 70 : ~objbox(strung_diamond_amulet,"You can now craft @dbl@Diamond Amulets@bla@.", 180, 0, divide(^objbox_height, -2));
     case 71 : ~objbox(blue_dragonhide_body,"Members can now craft @dbl@Blue Dragonhide Armour@bla@.", 250, 0, divide(^objbox_height, 2));
-    case 72 : ~objbox(dragonstone_necklace,"Members can now craft @dbl@Dragonstone Necklaces@bla@.", 250, 0, 0);
+    case 72 : ~objbox(dragonstone_necklace,"Members can now craft @dbl@Dragonstone Necklaces@bla@.", 180, 0, divide(^objbox_height, -2));
     case 73 : ~objbox(red_dragon_vambraces,"Members can now craft @dbl@Red Dragonhide Vambraces@bla@.", 250, 0, 0);
     case 75 : ~objbox(red_dragonhide_chaps,"Members can now craft @dbl@Red Dragonhide Chaps@bla@.", 250, 0, 0);
     case 77 : ~objbox(red_dragonhide_body,"Members can now craft @dbl@Red Dragonhide Armour@bla@.", 250, 0, divide(^objbox_height, 2));
     case 79 : ~objbox(black_dragon_vambraces,"Members can now craft @dbl@Black Dragonhide Vambraces@bla@.", 250, 0, 0);
-    case 80 : ~objbox(strung_dragonstone_amulet,"Members can now craft @dbl@Dragonstone Amulets@bla@.", 250, 0, 0);
+    case 80 : ~objbox(strung_dragonstone_amulet,"Members can now craft @dbl@Dragonstone Amulets@bla@.", 180, 0, divide(^objbox_height, -2));
     case 82 : ~objbox(black_dragonhide_chaps,"Members can now craft @dbl@Black Dragonhide Chaps@bla@.", 250, 0, 0);
     case 84 : ~objbox(black_dragonhide_body,"Members can now craft @dbl@Black Dragonhide Armour@bla@.", 250, 0, divide(^objbox_height, 2));
 }


### PR DESCRIPTION
- "Rings" for some of our unlocks were black instead of blue because of the line break. Not sure what it should be... but I made it blue. I'm 50/50 split on this
- Amulets, and necklaces' $y & $scale were off. Went ahead and applied the fix to all necklaces and amulets in our crafting unlock messages

Old screenshot:
![image](https://github.com/user-attachments/assets/3c53b87b-88ea-4f6e-8e46-dc353c993bd5)

Ours before:
![image](https://github.com/user-attachments/assets/3aeb1152-f4de-4694-bb6b-9647690a35cc)

Ours after:
![image](https://github.com/user-attachments/assets/e6cee602-8be9-4a09-955d-c341454feb08)

- Our crafting guild unlock was wrong, they added ruby necklaces to it sometime in 2007.
Old screenshot:
![image](https://github.com/user-attachments/assets/02b0c6bd-d02a-4f43-82cd-4735b6332351)

- added `~doubleobjbox2` with $x, $y, and $scale args for each obj. Needed to add this if I wanted to adjust the gold amulet (guess):

Ours before:
![image](https://github.com/user-attachments/assets/0ecab858-e50d-4966-9ff0-33aa00a7c393)
 
Ours after:
![image](https://github.com/user-attachments/assets/ec4e33c6-97c0-45cf-8ed6-d92bf97b3a64)
