### PR TITLE
fix(content): pk_skull should be 20 min not 30 min

### DIFF
--- a/data/src/scripts/skill_combat/configs/pvp.constant
+++ b/data/src/scripts/skill_combat/configs/pvp.constant
@@ -1,0 +1,1 @@
+^pk_skull_duration = 2000

--- a/data/src/scripts/skill_combat/scripts/pvp/pk_skull.rs2
+++ b/data/src/scripts/skill_combat/scripts/pvp/pk_skull.rs2
@@ -10,7 +10,7 @@ return(true);
 
 [proc,set_pk_vars]
 if (~deserves_pk_skull = true) {
-    ~pk_skull(3000); // 3000 ticks, or 30 minutes
+    ~pk_skull(^pk_skull_duration);
 }
 // for preys
 %pk_prey2 = %pk_prey1;
@@ -50,7 +50,7 @@ if (%pk_skull < 1) {
 if (%pk_skull < 1) {
     return;
 }
-if (%pk_skull > 3000) {
-    %pk_skull = 3000;
+if (%pk_skull > ^pk_skull_duration) {
+    %pk_skull = ^pk_skull_duration;
 }
 ~pk_skull(%pk_skull);


### PR DESCRIPTION
Seems to have been an osrs change to change it from 20 min -> 30 min.
- it was 20 min in [rsc](https://web.archive.org/web/20020204232538/http://www.jagex.com/manual/pk.html) (ty Mainely on discord)
![image](https://github.com/user-attachments/assets/6333d8c0-b023-4dde-a07d-7493c689cbdf)

- 20 min in [2006](https://web.archive.org/web/20060712071445/http://kbase.runescape.com/lang/en/aff/runescape/viewarticle.ws?article_id=1699)
![image](https://github.com/user-attachments/assets/162e3af1-6f37-46d8-adf3-05e16be2da9a)
- 20 min according to a forum post on [rsbandb](https://www.rsbandb.com/forums/viewtopic.php?f=17&t=17380)
![image](https://github.com/user-attachments/assets/f076b615-4ff3-4484-b41f-de4c71a8b454)


Perhaps it was changed in this [osrs update](https://oldschool.runescape.wiki/w/Skull_(status)). But the wording makes it seem like its already 30 minutes