### PR TITLE
fix(content): dont show wildy warning when logging into wildy warning zones

### DIFF
--- a/data/src/scripts/areas/area_wilderness/scripts/wilderness_warning.rs2
+++ b/data/src/scripts/areas/area_wilderness/scripts/wilderness_warning.rs2
@@ -4,6 +4,12 @@
 // https://youtu.be/jdcT9ogpMwE?t=104 underground
 // all on the same z axis
 
+// remove wildy warning if logged in at wildy border https://youtu.be/hiUfg8MsKMo
+[proc,wilderness_warning_login]
+if (inzone(0_45_54_48_56, 0_52_54_63_63, coord) = true | inzone(0_48_154_56_56, 0_48_154_63_63, coord) = true) {
+    %wilderness = ^true;
+}
+
 [queue,wilderness_warning]
 if (%wilderness = ^false) {
     %wilderness = ^true;

--- a/data/src/scripts/login_logout/login.rs2
+++ b/data/src/scripts/login_logout/login.rs2
@@ -43,6 +43,7 @@ queue(macro_event_login, 0);
 ~ferment_wines_login;
 ~thieving_stall_timers_login;
 ~stat_boost_login; // f2p boost reset
+~wilderness_warning_login; // remove wildy warning if logged in at wildy border https://youtu.be/hiUfg8MsKMo
 
 if(inzone(movecoord(^grandtree_jail_coord, 0, 0, -2), movecoord(^grandtree_jail_coord, 3, 0, 2), coord) = true) {
     ~grandtree_spawn_charlie;


### PR DESCRIPTION
Matches the behavior in this [video](https://youtu.be/hiUfg8MsKMo?t=5).... Not sure if this is the correct way to implement it:

https://github.com/user-attachments/assets/b40ac59d-b0a7-4e75-992a-a7e7d51086ea

