### PR TITLE
fix(content): match feedable fish to cats with rsc

### DIFF
--- a/data/src/scripts/quests/quest_fluffs/scripts/pet.rs2
+++ b/data/src/scripts/quests/quest_fluffs/scripts/pet.rs2
@@ -116,7 +116,10 @@ switch_obj(last_useitem) {
         p_delay(0);
         mes("The kitten laps up the milk.");
         npc_say("Purpurr");
-    case raw_shrimp, raw_anchovies, raw_sardine, raw_trout, trout, raw_salmon, salmon, raw_tuna, tuna :
+    // https://web.archive.org/web/20060703123352/http://tip.it/runescape/index.php?page=kitten_care.htm
+    // https://web.archive.org/web/20040606155804/http://www.runehq.com/viewskills.php?id=00235
+    // slightly conflicting info, ill just match rsc https://classic.runescape.wiki/w/Kitten
+    case raw_shrimp, raw_anchovies, raw_sardine, sardine, seasoned_sardine, raw_trout, trout, raw_salmon, salmon, raw_tuna, tuna :
         %cat_growth = setbit_range_toint(%cat_growth, 0, 0, 4);
         def_string $fishname = lowercase(oc_name(last_useitem));
         inv_del(inv, last_useitem, 1);


### PR DESCRIPTION
- [runehq June 2004](https://web.archive.org/web/20040606155804/http://www.runehq.com/viewskills.php?id=00235) says all raw except trout and tuna
![image](https://github.com/user-attachments/assets/d1298439-c84a-41f7-b4c2-4799e983de42)

- [tip.it July 2006](https://web.archive.org/web/20060703123352/http://tip.it/runescape/index.php?page=kitten_care.htm) says all raw except tuna and sardines
![image](https://github.com/user-attachments/assets/5916c3ce-5000-4643-a0c2-08c263ad348a)

- [Sals realm Mar 2005](https://web.archive.org/web/20050308123112/http://runescape.salmoneus.net/kitten_cat.html) says raw only?
![image](https://github.com/user-attachments/assets/39f973e6-12cb-45fd-9a88-038307239ee7)

- [Classic ](https://classic.runescape.wiki/w/Kitten) says all raw except sardine, trout, salmon and tuna
![image](https://github.com/user-attachments/assets/52144a41-d55d-449c-a835-0a2c382b73c1)

Given this info I think its probably best to match Rsc?