### PR TITLE
fix(engine): include staffmodlevel in MessagePublicHandler

### DIFF
--- a/src/network/game/client/handler/MessagePublicHandler.ts
+++ b/src/network/game/client/handler/MessagePublicHandler.ts
@@ -29,7 +29,7 @@ export default class MessagePublicHandler extends MessageHandler<MessagePublic> 
 
         player.messageColor = color;
         player.messageEffect = effect;
-        player.messageType = 0;
+        player.messageType = player.staffModLevel;
         player.logMessage = unpack;
 
         const out: Packet = Packet.alloc(0);

--- a/src/network/game/client/handler/MessagePublicHandler.ts
+++ b/src/network/game/client/handler/MessagePublicHandler.ts
@@ -29,7 +29,7 @@ export default class MessagePublicHandler extends MessageHandler<MessagePublic> 
 
         player.messageColor = color;
         player.messageEffect = effect;
-        player.messageType = player.staffModLevel;
+        player.messageType = Math.min(player.staffModLevel, 2);
         player.logMessage = unpack;
 
         const out: Packet = Packet.alloc(0);


### PR DESCRIPTION
Staff names should appear white in public chat, as stated in the Rules of Conduct (April 15th, 2004).
Source: https://web.archive.org/web/20040415002858/http://runescape.com/ (Rules & Security -> "Please *Click here* to learn our rules")

Listed under **Rule 5: Jagex Staff impersonation**
![image](https://github.com/user-attachments/assets/5ff1c9f7-fc90-4a73-86a2-e346a4d63345)
![image](https://github.com/user-attachments/assets/91b8d07a-ab21-4056-bcfe-b41aece65eb3)