### PR TITLE
fix(content): Fix spelling error during Hazeel Cult quest

### DIFF
--- a/data/src/scripts/quests/quest_hazeelcult/scripts/quest_hazeelcult.rs2
+++ b/data/src/scripts/quests/quest_hazeelcult/scripts/quest_hazeelcult.rs2
@@ -83,7 +83,7 @@ mes("You can hear there is a hollow behind this wall."); // from rs3
 
 [oploc1,loc_2851]
 if(%hazeelcult_progress = ^hazeelcult_given_armour_or_scroll & %hazeelcult_side = ^hazeelcult_goodside) {
-    ~mesbox("You search the cupbaord thoroughly. You find a bottle of poison and a mysterious amulet. You pass your discovery on to Ceril.");
+    ~mesbox("You search the cupboard thoroughly. You find a bottle of poison and a mysterious amulet. You pass your discovery on to Ceril.");
     ~chatplayer("<p,angry>Ceril!");
     if (npc_find(coord, ceril_carnillean, 6, 0) = false) { 
         return;


### PR DESCRIPTION
As per below video & image, 'cupbaord' should be 'cupboard':

https://youtu.be/Kf95y-YdviA?si=cZv2pC5sqafelQsw&t=337

![image](https://github.com/user-attachments/assets/15474411-5534-4142-975a-761fad839b95)
