### PR TITLE
fix(content): reset golden bowl charges when a bowl obj runs out

### DIFF
--- a/data/src/scripts/quests/quest_legends/scripts/quest_legends.rs2
+++ b/data/src/scripts/quests/quest_legends/scripts/quest_legends.rs2
@@ -287,6 +287,7 @@ if (last_useitem = goldbowlbless_pure) {
     if($bowl_uses >= 9) {
         inv_del(inv, goldbowlbless_pure, 1);
         inv_add(inv, goldbowlbless_empty, 1);
+        %legends_bits = setbit_range_toint(%legends_bits, 0, ^legends_golden_bowl_uses_start, ^legends_golden_bowl_uses_end);
         mes("The pure water in the golden bowl has run out...");
     }
     ~legends_fire_wall_walk;
@@ -1353,6 +1354,7 @@ if (last_useitem = vial_empty) {
     if ($bowl_uses >= 9) {
         inv_del(inv, goldbowlbless_pure, 1);
         inv_add(inv, goldbowlbless_empty, 1);
+        %legends_bits = setbit_range_toint(%legends_bits, 0, ^legends_golden_bowl_uses_start, ^legends_golden_bowl_uses_end);
         // osrs
         //mes("The golden bowl is empty. There's no sacred water left.");
         // rs3
@@ -1369,6 +1371,7 @@ if (last_useitem = vial_empty) {
     if ($bowl_uses >= 9) {
         inv_del(inv, goldbowlbless_pure, 1);
         inv_add(inv, goldbowlbless_empty, 1);
+        %legends_bits = setbit_range_toint(%legends_bits, 0, ^legends_golden_bowl_uses_start, ^legends_golden_bowl_uses_end);
         mes("The pure water in the golden bowl has run out...");
         return;
     }


### PR DESCRIPTION
matches https://www.youtube.com/watch?v=J30Q4Sr9Npk&t=351s