### PR TITLE
fix(content): use stat_boost and stat_drain for pvp/pvm magic

### DIFF
--- a/data/src/scripts/skill_combat/scripts/player/player_magic.rs2
+++ b/data/src/scripts/skill_combat/scripts/player/player_magic.rs2
@@ -259,9 +259,7 @@ while ($i < db_getfieldcount($spell_data, magic_spell_table:stat_change)) {
             // nothing ever uses this but i guess if someone wants to add some heal spell or something
             npc_statadd($npc_stat, $constant, $percent);
         } else {
-            if ($constant < 0) $constant = multiply($constant, -1);
-            if ($percent < 0) $percent = multiply($percent, -1);
-            npc_statsub($npc_stat, $constant, $percent);
+            npc_statsub($npc_stat, abs($constant), abs($percent)); // npc_statdrain?
         }
     }
     $i = add($i, 1);

--- a/data/src/scripts/skill_combat/scripts/player/spells/scripts/claws_of_guthix.rs2
+++ b/data/src/scripts/skill_combat/scripts/player/spells/scripts/claws_of_guthix.rs2
@@ -15,10 +15,16 @@ if (%claws_of_guthix_casts < ^mage_arena_spell_finished & ~inzone_coord_pair_tab
 ~pvm_spell_cast($spell_data);
 
 if (~player_npc_hit_roll(^magic_style) = true) {
-    ~pvm_spell_success($spell_data, ~god_spell_maxhit($spell_data), 64);
-    if (~has_god_cape_and_staff = true) {
-        ~pvm_stat_change_effect($spell_data);
+    def_int $maxhit = ~magic_spell_maxhit($spell_data);
+    if (inv_total(worn, guthix_cape) > 0 & inv_total(worn, guthix_staff) > 0) {
+        if (npc_stat(defence) = npc_basestat(defence)) { // https://oldschool.runescape.wiki/w/Update:Contact!
+            npc_statsub(defence, 1, 5); // npc_statdrain?
+        }
+        if (%charge_god_spell > 0) {
+            $maxhit = scale(3, 2, $maxhit);
+        }
     }
+    ~pvm_spell_success($spell_data, $maxhit, 64);
 } else {
     ~pvm_spell_fail($spell_data, 64);
 }

--- a/data/src/scripts/skill_combat/scripts/player/spells/scripts/crumble_undead.rs2
+++ b/data/src/scripts/skill_combat/scripts/player/spells/scripts/crumble_undead.rs2
@@ -13,7 +13,7 @@ if (npc_param(undead) = ^false) {
 def_int $duration = ~pvm_spell_cast($spell_data);
 
 if (~player_npc_hit_roll(^magic_style) = true) {
-     ~pvm_spell_success($spell_data, ~magic_spell_maxhit($spell_data), $duration);
+    ~pvm_spell_success($spell_data, ~magic_spell_maxhit($spell_data), $duration);
 } else {
     ~pvm_spell_fail($spell_data, $duration);
 }

--- a/data/src/scripts/skill_combat/scripts/player/spells/scripts/flames_of_zamorak.rs2
+++ b/data/src/scripts/skill_combat/scripts/player/spells/scripts/flames_of_zamorak.rs2
@@ -15,10 +15,16 @@ if (%flames_of_zamorak_casts < ^mage_arena_spell_finished & ~inzone_coord_pair_t
 ~pvm_spell_cast($spell_data);
 
 if (~player_npc_hit_roll(^magic_style) = true) {
-    ~pvm_spell_success($spell_data, ~god_spell_maxhit($spell_data), 64);
-    if (~has_god_cape_and_staff = true) {
-        ~pvm_stat_change_effect($spell_data);
+    def_int $maxhit = ~magic_spell_maxhit($spell_data);
+    if (inv_total(worn, zamorak_cape) > 0 & inv_total(worn, zamorak_staff) > 0) {
+        if (npc_stat(magic) = npc_basestat(magic)) { // https://oldschool.runescape.wiki/w/Update:Contact!
+            npc_statsub(magic, 1, 5); // npc_statdrain ?
+        }
+        if (%charge_god_spell > 0) {
+            $maxhit = scale(3, 2, $maxhit);
+        }
     }
+    ~pvm_spell_success($spell_data, $maxhit, 64);
 } else {
     ~pvm_spell_fail($spell_data, 64);
 }

--- a/data/src/scripts/skill_combat/scripts/player/spells/scripts/saradomin_strike.rs2
+++ b/data/src/scripts/skill_combat/scripts/player/spells/scripts/saradomin_strike.rs2
@@ -15,7 +15,13 @@ if (%saradomin_strike_casts < ^mage_arena_spell_finished & ~inzone_coord_pair_ta
 ~pvm_spell_cast($spell_data);
 
 if (~player_npc_hit_roll(^magic_style) = true) {
-    ~pvm_spell_success($spell_data, ~god_spell_maxhit($spell_data), 64);
+    def_int $maxhit = ~magic_spell_maxhit($spell_data);
+    if (inv_total(worn, saradomin_cape) > 0 & inv_total(worn, saradomin_staff) > 0) {
+        if (%charge_god_spell > 0) {
+            $maxhit = scale(3, 2, $maxhit);
+        }
+    }
+    ~pvm_spell_success($spell_data, $maxhit, 64);
 } else {
     ~pvm_spell_fail($spell_data, 64);
 }

--- a/data/src/scripts/skill_combat/scripts/pvp/pvp_magic.rs2
+++ b/data/src/scripts/skill_combat/scripts/pvp/pvp_magic.rs2
@@ -136,12 +136,10 @@ while ($i < db_getfieldcount($spell_data, magic_spell_table:stat_change)) {
         if ($constant > 0 & $percent > 0) {
             // if both positive assume statadd
             // nothing ever uses this but i guess if someone wants to add some heal spell or something
-            .stat_add($stat, $constant, $percent);
+            .stat_boost($stat, $constant, $percent);
         } else {
-            if ($constant < 0) $constant = multiply($constant, -1);
-            if ($percent < 0) $percent = multiply($percent, -1);
             .mes("You feel weakened.");
-            .stat_sub($stat, $constant, $percent);
+            .stat_drain($stat, abs($constant), abs($percent));
         }
     }
     $i = add($i, 1);

--- a/data/src/scripts/skill_combat/scripts/pvp/spells/scripts/claws_of_guthix.rs2
+++ b/data/src/scripts/skill_combat/scripts/pvp/spells/scripts/claws_of_guthix.rs2
@@ -18,10 +18,17 @@ if (%claws_of_guthix_casts < ^mage_arena_spell_finished & ~inzone_coord_pair_tab
 ~pvp_spell_cast($spell_data);
 // spell hit
 if (~pvp_hit_roll(^magic_style) = true) {
-    ~pvp_spell_success($spell_data, ~god_spell_maxhit($spell_data), 64);
-    if (~has_god_cape_and_staff = true) {
-        ~pvp_stat_change_effect($spell_data);
+    def_int $maxhit = ~magic_spell_maxhit($spell_data);
+    if (inv_total(worn, guthix_cape) > 0 & inv_total(worn, guthix_staff) > 0) {
+        if (.stat(defence) = .stat_base(defence)) { // https://oldschool.runescape.wiki/w/Update:Contact!
+            .stat_drain(defence, 1, 5);
+            .mes("You feel weakened.");
+        }
+        if (%charge_god_spell > 0) {
+            $maxhit = scale(3, 2, $maxhit);
+        }
     }
+    ~pvp_spell_success($spell_data, $maxhit, 64);
 } else {
     ~pvp_spell_fail($spell_data, 64);
 }

--- a/data/src/scripts/skill_combat/scripts/pvp/spells/scripts/flames_of_zamorak.rs2
+++ b/data/src/scripts/skill_combat/scripts/pvp/spells/scripts/flames_of_zamorak.rs2
@@ -18,18 +18,17 @@ if (%flames_of_zamorak_casts < ^mage_arena_spell_finished & ~inzone_coord_pair_t
 ~pvp_spell_cast($spell_data);
 // spell hit
 if (~pvp_hit_roll(^magic_style) = true) {
-    ~pvp_spell_success($spell_data, ~god_spell_maxhit($spell_data), 64);
-    if (~has_god_cape_and_staff = true & .stat(magic) >= .stat_base(magic)) {
-        .stat_sub(magic, 1, 5);
-        .mes("You feel your magical powers weaken.");
+    def_int $maxhit = ~magic_spell_maxhit($spell_data);
+    if (inv_total(worn, zamorak_cape) > 0 & inv_total(worn, zamorak_staff) > 0) {
+        if (.stat(magic) = .stat_base(magic)) { // https://oldschool.runescape.wiki/w/Update:Contact!
+            .stat_drain(magic, 1, 5);
+            .mes("You feel your magical powers weaken.");
+        }
+        if (%charge_god_spell > 0) {
+            $maxhit = scale(3, 2, $maxhit);
+        }
     }
+    ~pvp_spell_success($spell_data, $maxhit, 64);
 } else {
     ~pvp_spell_fail($spell_data, 64);
 }
-
-[proc,god_spell_maxhit](dbrow $spell_data)(int)
-def_int $maxhit = ~magic_spell_maxhit($spell_data);
-if (%charge_god_spell > 0 & ~has_god_cape_and_staff = true) {
-    return (scale(3, 2, $maxhit));
-}
-return ($maxhit);

--- a/data/src/scripts/skill_combat/scripts/pvp/spells/scripts/saradomin_strike.rs2
+++ b/data/src/scripts/skill_combat/scripts/pvp/spells/scripts/saradomin_strike.rs2
@@ -17,10 +17,14 @@ if (%saradomin_strike_casts < ^mage_arena_spell_finished & ~inzone_coord_pair_ta
 ~pvp_spell_cast($spell_data);
 // spell hit
 if (~pvp_hit_roll(^magic_style) = true) {
-    ~pvp_spell_success($spell_data, ~god_spell_maxhit($spell_data), 64);
-    if (~has_god_cape_and_staff = true) {
+    def_int $maxhit = ~magic_spell_maxhit($spell_data);
+    if (inv_total(worn, saradomin_cape) > 0 & inv_total(worn, saradomin_staff) > 0) {
         .stat_sub(prayer, 1, 0);
+        if (%charge_god_spell > 0) {
+            $maxhit = scale(3, 2, $maxhit);
+        }
     }
+    ~pvp_spell_success($spell_data, $maxhit, 64);
 } else {
     ~pvp_spell_fail($spell_data, 64);
 }

--- a/data/src/scripts/skill_magic/scripts/spells/charge.rs2
+++ b/data/src/scripts/skill_magic/scripts/spells/charge.rs2
@@ -34,16 +34,3 @@ if (%charge_god_spell < 1) {
     cleartimer(charge);
     return;
 }
-
-
-[proc,has_god_cape_and_staff]()(boolean)
-if (inv_total(worn, saradomin_cape) > 0 & inv_total(worn, saradomin_staff) > 0) {
-    return (true);
-}
-if (inv_total(worn, guthix_cape) > 0 & inv_total(worn, guthix_staff) > 0) {
-    return (true);
-}
-if (inv_total(worn, zamorak_cape) > 0 & inv_total(worn, zamorak_staff) > 0) {
-    return (true);
-}
-return (false);


### PR DESCRIPTION
So our pvp was using stat_sub, which drains by your *base stat*. In osrs pvp spells drain by your *current stat*.


-5 strength at 99;

https://github.com/user-attachments/assets/b18718ae-7fd0-42be-90e4-7bfc02a6b9a9

-6 strength at 111:

https://github.com/user-attachments/assets/cc2adce1-52bf-44d8-9cab-de193707fbae

Additionally, I found a [blog post](https://oldschool.runescape.wiki/w/Update:Contact!) from 2007 that states:
`The effect of the Flames of Zamorak spell is to temporarily reduce its victim's magic level. This was not working against players who'd boosted their magic levels (such as by drinking a potion). We have now fixed the spell to make it drain its victim's magic level, even if that level had been boosted. A corresponding bug has been fixed with the Claws of Guthix.`

So I went ahead and implemented this as well.