### PR TITLE
fix(content): Update Sheep Herder Quest Stage Cleaner Incrementing

### DIFF
--- a/data/src/scripts/quests/quest_sheepherder/scripts/npcs/doctor_orbon.rs2
+++ b/data/src/scripts/quests/quest_sheepherder/scripts/npcs/doctor_orbon.rs2
@@ -53,6 +53,7 @@ if (inv_total(inv, coins) < 100) {
     inv_add(inv, plague_jacket, 1);
     inv_add(inv, plague_trousers, 1);
     ~mesbox("You give Doctor Orbon 100 coins.|He hands over a protective suit.");
+    
     if (%sheepherder_progress = ^sheepherder_tasked_with_talking_to_dr_orbon) {
         %sheepherder_progress = ^sheepherder_tasked_with_disposing_of_sheep;
     }

--- a/data/src/scripts/quests/quest_sheepherder/scripts/npcs/doctor_orbon.rs2
+++ b/data/src/scripts/quests/quest_sheepherder/scripts/npcs/doctor_orbon.rs2
@@ -52,11 +52,10 @@ if (inv_total(inv, coins) < 100) {
     inv_del(inv, coins, 100);
     inv_add(inv, plague_jacket, 1);
     inv_add(inv, plague_trousers, 1);
-    ~mesbox("You give Doctor Orbon 100 coins.|He hands over a protective suit.");
-    
     if (%sheepherder_progress = ^sheepherder_tasked_with_talking_to_dr_orbon) {
         %sheepherder_progress = ^sheepherder_tasked_with_disposing_of_sheep;
     }
+    ~mesbox("You give Doctor Orbon 100 coins.|He hands over a protective suit.");
     ~chatnpc("<p,neutral>These should protect you from infection.");
 }
 


### PR DESCRIPTION
When talking to Dr. Orbon the quest stage currently would increment after the mesbox telling the player they bought the protective suit. This lead to a lot of players getting confused as to why they could burn the sheep but not complete the quest. 

I've moved the quest stage incrementing up to before the mesbox when the gear is added to the inventory.