### PR TITLE
feat(content): thshantaydisc text

### DIFF
--- a/data/src/scripts/areas/area_alkharid/scripts/shantay_pass.rs2
+++ b/data/src/scripts/areas/area_alkharid/scripts/shantay_pass.rs2
@@ -118,13 +118,3 @@ p_telejump(movecoord(coord, 0, 0, -3));
 // different than osrs https://web.archive.org/web/20060428031722/http://www.runecrypt.com:80/index.php?pid=202
 ~mesbox("The Desert is a VERY Dangerous place. Do not enter if|you are scared of dying. Beware of high temperatures,|sand storms, robbers, and slavers.");
 ~mesbox("Despite this warning lots of people seem to pass through the gate.");
-
-// todo: Find a screenshot of this
-[opheld1,thshantaydisc]
-~mesbox("The Desert is a VERY Dangerous place. Do not enter if|you are scared of dying. Beware of high temperatures,|sand storms, robbers, and slavers."); // complete guess
-
-//guess, matches osrs dialogue
-[opheld1,thkebabinstructs]
-~objbox(thkebabinstructs, "*** Delicious Ugthanki Kebab *** Ingredients: Cooked Ugthanki meat, Flour, Water, Onion, Tomato. The Ugthanki meat should be nicely grilled.", 200, 0, 0);
-~objbox(thkebabinstructs, "Next take the flour and water and make some Pitta Bread. You'll need a range to do this.Take an onion and chop it into a bowl. Take a tomato and chop it into the onion mixture.", 200, 0, 0);
-~objbox(thkebabinstructs, "Chop the meat into the Onion and Tomato mixture. Finally fill the pitta bread with the Ugthanki, Onion and Tomato mixture to make your delicious Ugthanki Kebab.", 200, 0, 0);

--- a/data/src/scripts/areas/area_alkharid/scripts/thkebabinstructs.rs2
+++ b/data/src/scripts/areas/area_alkharid/scripts/thkebabinstructs.rs2
@@ -1,0 +1,5 @@
+//guess, matches osrs dialogue
+[opheld1,thkebabinstructs]
+~objbox(thkebabinstructs, "*** Delicious Ugthanki Kebab ***|Ingredients: Cooked Ugthanki meat, Flour, Water, Onion, Tomato. The Ugthanki meat should be nicely grilled.", 200, 0, 0);
+~objbox(thkebabinstructs, "Next take the flour and water and make some Pitta Bread. You'll need a range to do this.Take an onion and chop it into a bowl. Take a tomato and chop it into the onion mixture.", 200, 0, 0);
+~objbox(thkebabinstructs, "Chop the meat into the Onion and Tomato mixture. Finally fill the pitta bread with the Ugthanki, Onion and Tomato mixture to make your delicious Ugthanki Kebab.", 200, 0, 0);

--- a/data/src/scripts/areas/area_alkharid/scripts/thshantaydisc.rs2
+++ b/data/src/scripts/areas/area_alkharid/scripts/thshantaydisc.rs2
@@ -1,0 +1,4 @@
+// https://youtu.be/l0KsSdtW06U?t=212
+[opheld1,thshantaydisc]
+~objbox(thshantaydisc, "@red@*** Shantay Disclaimer ***|The Desert is a VERY Dangerous place.|Do not enter if you're afraid of dying.|Beware of high temperatures, sand storms, and slavers.", 200, 0, 0);
+~objbox(thshantaydisc, "No responsibility is taken by Shantay if anything bad happens to you under any circumstances.", 200, 0, 0);


### PR DESCRIPTION
- Found a screenshot for the shantay disclaimer (finally!). This matches rsc a little bit. Decided to add line breaks to it.

![image](https://github.com/user-attachments/assets/4e657d58-6189-40cf-b874-7284e649a588)


- I find it likely it wasnt originally fully red since the shantay pass text was changed from black to red:

![image](https://github.com/user-attachments/assets/ca86a8b5-3a8d-4dc6-b566-dc4b5fe943d3)

![image](https://github.com/user-attachments/assets/aa313df7-076a-4097-bc55-1f931afa47f9)

- I think there was also a ~objbox after clicking `Click here to continue`, since this is rsc:
![image](https://github.com/user-attachments/assets/72328f24-5f6d-4cfe-8271-2b77d3796c1c)

- So ultimately this is what I came up with:
![image](https://github.com/user-attachments/assets/a544cc8e-330e-4c91-9661-d43cf79635de)
![image](https://github.com/user-attachments/assets/fe400ed3-de40-474c-b510-790569cdfcca)

- I also added a line break to the title of the kebab paper:
![image](https://github.com/user-attachments/assets/62f5fa32-ec0b-47cc-8364-28d973579c85)
